### PR TITLE
fix: 修复拖拽文件到zip或7z文件中生成了压缩文件变成了临时文件

### DIFF
--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -2267,12 +2267,12 @@ void MainWindow::watcherArchiveFile(const QString &strFullPath)
     });
 
     connect(m_pFileWatcher, &DFileWatcher::fileDeleted, this, [ = ]() { //监控压缩包，重命名时提示
-        // 取消操作
-        slotCancel();
 
         // 显示提示对话框
         TipDialog dialog(this);
         dialog.showDialog(tr("The archive was changed on the disk, please import it again."), tr("OK", "button"));
+        // 取消操作
+        slotCancel();
 
         resetMainwindow();
         m_ePageID = PI_Home;


### PR DESCRIPTION
修复拖拽文件到zip或7z文件中生成了压缩文件变成了临时文件

Log: 修复拖拽文件到zip或7z文件中生成了压缩文件变成了临时文件