### PR TITLE
chore: Bump version to 6.5.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-compressor (6.5.3) unstable; urgency=medium
+
+  * bump version to 6.5.3
+  * Fix encryption with chinese characters issue.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 27 Mar 2025 13:25:42 +0800
+
 deepin-compressor (6.5.2) unstable; urgency=medium
 
   * bump version to 6.5.2.


### PR DESCRIPTION
Bump version to 6.5.3

Log: Bump version to 6.5.3

## Summary by Sourcery

Chores:
- Bump the project version number in the Debian changelog