### PR TITLE
fix: 部分104X、1050系统上点击“高级选项”按钮后出现窗口闪屏

### DIFF
--- a/src/source/page/compresssettingpage.cpp
+++ b/src/source/page/compresssettingpage.cpp
@@ -357,6 +357,9 @@ void CompressSettingPage::initUI()
 
     setBackgroundRole(DPalette::Base);
     setAutoFillBackground(true);
+
+    // bug103712  滚动区域内widget高度发生变化导致页面闪动
+    pRightWgt ->setMinimumHeight(pRightWgt->height());
 }
 
 void CompressSettingPage::initConnections()


### PR DESCRIPTION
 当滚动区域内的Widget高度发生变化时，页面刷新出现闪动，设置滚动区域内的Widget的最小高度为所有空间全展示的高度

Log: 103712 【KLUA】【专业版1050】【wayland】【归档管理器】部分104X、1050系统上点击“高级选项”按钮后出现窗口闪屏【1/10】

Bug: https://pms.uniontech.com/bug-view-103712.html