### PR TITLE
cherry-pick 2 release/eagle commits to develop/snipe

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -201,6 +201,14 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
                 }
             }
         }
+
+        if (bHandleLongName && !checkMoveCapability()) {
+            qWarning() << "Long filename detected, but moveProgram (" << m_cliProps->property("moveProgram").toString() << ") is not available.";
+            qWarning() << "Archive format:" << m_mimetype.name() << "Skipping long name handling.";
+            qWarning() << "The extraction tool will report errors for files with names exceeding system limit (255 bytes).";
+            bHandleLongName = false;
+        }
+
         if (destPath.startsWith("/tmp") && destPath.contains("/deepin-compressor-")) {   // 打开解压列表文件
             if (!QDir(destPath).exists()) {
                 QDir(destPath).mkpath(destPath);
@@ -242,6 +250,7 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
         } else {
             password = options.password;
         }
+
         if (!bLnfs) {
             for (QMap<QString, FileEntry>::const_iterator iter = arcData.mapFileEntry.begin(); iter != arcData.mapFileEntry.end(); iter++) {
                 if (NAME_MAX < iter.value().strFileName.toLocal8Bit().length()) {
@@ -250,6 +259,14 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
                 }
             }
         }
+
+        if (bHandleLongName && !checkMoveCapability()) {
+            qWarning() << "Long filename detected, but moveProgram (" << m_cliProps->property("moveProgram").toString() << ") is not available.";
+            qWarning() << "Archive format:" << m_mimetype.name() << "Skipping long name handling.";
+            qWarning() << "The extraction tool will report errors for files with names exceeding system limit (255 bytes).";
+            bHandleLongName = false;
+        }
+
         if (bHandleLongName) {
             if (!handleLongNameExtract(arcData.mapFileEntry.values())) {
                 m_eErrorType = ET_FileWriteError;
@@ -1108,6 +1125,17 @@ bool CliInterface::moveExtractTempFilesToDest(const QList<FileEntry> &files, con
     }
 
     return moveSuccess;
+}
+
+bool CliInterface::checkMoveCapability()
+{
+    bool hasMoveCapability = false;
+    QString moveProgram = m_cliProps->property("moveProgram").toString();
+    if (!moveProgram.isEmpty()) {
+        QString moveProgramPath = QStandardPaths::findExecutable(moveProgram);
+        hasMoveCapability = !moveProgramPath.isEmpty();
+    }
+    return hasMoveCapability;
 }
 
 void CliInterface::removeExtractedFilesOnFailure(const QString &strTargetPath, const QList<FileEntry> &entries)

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -193,6 +193,13 @@ private:
      */
     bool moveExtractTempFilesToDest(const QList<FileEntry> &files, const ExtractionOptions &options);
 
+    /**
+     * @brief removeExtractedFilesOnFailure 解压失败时清理已生成的文件（如分卷加密包输错密码时产生的 size 为 0 的文件）
+     * @param strTargetPath 解压目标路径
+     * @param entries 本次解压涉及的条目列表（可为空，为空时从 ArchiveData 获取全部）
+     */
+    void removeExtractedFilesOnFailure(const QString &strTargetPath, const QList<FileEntry> &entries);
+
     bool handleLongNameExtract(const QList<FileEntry> &files);
 
 private slots:

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -202,6 +202,8 @@ private:
 
     bool handleLongNameExtract(const QList<FileEntry> &files);
 
+    bool checkMoveCapability();
+
 private slots:
     /**
      * @brief readStdout  读取命令行输出


### PR DESCRIPTION
1 fix: [unrar] can not extract rar files with longFilenames
    
2 fix: remove empty files left when split-volume encrypted extraction fails (e.g. wrong password)

## Summary by Sourcery

Improve archive extraction robustness for long file names and failed encrypted extractions.

Bug Fixes:
- Prevent long-filename extraction workflow from running when the configured move program is unavailable, avoiding unrar failures on long paths.
- Remove leftover zero-size files and empty directories when full extraction fails (e.g. wrong password on split-volume encrypted archives).

Enhancements:
- Add a capability check for the external move program before performing long-filename handling, with clear diagnostic logging when it is missing.
- Ensure progress is reported as complete before aborting extraction when command output handling fails.