### PR TITLE
fix: 修复点击压缩，在格式下拉列表中没有7z格式压缩的选项

### DIFF
--- a/src/source/page/compresssettingpage.cpp
+++ b/src/source/page/compresssettingpage.cpp
@@ -141,11 +141,17 @@ void CompressSettingPage::refreshMenu()
     QAction *pAction = nullptr;
     bool bHas7z = false;
     for (const QString &type : qAsConst(m_listSupportedMimeTypes)) {
-        if (QMimeDatabase().mimeTypeForName(type).preferredSuffix() == "7z") {
+        QMimeType mType = QMimeDatabase().mimeTypeForName(type);
+        // QStringList suffixLst = mType.globPatterns(); 支持的后缀名
+        QString suffix = mType.preferredSuffix();
+        if(type.contains("x-7z-compressed")) {
+            suffix = "7z";
+        }
+        if (suffix == "7z") {
             bHas7z = true;
         }
 
-        pAction = new QAction(QMimeDatabase().mimeTypeForName(type).preferredSuffix(), m_pTypeMenu);
+        pAction = new QAction(suffix, m_pTypeMenu);
         pAction->setData(type);
         m_pTypeMenu->addAction(pAction);
 


### PR DESCRIPTION
修复点击压缩，在格式下拉列表中没有7z格式压缩的选项

Bug: https://pms.uniontech.com/bug-view-246539.html
Log: 修复点击压缩，在格式下拉列表中没有7z格式压缩的选项