### PR TITLE
fix: 外接扩展屏时，无权限的文件夹进行压缩操作，提示框显示在主屏正中间

### DIFF
--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -2714,7 +2714,7 @@ int MainWindow::showWarningDialog(const QString &msg, const QString &strToolTip)
 
 void MainWindow::moveDialogToCenter(DDialog *dialog)
 {
-    QRect screenRect =  QGuiApplication::primaryScreen()->availableVirtualGeometry();
+    QRect screenRect =  QGuiApplication::primaryScreen()->availableGeometry();
     dialog->move(((screenRect.width() / 2) - (dialog->width() / 2)), ((screenRect.height() / 2) - (dialog->height() / 2)));
 }
 


### PR DESCRIPTION
外接扩展屏时，无权限的文件夹进行压缩操作，提示框显示在主屏正中间

Bug: https://pms.uniontech.com/bug-view-184227.html
Log: 外接扩展屏时，无权限的文件夹进行压缩操作，提示框显示在主屏正中间