### PR TITLE
fix: 压缩本地快捷方式指向网络路径时，本地文件不允许拖拽到压缩快捷方式追加文件

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -284,6 +284,13 @@ int main(int argc, char *argv[])
             if (strType == "dragdropadd") {
                 // 最后一个参数为“dragdropadd”时，说明是拖拽追加
                 eType = MainWindow::AT_DragDropAdd;
+                QFileInfo info(newfilelist.first());
+                if (info.isSymLink()) {
+                    QUrl fileName = QUrl::fromLocalFile(info.symLinkTarget());
+                    if (!UiTools::isLocalDeviceFile(fileName.toLocalFile())) {
+                        return -1;
+                    }
+                }
             } else if (strType == "compress" || strType == "compress_to_7z" || strType == "compress_to_zip" ||
                        strType == "extract" || strType == "extract_here" || strType == "extract_to_specifypath") {
                 // 右键操作


### PR DESCRIPTION
压缩本地快捷方式指向网络路径时，本地文件不允许拖拽到压缩快捷方式追加文件

Bug: https://pms.uniontech.com/bug-view-276309.html
Log: 压缩本地快捷方式指向网络路径时，本地文件不允许拖拽到压缩快捷方式追加文件