### PR TITLE
fix: 修复wps定制回合时，设置中‘解压后删除压缩文件’下拉选择框未置灰

### DIFF
--- a/src/source/dialog/settingdialog.cpp
+++ b/src/source/dialog/settingdialog.cpp
@@ -296,7 +296,10 @@ void SettingDialog::createDeleteBox()
 
                 m_deleteArchiveOption->setValue(m_autoDeleteArchive);
             });
-
+            if(parent()&&parent()->property(ORDER_JSON).isValid()) {
+                combobox->setCurrentIndex(0);
+                combobox->setEnabled(false);
+            }
             return widget;
         }
 


### PR DESCRIPTION
修复wps定制回合时，设置中‘解压后删除压缩文件’下拉选择框未置灰

Bug: https://pms.uniontech.com/bug-view-243643.html
Log: 修复wps定制回合时，设置中‘解压后删除压缩文件’下拉选择框未置灰