### PR TITLE
feat: Adapt to V23 dde dbus interface

### DIFF
--- a/src/source/common/dbusadpator.cpp
+++ b/src/source/common/dbusadpator.cpp
@@ -72,14 +72,17 @@ void ApplicationAdaptor::onActiveWindow(qint64 pid)
         qInfo() << "activateWindow by Dock dbus";
         QDBusInterface dockDbusInterfaceV20(
                 "com.deepin.dde.daemon.Dock", "/com/deepin/dde/daemon/Dock", "com.deepin.dde.daemon.Dock");
-            if (dockDbusInterfaceV20.isValid()) {
-                QDBusReply<void> reply = dockDbusInterfaceV20.call("ActivateWindow", m_curShowWidget->winId());
-                if (!reply.isValid()) {
-                    qWarning() << qPrintable("Call v20 com.deepin.dde.daemon.Dock failed") << reply.error();
-                } else {
-                    qInfo() << "Dock dbus activateWindow success!";
-                }
+        QDBusInterface dockDbusInterfaceV23(
+                "org.deepin.dde.daemon.Dock1", "/org/deepin/dde/daemon/Dock1", "org.deepin.dde.daemon.Dock1");
+        QDBusInterface *dockDbusInterface = dockDbusInterfaceV23.isValid() ? &dockDbusInterfaceV23 : &dockDbusInterfaceV20;
+        if (dockDbusInterface->isValid()) {
+            QDBusReply<void> reply = dockDbusInterface->call("ActivateWindow", m_curShowWidget->winId());
+            if (!reply.isValid()) {
+                qWarning() << "Dock dbus activateWindow failed via" << dockDbusInterface->service() << ", error:" << reply.error();
+            } else {
+                qInfo() << "Dock dbus activateWindow success!";
             }
+        }
     }
 
 }


### PR DESCRIPTION
As title.

Log: Adapt to V23 dde dbus interface

## Summary by Sourcery

Adapt window activation to support the new DDE Dock DBus interface v23 while retaining compatibility with the existing v20 interface

Enhancements:
- Introduce detection and use of the org.deepin.dde.daemon.Dock1 interface for v23 with fallback to com.deepin.dde.daemon.Dock for v20
- Consolidate activation logic into a single code path and enhance error logging to include the service name