### PR TITLE
fix: Refactor long file name handling in common interface

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -104,13 +104,13 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
         });
         return PFT_Nomral;
     }
-    bool bDlnfs = m_common->isSubpathOfDlnfs(options.strTargetPath);
-    setProperty("dlnfs", bDlnfs);
+    bool bLnfs = m_common->isSubpathOfLnfs(options.strTargetPath);
+    setProperty("lnfs", bLnfs);
     ArchiveData arcData = DataManager::get_instance().archiveData();
     m_files = files;
     m_extractOptions = options;
 
-    if (!bDlnfs) {
+    if (!bLnfs) {
         if (arcData.listRootEntry.isEmpty() && options.qSize < FILE_MAX_SIZE) {
             emit signalprogress(1);
             setProperty("list", "tmpList");
@@ -119,10 +119,10 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
             return PFT_Nomral;
         }
     }
-    return extractFiles(files, options, bDlnfs);
+    return extractFiles(files, options, bLnfs);
 }
 
-PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const ExtractionOptions &options, bool bDlnfs)
+PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const ExtractionOptions &options, bool bLnfs)
 {
     ArchiveData arcData = DataManager::get_instance().archiveData();
     setProperty("list", "");
@@ -187,7 +187,7 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
             }
         }
         //长文件解压
-        if (!bDlnfs) {
+        if (!bLnfs) {
             for (FileEntry entry : m_files) {
                 if (NAME_MAX < entry.strFileName.toLocal8Bit().length() || NAME_MAX < entry.strFullPath.toLocal8Bit().length()) {
                     bHandleLongName = true;
@@ -236,7 +236,7 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
         } else {
             password = options.password;
         }
-        if (!bDlnfs) {
+        if (!bLnfs) {
             for (QMap<QString, FileEntry>::const_iterator iter = arcData.mapFileEntry.begin(); iter != arcData.mapFileEntry.end(); iter++) {
                 if (NAME_MAX < iter.value().strFileName.toLocal8Bit().length()) {
                     bHandleLongName = true;
@@ -751,7 +751,7 @@ bool CliInterface::runProcess(const QString &programName, const QStringList &arg
                             emit signalFinished(PFT_Error);
                         }
                         deleteProcess();
-                        extractFiles(m_files, m_extractOptions, property("dlnfs").toBool());
+                        extractFiles(m_files, m_extractOptions, property("lnfs").toBool());
                     }
                 });
     }

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -182,7 +182,7 @@ protected:
     /**
      * @brief extractFiles 业务解压
      */
-    PluginFinishType extractFiles(const QList<FileEntry> &files, const ExtractionOptions &options, bool bDlnfs);
+    PluginFinishType extractFiles(const QList<FileEntry> &files, const ExtractionOptions &options, bool bLnfs);
 
 private:
     /**

--- a/3rdparty/interface/common.h
+++ b/3rdparty/interface/common.h
@@ -40,7 +40,7 @@ public:
     //长文件夹处理
     QString handleLongNameforPath(const QString &strFilePath, const QString &entryName, QMap<QString, int> &mapLongDirName, QMap<QString, int> &mapRealDirValue);
     //当前文件系统是否支持长文件
-    bool isSubpathOfDlnfs(const QString &path);
+    bool isSubpathOfLnfs(const QString &path);
     /**
      * @brief isSupportSeek    是否支持seek操作
      * @param sFileName            文件名
@@ -48,7 +48,7 @@ public:
     bool isSupportSeek(QString sFileName);
 private:
     //通过mount对应方法判断文件系统是否支持长文件
-    bool findDlnfsPath(const QString &target, Compare func);
+    bool findLnfsPath(const QString &target, Compare func);
 };
 
 /**

--- a/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
+++ b/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
@@ -168,7 +168,7 @@ PluginFinishType LibarchivePlugin::extractFiles(const QList<FileEntry> &files, c
     struct archive_entry *entry = nullptr;
 
     QString extractDst;
-    bool bDlnfs = m_common->isSubpathOfDlnfs(options.strTargetPath);
+    bool bLnfs = m_common->isSubpathOfLnfs(options.strTargetPath);
     // Iterate through all entries in archive.
     int iIndex = 0;     // 存储索引值
     while (!QThread::currentThread()->isInterruptionRequested() && (archive_read_next_header(m_archiveReader.data(), &entry) == ARCHIVE_OK)) {
@@ -265,7 +265,7 @@ PluginFinishType LibarchivePlugin::extractFiles(const QList<FileEntry> &files, c
         bool bLongName = false;
         QString tempFilePathName;
         QString strOriginName = entryName;
-        if(!bDlnfs) {
+        if(!bLnfs) {
             QString sDir = m_common->handleLongNameforPath(strFilePath, entryName, m_mapLongDirName, m_mapRealDirValue);
             if(sDir.length() > 0) {
                strFilePath = sDir.endsWith(QDir::separator())?sDir.left(sDir.length() -1):sDir;

--- a/3rdparty/libzipplugin/libzipplugin.cpp
+++ b/3rdparty/libzipplugin/libzipplugin.cpp
@@ -161,7 +161,7 @@ PluginFinishType LibzipPlugin::extractFiles(const QList<FileEntry> &files, const
     } else {
         m_dScaleSize = 100.0 / options.qSize;
     }
-    m_bDlnfs = m_common->isSubpathOfDlnfs(options.strTargetPath);
+    m_bLnfs = m_common->isSubpathOfLnfs(options.strTargetPath);
 
     // 执行解压操作
     bool bHandleLongName = false;
@@ -812,7 +812,7 @@ ErrorType LibzipPlugin::extractEntry(zip_t *archive, zip_int64_t index, const Ex
     }
 
     QString tempFilePathName;
-    if(!m_bDlnfs) {
+    if(!m_bLnfs) {
         QString sDir = m_common->handleLongNameforPath(strFilePath, strFileName, m_mapLongDirName, m_mapRealDirValue);
         if(sDir.length() > 0) {
            strFilePath = sDir.endsWith(QDir::separator())?sDir.left(sDir.length() -1):sDir;

--- a/3rdparty/libzipplugin/libzipplugin.h
+++ b/3rdparty/libzipplugin/libzipplugin.h
@@ -197,7 +197,7 @@ private:
     QMap<QString, int> m_mapLongDirName;    // 长文件夹统计
     QMap<QString, int> m_mapRealDirValue;   // 长文件真实文件统计
     QSet<QString> m_setLongName;            // 存储被截取之后的文件名称（包含001之类的）
-    bool m_bDlnfs = false;                        //文件系统是否支持长文件
+    bool m_bLnfs = false;                        //文件系统是否支持长文件名
 };
 
 #endif // LIBZIPPLUGIN_H

--- a/src/source/common/uitools.cpp
+++ b/src/source/common/uitools.cpp
@@ -415,7 +415,19 @@ bool UiTools::isLocalDeviceFile(const QString &strFileName)
 {
     QStorageInfo info(strFileName);
     QString sDevice = info.device();
-    return sDevice.startsWith("/dev/") || sDevice.startsWith("dlnfs"); //长文件名开启后以dlnfs方式挂载
+    QString sFileSystemType = info.fileSystemType();
+
+    // 检查传统的本地设备（以 /dev/ 开头）
+    if (sDevice.startsWith("/dev/")) {
+        return true;
+    }
+
+    // 检查长文件名文件系统类型
+    if (sFileSystemType == "fuse.dlnfs" || sFileSystemType == "ulnfs") {
+        return true;
+    }
+
+    return false;
 }
 
 QStringList UiTools::removeSameFileName(const QStringList &listFiles)


### PR DESCRIPTION
Renamed functions and updated logic to improve clarity and consistency in handling long file names across the codebase. The function `isSubpathOfDlnfs` is now `isSubpathOfLnfs`, and `findDlnfsPath` has been changed to `findLnfsPath`. This refactoring enhances the readability of the code and ensures that the correct file system types are checked for long file name support.

Log: Refactor long file name handling in common interface

Bug: https://pms.uniontech.com/bug-view-326015.html