### PR TITLE
fix: bug 153129 解压场景-重命名弹窗输入为空时，检查窗口显示,设置确认按钮置灰

### DIFF
--- a/src/source/dialog/popupdialog.cpp
+++ b/src/source/dialog/popupdialog.cpp
@@ -531,14 +531,9 @@ void AppendDialog::changeEvent(QEvent *event)
 RenameDialog::RenameDialog(QWidget *parent)
     : DDialog(parent)
 {
+    m_nOkBtnIndex = -1;
+    m_lineEdit = NULL;
     setFixedSize(g_nDlgWidth, g_nDlgHeight); // 提示框宽度固定
-    m_lineEdit = new DLineEdit;
-    //输入字符格式与文管保持一致
-    connect(m_lineEdit, &DLineEdit::textChanged,[=](){
-        QString name = "(^\\s+|[/\\\\:*\"'?<>|\r\n\t])";
-        QString text = m_lineEdit->text();
-        m_lineEdit->setText(text.remove(QRegularExpression(name)));
-    });
     m_isDirectory = false;
     QPixmap pixmap = UiTools::renderSVG(":assets/icons/deepin/builtin/icons/compress_warning_32px.svg", QSize(64, 64));
     setIcon(pixmap);
@@ -546,11 +541,30 @@ RenameDialog::RenameDialog(QWidget *parent)
 
 RenameDialog::~RenameDialog()
 {
-
+    if(m_lineEdit)  {
+        delete m_lineEdit;
+        m_lineEdit = NULL;
+    }
 }
 
 int RenameDialog::showDialog(const QString &strReName, const QString &strAlias, bool isDirectory, bool isRepeat)
 {
+    if(m_lineEdit == NULL) {//创建DLineEdit,设定显示规则。
+        m_lineEdit = new DLineEdit(this);
+        //输入字符格式与文管保持一致
+        connect(m_lineEdit, &DLineEdit::textChanged,[=](){
+            QString name = "(^\\s+|[/\\\\:*\"'?<>|\r\n\t])";
+            QString text = m_lineEdit->text();
+            m_lineEdit->setText(text.remove(QRegularExpression(name)));
+            if(m_nOkBtnIndex >= 0) { //重命名输入文字为空时确认按钮不可点击，输入文字后恢复
+                if(text.isNull()||text.isEmpty()){
+                    getButton(m_nOkBtnIndex)->setEnabled(false);
+                } else {
+                    getButton(m_nOkBtnIndex)->setEnabled(true);
+                }
+            }
+        });
+    }
     DLabel *strlabel = new DLabel;
     strlabel->setObjectName("ContentLabel");
     strlabel->setFixedSize(g_nDlgWidth, g_nLableHeight); // 宽度固定
@@ -606,7 +620,7 @@ int RenameDialog::showDialog(const QString &strReName, const QString &strAlias, 
     addContent(widget, Qt::AlignHCenter);
     // 添加取消和转换按钮
     addButton(tr("Cancel", "button"));
-    addButton(tr("OK", "button"), true, DDialog::ButtonRecommend);
+    m_nOkBtnIndex = addButton(tr("OK", "button"), true, DDialog::ButtonRecommend);
 
     // 设置焦点顺序
     setTabOrder(m_lineEdit, getButton(0));
@@ -624,6 +638,7 @@ int RenameDialog::showDialog(const QString &strReName, const QString &strAlias, 
 
 QString RenameDialog::getNewNameText() const
 {
+    if(!m_lineEdit) return "";
     if(m_lineEdit->text().isNull() || m_lineEdit->text().isEmpty()) {
         return QFileInfo(m_strName).absoluteFilePath();
     }

--- a/src/source/dialog/popupdialog.h
+++ b/src/source/dialog/popupdialog.h
@@ -246,5 +246,6 @@ private:
     bool m_isDirectory;
     DLineEdit *m_lineEdit;
     bool m_bPasswordVisible = false;
+    int m_nOkBtnIndex; //确认(Ok)按钮在对话框中的索引
 };
 #endif // POPUPDIALOG_H

--- a/src/source/tree/compressview.cpp
+++ b/src/source/tree/compressview.cpp
@@ -402,7 +402,9 @@ void CompressView::slotRenameFile()
     RenameDialog dialog(this);
     // 获取重命名所需文件
     FileEntry entry = listSelEntry.first();
-    bool isRepeat = !sender()->property("repeat").isNull();
+    bool isRepeat = true;
+    if(sender())
+        isRepeat = !sender()->property("repeat").isNull();
     int iResult = dialog.showDialog(entry.strFullPath, entry.strAlias, entry.isDirectory, isRepeat);
     if (0 == m_iLevel) { // 如果是根目录，重命名缓存文件名
         if (1 == iResult) {     // 如果点击确定，重命名文件
@@ -413,6 +415,7 @@ void CompressView::slotRenameFile()
             QString strAlias = QFileInfo(dialog.getNewNameText()).fileName();
             if(strAlias == entry.strFileName || strAlias == entry.strAlias) { //名字与原来相同不做处理
                 qInfo() << entry.strAlias <<" | The name already exists. Level" << m_iLevel;
+                if(!sender()) return;
                 sender()->setProperty("repeat", "true");
                 slotRenameFile();
                 return;
@@ -421,6 +424,7 @@ void CompressView::slotRenameFile()
             for(FileEntry tmpentry: m_listEntry) {
                 if(tmpentry.isDirectory == entry.isDirectory && tmpentry.strFullPath.endsWith(strAliasEndPath)) {
                     qInfo() << entry.strFullPath << " | The name already exists。 Level" << m_iLevel;
+                    if(!sender()) return;
                     sender()->setProperty("repeat", "true");
                     slotRenameFile();
                     return;
@@ -441,6 +445,7 @@ void CompressView::slotRenameFile()
                 bool bRename = dir.rename(entry.strFullPath, dialog.getNewNameText());
                 if(!bRename) {
                     qInfo() << entry.strFullPath <<" | The name already exists. Level" << m_iLevel;
+                    if(!sender()) return;
                     sender()->setProperty("repeat", "true");
                     slotRenameFile();
                 }
@@ -449,6 +454,7 @@ void CompressView::slotRenameFile()
                 bool bRename = file.rename(dialog.getNewNameText());
                 if(!bRename) {
                     qInfo() << entry.strFullPath <<" | The name already exists. Level" << m_iLevel;
+                    if(!sender()) return;
                     sender()->setProperty("repeat", "true");
                     slotRenameFile();
                 }


### PR DESCRIPTION
解压场景-重命名弹窗输入为空时，检查窗口显示,设置确认按钮置灰

Bug: https://pms.uniontech.com/bug-view-153129.html
Log: 解压场景-重命名弹窗输入为空时，检查窗口显示,设置确认按钮置灰