### PR TITLE
fix: changelog 5.12.27

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-compressor (5.12.27) unstable; urgency=medium
+
+  * changelog 5.12.27.
+
+ -- muyuankai <muyuankai@uniontech.com>  Mon, 16 Jun 2025 15:31:40 +0800
+
 deepin-compressor (5.12.26) unstable; urgency=medium
 
   * fix: Optimization of file list encryption method for decompression(Task: 326497)


### PR DESCRIPTION
changelog 5.12.27

Log: changelog 5.12.27

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to 5.12.27