### PR TITLE
fix: 修复大压缩文件二次提取相同文件奔溃问题

### DIFF
--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -2776,6 +2776,9 @@ void MainWindow::slotExtract2Path(const QList<FileEntry> &listSelEntry, const Ex
     if (!ArchiveManager::get_instance()->extractFiles2Path(strArchiveFullPath, listSelEntry, stOptions)) {
         // 无可用插件
         showErrorMessage(FI_Uncompress, EI_NoPlugin);
+    } else {
+        m_pProgressdialog->showDialog();
+        m_pProgressdialog->setProcess(1);
     }
 }
 


### PR DESCRIPTION
修复大压缩文件二次提取相同文件奔溃问题

Bug: https://pms.uniontech.com/bug-view-136823.html
Log: 修复大压缩文件二次提取相同文件奔溃问题