### PR TITLE
fix: 与主线保持一致屏蔽tar.zst格式

### DIFF
--- a/3rdparty/libarchive/readwritelibarchiveplugin/kerfuffle_libarchive.json
+++ b/3rdparty/libarchive/readwritelibarchiveplugin/kerfuffle_libarchive.json
@@ -44,7 +44,6 @@
             "application/x-lzip-compressed-tar",
             "application/x-tzo",
             "application/x-lrzip-compressed-tar",
-            "application/x-zstd-compressed-tar",
             "application/zip"
         ],
         "Name": "Libarchive plugin",


### PR DESCRIPTION
与主线保持一致屏蔽tar.zst格式

Bug: https://pms.uniontech.com/bug-view-266021.html
Log: 与主线保持一致屏蔽tar.zst格式