### PR TITLE
fix: [zip] improve ARM platform plugin selection for large files

### DIFF
--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -1032,8 +1032,23 @@ void MainWindow::slotCompress(const QVariant &val)
 
     bool bUseLibarchive = false;
 #ifdef __aarch64__ // 华为arm平台 zip压缩 性能提升. 在多线程场景下使用7z,单线程场景下使用libarchive
-    double maxFileSizeProportion = static_cast<double>(maxFileSize_) / static_cast<double>(m_stCompressParameter.qSize);
-    bUseLibarchive = maxFileSizeProportion > 0.6;
+    // 最大文件超过50MB使用libarchive
+    if (maxFileSize_ > 50 * 1024 * 1024) {
+        bUseLibarchive = true;
+    }
+    // 总大小超过200MB使用libarchive
+    else if (m_stCompressParameter.qSize > 200 * 1024 * 1024) {
+        bUseLibarchive = true;
+    }
+    // 总大小超过100MB且最大文件超过10MB使用libarchive（处理均匀分布的大文件）
+    else if (m_stCompressParameter.qSize > 100 * 1024 * 1024 && maxFileSize_ > 10 * 1024 * 1024) {
+        bUseLibarchive = true;
+    }
+    // 大文件占比超过60%使用libarchive
+    else {
+        double maxFileSizeProportion = static_cast<double>(maxFileSize_) / static_cast<double>(m_stCompressParameter.qSize);
+        bUseLibarchive = maxFileSizeProportion > 0.6;
+    }
 #else
     bUseLibarchive = false;
 #endif


### PR DESCRIPTION
- Replace proportion-based logic with size-based thresholds
- Fix uniform large files incorrectly using 7z instead of libarchive
- Add size thresholds: max file > 50MB, total > 200MB, or (total > 100MB && max > 10MB)
- Maintain backward compatibility with original proportion logic

log: 性能优化

Bug:

## Summary by Sourcery

Replace proportion-based logic for selecting libarchive vs 7z on ARM with explicit file size thresholds to fix incorrect plugin selection and optimize performance

Bug Fixes:
- Correct cases where uniformly large files on ARM were wrongly compressed with 7z instead of libarchive

Enhancements:
- Add absolute size thresholds for using libarchive: max file >50MB, total >200MB, or (total >100MB and max >10MB), while retaining the original proportion check for fallback