### PR TITLE
fix: 手机MTP内部，拖拽文件到压缩文件图标上，压缩完成后，压缩文件变为tmp后缀文件

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -98,6 +98,9 @@ public:
 
     // ReadWriteArchiveInterface interface
 public:
+    /**
+     * @brief note:在mtp中压缩的时候，需要先建立一个临时目录，在该临时目录中压缩，压缩完毕后move到正确的位置
+     */
     PluginFinishType addFiles(const QList<FileEntry> &files, const CompressOptions &options) override;
     PluginFinishType moveFiles(const QList<FileEntry> &files, const CompressOptions &options) override;
     PluginFinishType copyFiles(const QList<FileEntry> &files, const CompressOptions &options) override;

--- a/3rdparty/interface/common.cpp
+++ b/3rdparty/interface/common.cpp
@@ -461,3 +461,9 @@ bool Common::findDlnfsPath(const QString &target, Compare func)
     if (iter) mnt_free_iter(iter);
     return false;
 }
+
+
+bool IsMtpFileOrDirectory(QString path) noexcept {
+    const static QRegExp regexp("((/run/user/[0-9]+/gvfs/mtp:)|(/root/.gvfs/mtp:)).+");
+    return regexp.exactMatch(path);
+}

--- a/3rdparty/interface/common.h
+++ b/3rdparty/interface/common.h
@@ -46,4 +46,11 @@ private:
     bool findDlnfsPath(const QString &target, Compare func);
 };
 
+/**
+ * 判断文件夹或文件夹是否是由mtp挂载的：
+ * /run/user/$UID/gvfs/mtp:xxxxxxxxx/xxx
+ * /root/.gvfs/mtp:xxxxxxxxx/xxx
+*/
+bool IsMtpFileOrDirectory(QString path) noexcept;
+
 #endif

--- a/3rdparty/libarchive/readwritelibarchiveplugin/readwritelibarchiveplugin.cpp
+++ b/3rdparty/libarchive/readwritelibarchiveplugin/readwritelibarchiveplugin.cpp
@@ -40,19 +40,9 @@
 #include <QProcess>
 
 #include <archive_entry.h>
-
+#include "common.h"
 // 300M
 #define MB300 314572800 /*(300*1024*1024)*/
-
-/**
- * 判断文件夹或文件夹是否是由mtp挂载的：
- * /run/user/$UID/gvfs/mtp:xxxxxxxxx/xxx
- * /root/.gvfs/mtp:xxxxxxxxx/xxx
-*/
-static bool IsMtpFileOrDirectory(QString path) noexcept {
-    const static QRegExp regexp("((/run/user/[0-9]+/gvfs/mtp:)|(/root/.gvfs/mtp:)).+");
-    return regexp.exactMatch(path);
-}
 
 ReadWriteLibarchivePluginFactory::ReadWriteLibarchivePluginFactory()
 {


### PR DESCRIPTION
mtp内部重命名失败,建立临时文件copy过去

Log: mtp内部重命名失败,建立临时文件copy过去
Bug: https://pms.uniontech.com/bug-view-200113.html