### PR TITLE
fix: 修复焦点在返回按钮时，移入鼠标在移出鼠标时返回键无UI效果

### DIFF
--- a/src/source/tree/treeheaderview.cpp
+++ b/src/source/tree/treeheaderview.cpp
@@ -45,6 +45,11 @@ void PreviousLabel::setPrePath(const QString &strPath)
     setText("     .. " + tr("Back to: %1").arg(str));
 }
 
+void PreviousLabel::setFocusValue(bool bFocus)
+{
+    focusIn_ = bFocus;
+}
+
 void PreviousLabel::paintEvent(QPaintEvent *e)
 {
     QRectF rectangle(0, 0, width(), height());
@@ -80,14 +85,18 @@ void PreviousLabel::mouseDoubleClickEvent(QMouseEvent *event)
 
 void PreviousLabel::enterEvent(QEvent *event)
 {
-    focusIn_ = true;
+    if(!hasFocus()) {
+        focusIn_ = true;
+    }
     DLabel::enterEvent(event);
     update();
 }
 
 void PreviousLabel::leaveEvent(QEvent *event)
 {
-    focusIn_ = false;
+    if(!hasFocus()) {
+        focusIn_ = false;
+    }
     DLabel::leaveEvent(event);
     update();
 }
@@ -183,6 +192,7 @@ void TreeHeaderView::setLabelFocus(bool focus)
     } else {
         m_pPreLbl->clearFocus();
     }
+    m_pPreLbl->setFocusValue(focus);
 }
 /*
 void TreeHeaderView::paintEvent(QPaintEvent *e)

--- a/src/source/tree/treeheaderview.h
+++ b/src/source/tree/treeheaderview.h
@@ -33,6 +33,11 @@ public:
      * @return
      */
     bool isFocus() {return focusIn_;}
+    /**
+     * @brief setFocusValue 设置focusIn_
+     * @return
+     */
+    void setFocusValue(bool bFocus);
 
 protected:
     void paintEvent(QPaintEvent *e) override;


### PR DESCRIPTION
修复焦点在返回按钮时，移入鼠标在移出鼠标时返回键无UI效果

Bug: https://pms.uniontech.com/bug-view-122587.html
Log: 修复焦点在返回按钮时，移入鼠标在移出鼠标时返回键无UI效果