### PR TITLE
fix: build failures for new dtkgui

### DIFF
--- a/src/source/tree/datamodel.cpp
+++ b/src/source/tree/datamodel.cpp
@@ -17,6 +17,9 @@
 #include <QElapsedTimer>
 #include <QItemSelection>
 #include <DApplicationHelper>
+#include <DGuiApplicationHelper>
+
+DGUI_USE_NAMESPACE
 
 DataModel::DataModel(QObject *parent)
     : QAbstractTableModel(parent)


### PR DESCRIPTION
Fixes the following build failures:
```
/home/felix/projects/deepin/deepin-compressor/src/source/tree/datamodel.cpp: In member function ‘virtual QVariant DataModel::data(const QModelIndex&, int) const’:
/home/felix/projects/deepin/deepin-compressor/src/source/tree/datamodel.cpp:105:17: error: ‘DGuiApplicationHelper’ has not been declared
  105 |             if (DGuiApplicationHelper::instance()->sizeMode() == DGuiApplicationHelper::NormalMode) {
      |                 ^~~~~~~~~~~~~~~~~~~~~
/home/felix/projects/deepin/deepin-compressor/src/source/tree/datamodel.cpp:105:66: error: ‘DGuiApplicationHelper’ has not been declared
  105 |             if (DGuiApplicationHelper::instance()->sizeMode() == DGuiApplicationHelper::NormalMode) {
      |                                                                  ^~~~~~~~~~~~~~~~~~~~~
```