### PR TITLE
fix: Add error handling for long file names in MainWindow

### DIFF
--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -2118,6 +2118,10 @@ void MainWindow::showErrorMessage(FailureInfo fFailureInfo, ErrorInfo eErrorInfo
             m_pFailurePage->setFailureDetail(tr("No compression support in current directory. Download the files to a local device."));
         }
         break;
+        case EI_LongFileName: {
+            m_pFailurePage->setFailureDetail(tr("The file name is too long. Keep the name within 60 characters please."));
+        }
+        break;
         default:
             break;
         }


### PR DESCRIPTION
Implemented a new error message for cases where the file name exceeds the character limit, providing user guidance to keep names within 60 characters. This enhancement improves user experience by clearly communicating file name restrictions.

Log: Add error handling for long file names in MainWindow
Bug: https://pms.uniontech.com/bug-view-326405.html