### PR TITLE
fix: 修复bzip2/xz/gzip/lzma压缩的单文件打开时文件时间显示问题

### DIFF
--- a/3rdparty/libsinglefileplugin/singlefile/singlefileplugin.cpp
+++ b/3rdparty/libsinglefileplugin/singlefile/singlefileplugin.cpp
@@ -57,6 +57,7 @@ PluginFinishType LibSingleFileInterface::list()
     entry.strFullPath = uncompressedFileName();
     entry.strFileName = entry.strFullPath;
     entry.qSize = QFileInfo(m_strArchiveName).size(); // 只能获取到压缩后大小
+    entry.uLastModifiedTime = QFileInfo(m_strArchiveName).lastModified().toTime_t();
 
     stArchiveData.qSize = entry.qSize;
     stArchiveData.qComressSize = entry.qSize;


### PR DESCRIPTION
修复bzip2/xz/gzip/lzma压缩的单文件打开时文件时间显示问题

Bug: https://pms.uniontech.com/bug-view-275771.html
Log: 修复bzip2/xz/gzip/lzma压缩的单文件打开时文件时间显示问题