### PR TITLE
fix: 适配osconfig定制

### DIFF
--- a/src/assets/org.deepin.compressor.method.json
+++ b/src/assets/org.deepin.compressor.method.json
@@ -2,6 +2,16 @@
   "magic": "dsg.config.meta",
   "version": "1.0",
   "contents": {
+      "specialCustomizedType": {
+        "value": -1,
+        "serial": 0,
+        "flags": ["global"],
+        "name": "Special Customized Type",
+        "name[zh_CN]": "定制类型",
+        "description": "Customized Type",
+        "permissions": "readwrite",
+        "visibility": "private"
+      },
       "specialCompressorType": {
           "value": 11,
           "serial": 0,

--- a/src/source/page/compresssettingpage.cpp
+++ b/src/source/page/compresssettingpage.cpp
@@ -690,19 +690,11 @@ void CompressSettingPage::setDefaultName(const QString &strName)
 void CompressSettingPage::initConfig()
 {
 #ifdef DTKCORE_CLASS_DConfigFile
-    QProcess process;
-    process.start("dmidecode");
-    process.waitForStarted();
-    process.waitForFinished();
-    QString result = process.readAll();
-    QStringList lines = result.split('\n');
-    for (const QString &line : lines) {
-        if (line.contains("String 4", Qt::CaseInsensitive)) {
-            m_isOrderMode = line.contains("PGUX", Qt::CaseInsensitive) || line.contains("FXK11", Qt::CaseInsensitive)  || line.contains("FXSK11", Qt::CaseInsensitive);
-        }
-    }
-    process.close();
     m_dconfig = DConfig::create("org.deepin.compressor","org.deepin.compressor.method");
+    DConfig *dconfig = (DConfig *)m_dconfig;
+    if(dconfig && dconfig->isValid() && dconfig->keyList().contains("specialCustomizedType")){
+        m_isOrderMode = dconfig->value("specialCustomizedType").toInt() == 1;
+    }
 #endif
 }
 


### PR DESCRIPTION
适配osconfig定制

Task: https://pms.uniontech.com/task-view-377485.html
Log: 适配osconfig定制

## Summary by Sourcery

Adapt the compressor’s order mode detection to use the OSConfig customization key instead of parsing dmidecode output

Enhancements:
- Remove legacy dmidecode-based hardware check
- Introduce and read the "specialCustomizedType" DConfig key to set order mode