### PR TITLE
fix: 修复翻译

### DIFF
--- a/translations/deepin-compressor_zh_CN.ts
+++ b/translations/deepin-compressor_zh_CN.ts
@@ -407,6 +407,25 @@
     </message>
 </context>
 <context>
+    <name>LoadCorruptQuery</name>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <source>The archive is damaged</source>
+        <translation>当前压缩包文件已损坏</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <source>Open as read-only</source>
+        <translation>以只读模式打开</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>取 消</translation>
+    </message>
+</context>
+<context>
     <name>LoadingPage</name>
     <message>
         <location filename="../src/source/page/loadingpage.cpp" line="49"/>
@@ -967,6 +986,14 @@
     </message>
 </context>
 <context>
+    <name>PasswordNeededQuery</name>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <source>Encrypted file, please enter the password</source>
+        <translation>此文件已加密，请输入解压密码</translation>
+    </message>
+</context>
+<context>
     <name>PreviousLabel</name>
     <message>
         <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
@@ -1229,6 +1256,7 @@
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
         <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>跳 过</translation>
@@ -1241,23 +1269,27 @@
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>文件已存在，是否替换？</translation>
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>替 换</translation>
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
@@ -1269,6 +1301,7 @@
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
         <source>Apply to all</source>
         <translation>应用到全部文件</translation>
     </message>

--- a/translations/deepin-compressor_zh_HK.ts
+++ b/translations/deepin-compressor_zh_HK.ts
@@ -407,6 +407,25 @@
     </message>
 </context>
 <context>
+    <name>LoadCorruptQuery</name>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <source>The archive is damaged</source>
+        <translation>當前壓縮包文件已損壞</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <source>Open as read-only</source>
+        <translation>以只讀模式打開</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>取 消</translation>
+    </message>
+</context>
+<context>
     <name>LoadingPage</name>
     <message>
         <location filename="../src/source/page/loadingpage.cpp" line="49"/>
@@ -967,6 +986,14 @@
     </message>
 </context>
 <context>
+    <name>PasswordNeededQuery</name>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <source>Encrypted file, please enter the password</source>
+        <translation>此文件已加密，請輸入解壓密碼</translation>
+    </message>
+</context>
+<context>
     <name>PreviousLabel</name>
     <message>
         <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
@@ -1229,6 +1256,7 @@
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
         <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>跳 過</translation>
@@ -1241,23 +1269,27 @@
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>文件已存在，是否替換？</translation>
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>替 換</translation>
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -1269,6 +1301,7 @@
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
         <source>Apply to all</source>
         <translation>應用到全部文件</translation>
     </message>

--- a/translations/deepin-compressor_zh_TW.ts
+++ b/translations/deepin-compressor_zh_TW.ts
@@ -407,6 +407,25 @@
     </message>
 </context>
 <context>
+    <name>LoadCorruptQuery</name>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <source>The archive is damaged</source>
+        <translation>當前壓縮包文件已損壞</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <source>Open as read-only</source>
+        <translation>以只讀模式打開</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>取 消</translation>
+    </message>
+</context>
+<context>
     <name>LoadingPage</name>
     <message>
         <location filename="../src/source/page/loadingpage.cpp" line="49"/>
@@ -967,6 +986,14 @@
     </message>
 </context>
 <context>
+    <name>PasswordNeededQuery</name>
+    <message>
+        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <source>Encrypted file, please enter the password</source>
+        <translation>此文件已加密，請輸入解壓密碼</translation>
+    </message>
+</context>
+<context>
     <name>PreviousLabel</name>
     <message>
         <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
@@ -1229,6 +1256,7 @@
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
         <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>跳 過</translation>
@@ -1241,23 +1269,27 @@
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>文件已存在，是否取代？</translation>
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>替 換</translation>
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -1269,6 +1301,7 @@
     </message>
     <message>
         <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
         <source>Apply to all</source>
         <translation>應用到全部文件</translation>
     </message>


### PR DESCRIPTION
修复翻译

Bug: https://pms.uniontech.com/bug-view-319371.html
     https://pms.uniontech.com/bug-view-319211.html
Log: 修复翻译

## Summary by Sourcery

Add missing Chinese translations for archive error and password prompt dialogs and align translation entries with new query code locations across all Chinese locale TS files.

Enhancements:
- Add LoadCorruptQuery context translations (archive damaged, open read-only, cancel) in zh_CN, zh_HK, and zh_TW TS files
- Add PasswordNeededQuery context translation for encrypted file password prompt in all Chinese locale TS files
- Extend location references for Skip, Replace, Cancel, OK, and Apply to all button labels to include corresponding 3rdparty interface query code