### PR TITLE
fix: 修复长文件名开启后，无法将文件拖到归档管理器应用中

### DIFF
--- a/src/source/common/uitools.cpp
+++ b/src/source/common/uitools.cpp
@@ -414,7 +414,8 @@ QString UiTools::handleFileName(const QString &strFileName)
 bool UiTools::isLocalDeviceFile(const QString &strFileName)
 {
     QStorageInfo info(strFileName);
-    return info.device().startsWith("/dev/");
+    QString sDevice = info.device();
+    return sDevice.startsWith("/dev/") || sDevice.startsWith("dlnfs"); //长文件名开启后以dlnfs方式挂载
 }
 
 QStringList UiTools::removeSameFileName(const QStringList &listFiles)


### PR DESCRIPTION
修复长文件名开启后，无法将文件拖到归档管理器应用中

Bug: https://pms.uniontech.com/bug-view-262097.html
Log: 修复长文件名开启后，无法将文件拖到归档管理器应用中