### PR TITLE
fix: 部分104X、1050系统上点击“高级选项”按钮后出现窗口闪屏，修改后出现收缩状态下也有滚动条显示的问题

### DIFF
--- a/src/source/page/compresssettingpage.cpp
+++ b/src/source/page/compresssettingpage.cpp
@@ -44,6 +44,9 @@
 
 #include <cmath>
 
+#define SCROLL_MAX 621
+#define SCROLL_MIN 348
+
 TypeLabel::TypeLabel(QWidget *parent)
     : DFrame(parent)
 {
@@ -322,7 +325,7 @@ void CompressSettingPage::initUI()
     pRightLayout->setContentsMargins(0, 0, 50, 0);
 
     // 右侧滚动区域
-    QScrollArea *m_pRightScroll = new QScrollArea(this);
+    m_pRightScroll = new QScrollArea(this);
     DWidget *pRightWgt = new DWidget(this);
     pRightWgt->setLayout(pRightLayout);
     m_pRightScroll->setFrameShape(QFrame::NoFrame);
@@ -359,7 +362,7 @@ void CompressSettingPage::initUI()
     setAutoFillBackground(true);
 
     // bug103712  滚动区域内widget高度发生变化导致页面闪动
-    pRightWgt ->setMinimumHeight(pRightWgt->height());
+    pRightWgt ->setFixedHeight(pRightWgt->height());
 }
 
 void CompressSettingPage::initConnections()
@@ -660,6 +663,12 @@ void CompressSettingPage::slotRefreshFileNameEdit()
 
 void CompressSettingPage::slotAdvancedEnabled(bool bEnabled)
 {
+    // bug103712  滚动区域内widget高度发生变化导致页面闪动   页面变化前先设置widget大小
+    if (bEnabled) {
+        m_pRightScroll->widget()->setFixedHeight(SCROLL_MAX);
+    } else {
+        m_pRightScroll->widget()->setFixedHeight(SCROLL_MIN);
+    }
     // 设置控件是否隐藏
     m_pEncryptedLbl->setVisible(bEnabled);
     m_pPasswordEdt->setVisible(bEnabled);
@@ -682,6 +691,8 @@ void CompressSettingPage::slotAdvancedEnabled(bool bEnabled)
         m_pCpuCmb->setCurrentIndex(0);
         m_pCommentEdt->clear();
     }
+
+
 }
 
 void CompressSettingPage::slotSplitEdtEnabled()

--- a/src/source/page/compresssettingpage.h
+++ b/src/source/page/compresssettingpage.h
@@ -267,6 +267,8 @@ private:
     qint64 m_qFileSize = 0;     // 待压缩文件大小
 
     QString m_strMimeType;  // 压缩类型（application/x-tar）
+
+    QScrollArea *m_pRightScroll = nullptr;
 };
 
 #endif // COMPRESSSETTINGPAGE_H


### PR DESCRIPTION
 点击SwitchButton后，先修改ScrollArea内部的Widget高度

Log: 103712 【KLUA】【专业版1050】【wayland】【归档管理器】部分104X、1050系统上点击“高级选项”按钮后出现窗口
    闪屏【1/10】

Bug: https://pms.uniontech.com/bug-view-103712.html