### PR TITLE
fix: Add temporary message support for non-blocking error notifications

### DIFF
--- a/3rdparty/clirarplugin/clirarplugin.cpp
+++ b/3rdparty/clirarplugin/clirarplugin.cpp
@@ -284,13 +284,14 @@ bool CliRarPlugin::handleLine(const QString &line, WorkType workStatus)
     }
 
     if (isWrongPasswordMsg(line)) {  // 提示密码错误
+        m_eErrorType = ET_WrongPassword;
+
         // RAR4密码错误直接结束
         if (line.startsWith(QLatin1String("Checksum error in the encrypted file"))) {
-            m_eErrorType = ET_WrongPassword;
             m_finishType = PFT_Error;
             return false;
-        } else { // RAR5密码错误反复输入新密码
-            m_eErrorType = ET_WrongPassword;
+        } else { // RAR5密码错误：发送错误提示但不中断进程，允许用户重新输入密码
+            emit error(tr("Wrong password"), tr("The password entered is incorrect. Please try again."));
             return true;
         }
     }

--- a/src/source/archivemanager/archivejob.h
+++ b/src/source/archivemanager/archivejob.h
@@ -110,6 +110,12 @@ Q_SIGNALS:
      */
     void signalQuery(Query *query);
 
+    /**
+     * @brief signalTempMessage 发送临时消息（不中断操作）
+     * @param message 消息内容
+     */
+    void signalTempMessage(const QString &message);
+
 public:
     JobType m_eJobType = JT_NoJob;     // 操作类型
     PluginFinishType m_eFinishedType = PFT_Nomral;

--- a/src/source/archivemanager/archivemanager.cpp
+++ b/src/source/archivemanager/archivemanager.cpp
@@ -111,6 +111,7 @@ bool ArchiveManager::loadArchive(const QString &strArchiveFullPath, UiTools::Ass
         // 连接槽函数
         connect(pLoadJob, &LoadJob::signalJobFinshed, this, &ArchiveManager::slotJobFinished);
         connect(pLoadJob, &LoadJob::signalQuery, this, &ArchiveManager::signalQuery);
+        connect(pLoadJob, &LoadJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
         m_pArchiveJob = pLoadJob;
         pLoadJob->start();
@@ -139,6 +140,7 @@ bool ArchiveManager::addFiles(const QString &strArchiveFullPath, const QList<Fil
         connect(pAddJob, &AddJob::signalprogress, this, &ArchiveManager::signalprogress);
         connect(pAddJob, &AddJob::signalCurFileName, this, &ArchiveManager::signalCurFileName);
         connect(pAddJob, &AddJob::signalQuery, this, &ArchiveManager::signalQuery);
+        connect(pAddJob, &AddJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
         m_pArchiveJob = pAddJob;
         pAddJob->start();
@@ -171,6 +173,7 @@ bool ArchiveManager::extractFiles(const QString &strArchiveFullPath, const QList
             connect(pExtractJob, &ExtractJob::signalCurFileName, this, &ArchiveManager::signalCurFileName);
             connect(pExtractJob, &ExtractJob::signalFileWriteErrorName, this, &ArchiveManager::signalFileWriteErrorName);
             connect(pExtractJob, &ExtractJob::signalQuery, this, &ArchiveManager::signalQuery);
+            connect(pExtractJob, &ExtractJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
             m_pArchiveJob = pExtractJob;
             pExtractJob->start();
@@ -186,6 +189,7 @@ bool ArchiveManager::extractFiles(const QString &strArchiveFullPath, const QList
             connect(pStepExtractJob, &StepExtractJob::signalprogress, this, &ArchiveManager::signalprogress);
             connect(pStepExtractJob, &StepExtractJob::signalCurFileName, this, &ArchiveManager::signalCurFileName);
             connect(pStepExtractJob, &StepExtractJob::signalQuery, this, &ArchiveManager::signalQuery);
+            connect(pStepExtractJob, &StepExtractJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
             pStepExtractJob->start();
             return true;
@@ -217,6 +221,7 @@ bool ArchiveManager::extractFiles2Path(const QString &strArchiveFullPath, const 
         connect(pExtractJob, &ExtractJob::signalprogress, this, &ArchiveManager::signalprogress);
         connect(pExtractJob, &ExtractJob::signalCurFileName, this, &ArchiveManager::signalCurFileName);
         connect(pExtractJob, &ExtractJob::signalQuery, this, &ArchiveManager::signalQuery);
+        connect(pExtractJob, &ExtractJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
         m_pArchiveJob = pExtractJob;
         pExtractJob->start();
@@ -247,6 +252,7 @@ bool ArchiveManager::deleteFiles(const QString &strArchiveFullPath, const QList<
         connect(pDeleteJob, &DeleteJob::signalprogress, this, &ArchiveManager::signalprogress);
         connect(pDeleteJob, &DeleteJob::signalCurFileName, this, &ArchiveManager::signalCurFileName);
         connect(pDeleteJob, &DeleteJob::signalQuery, this, &ArchiveManager::signalQuery);
+        connect(pDeleteJob, &DeleteJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
         m_pArchiveJob = pDeleteJob;
         pDeleteJob->start();
@@ -277,6 +283,7 @@ bool ArchiveManager::renameFiles(const QString &strArchiveFullPath, const QList<
         connect(pRenameJob, &RenameJob::signalprogress, this, &ArchiveManager::signalprogress);
         connect(pRenameJob, &RenameJob::signalCurFileName, this, &ArchiveManager::signalCurFileName);
         connect(pRenameJob, &RenameJob::signalQuery, this, &ArchiveManager::signalQuery);
+        connect(pRenameJob, &RenameJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
         m_pArchiveJob = pRenameJob;
         pRenameJob->start();
@@ -299,6 +306,7 @@ bool ArchiveManager::batchExtractFiles(const QStringList &listFiles, const QStri
         connect(pBatchExtractJob, &BatchExtractJob::signalCurFileName, this, &ArchiveManager::signalCurFileName);
         connect(pBatchExtractJob, &BatchExtractJob::signalQuery, this, &ArchiveManager::signalQuery);
         connect(pBatchExtractJob, &BatchExtractJob::signalCurArchiveName, this, &ArchiveManager::signalCurArchiveName);
+        connect(pBatchExtractJob, &BatchExtractJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
         m_pArchiveJob = pBatchExtractJob;
         pBatchExtractJob->start();
@@ -328,6 +336,7 @@ bool ArchiveManager::openFile(const QString &strArchiveFullPath, const FileEntry
         // 连接槽函数
         connect(pOpenJob, &OpenJob::signalJobFinshed, this, &ArchiveManager::slotJobFinished);
         connect(pOpenJob, &OpenJob::signalQuery, this, &ArchiveManager::signalQuery);
+        connect(pOpenJob, &OpenJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
 
         m_pArchiveJob = pOpenJob;
@@ -386,6 +395,7 @@ bool ArchiveManager::convertArchive(const QString &strOriginalArchiveFullPath, c
     connect(pConvertJob, &ConvertJob::signalprogress, this, &ArchiveManager::signalprogress);
     connect(pConvertJob, &ConvertJob::signalCurFileName, this, &ArchiveManager::signalCurFileName);
     connect(pConvertJob, &ConvertJob::signalQuery, this, &ArchiveManager::signalQuery);
+    connect(pConvertJob, &ConvertJob::signalTempMessage, this, &ArchiveManager::signalTempMessage);
 
     pConvertJob->start();
     return true;

--- a/src/source/archivemanager/archivemanager.h
+++ b/src/source/archivemanager/archivemanager.h
@@ -213,6 +213,12 @@ Q_SIGNALS:
      */
     void signalCurArchiveName(const QString &strArchiveName);
 
+    /**
+     * @brief signalTempMessage 发送临时消息（不中断操作）
+     * @param message 消息内容
+     */
+    void signalTempMessage(const QString &message);
+
 private:
     explicit ArchiveManager(QObject *parent = nullptr);
     ~ArchiveManager() override;

--- a/src/source/archivemanager/batchjob.cpp
+++ b/src/source/archivemanager/batchjob.cpp
@@ -186,6 +186,7 @@ bool BatchExtractJob::addExtractItem(const QFileInfo &fileInfo)
             connect(pExtractJob, &ExtractJob::signalCurFileName, this, &BatchExtractJob::slotHandleSingleJobCurFileName);
             connect(pExtractJob, &ExtractJob::signalQuery, this, &BatchExtractJob::signalQuery);
             connect(pExtractJob, &ExtractJob::signalJobFinshed, this, &BatchExtractJob::slotHandleSingleJobFinished);
+            connect(pExtractJob, &ExtractJob::signalTempMessage, this, &BatchExtractJob::signalTempMessage);
             addSubjob(pExtractJob);
         } else {
             StepExtractJob *pStepExtractJob = new StepExtractJob(fileInfo.absoluteFilePath(), stOptions);
@@ -193,6 +194,7 @@ bool BatchExtractJob::addExtractItem(const QFileInfo &fileInfo)
             connect(pStepExtractJob, &StepExtractJob::signalCurFileName, this, &BatchExtractJob::slotHandleSingleJobCurFileName);
             connect(pStepExtractJob, &StepExtractJob::signalQuery, this, &BatchExtractJob::signalQuery);
             connect(pStepExtractJob, &StepExtractJob::signalJobFinshed, this, &BatchExtractJob::slotHandleSingleJobFinished);
+            connect(pStepExtractJob, &StepExtractJob::signalTempMessage, this, &BatchExtractJob::signalTempMessage);
             addSubjob(pStepExtractJob);
         }
         return true;

--- a/src/source/archivemanager/batchjob.h
+++ b/src/source/archivemanager/batchjob.h
@@ -114,6 +114,12 @@ Q_SIGNALS:
      */
     void signalCurArchiveName(const QString &strArchiveName);
 
+    /**
+     * @brief signalTempMessage 发送临时消息（不中断操作）
+     * @param message 消息内容
+     */
+    void signalTempMessage(const QString &message);
+
 private Q_SLOTS:
     /**
      * @brief slotHandleSingleJobProgress       处理单个压缩包解压进度

--- a/src/source/archivemanager/singlejob.cpp
+++ b/src/source/archivemanager/singlejob.cpp
@@ -116,6 +116,7 @@ void SingleJob::initConnections()
     connect(m_pInterface, &ReadOnlyArchiveInterface::signalCurFileName, this, &SingleJob::signalCurFileName, Qt::ConnectionType::UniqueConnection);
     connect(m_pInterface, &ReadOnlyArchiveInterface::signalFileWriteErrorName, this, &SingleJob::signalFileWriteErrorName, Qt::ConnectionType::UniqueConnection);
     connect(m_pInterface, &ReadOnlyArchiveInterface::signalQuery, this, &SingleJob::signalQuery, Qt::ConnectionType::AutoConnection);
+    connect(m_pInterface, &ReadOnlyArchiveInterface::error, this, &SingleJob::slotError, Qt::AutoConnection);
 }
 
 void SingleJob::slotFinished(PluginFinishType eType)
@@ -127,6 +128,13 @@ void SingleJob::slotFinished(PluginFinishType eType)
         m_eErrorType = m_pInterface->errorType();
 
     emit signalJobFinshed();
+}
+
+void SingleJob::slotError(const QString &message, const QString &details)
+{
+    Q_UNUSED(details);
+    // 传递临时消息信号，用于显示但不中断操作的非致命错误提示
+    emit signalTempMessage(message);
 }
 
 // 加载操作
@@ -361,6 +369,7 @@ OpenJob::OpenJob(const FileEntry &stEntry, const QString &strTempExtractPath, co
     m_eJobType = JT_Open;
     connect(m_pInterface, &ReadOnlyArchiveInterface::signalFinished, this, &OpenJob::slotFinished, Qt::ConnectionType::UniqueConnection);
     connect(m_pInterface, &ReadOnlyArchiveInterface::signalQuery, this, &SingleJob::signalQuery, Qt::ConnectionType::AutoConnection);
+    connect(m_pInterface, &ReadOnlyArchiveInterface::error, this, &SingleJob::slotError, Qt::AutoConnection);
 }
 
 OpenJob::~OpenJob()

--- a/src/source/archivemanager/singlejob.h
+++ b/src/source/archivemanager/singlejob.h
@@ -70,6 +70,13 @@ public:
      */
     bool status() override;
 
+    /**
+     * @brief slotError  处理错误消息（不中断操作）
+     * @param message 错误消息
+     * @param details 详细信息
+     */
+    void slotError(const QString &message, const QString &details);
+
     SingleJobThread *getdptr();
 protected:
     /**

--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -278,6 +278,7 @@ void MainWindow::initConnections()
     connect(ArchiveManager::get_instance(), &ArchiveManager::signalFileWriteErrorName, this, &MainWindow::slotReceiveFileWriteErrorName);
     connect(ArchiveManager::get_instance(), &ArchiveManager::signalCurArchiveName, this, &MainWindow::slotReceiveCurArchiveName);
     connect(ArchiveManager::get_instance(), &ArchiveManager::signalQuery, this, &MainWindow::slotQuery);
+    connect(ArchiveManager::get_instance(), &ArchiveManager::signalTempMessage, this, &MainWindow::slotReceiveTempMessage);
 
     connect(m_pOpenFileWatcher, &OpenFileWatcher::fileChanged, this, &MainWindow::slotOpenFileChanged);
     //定制需求不显示ctrl+shift+？快捷键菜单
@@ -1260,6 +1261,13 @@ void MainWindow::slotReceiveCurFileName(const QString &strName)
 void MainWindow::slotReceiveFileWriteErrorName(const QString &strName)
 {
     m_fileWriteErrorName = strName;
+}
+
+void MainWindow::slotReceiveTempMessage(const QString &strMessage)
+{
+    qInfo() << "Temp message:" << strMessage;
+    QIcon icon = UiTools::renderSVG(":assets/icons/deepin/builtin/icons/compress_fail_128px.svg", QSize(30, 30));
+    sendMessage(new CustomFloatingMessage(icon, strMessage, 2000, this));
 }
 
 void MainWindow::slotQuery(Query *query)

--- a/src/source/mainwindow.h
+++ b/src/source/mainwindow.h
@@ -416,6 +416,12 @@ private Q_SLOTS:
     void slotReceiveFileWriteErrorName(const QString &strName);
 
     /**
+     * @brief slotReceiveTempMessage    接收临时消息
+     * @param strMessage    消息内容
+     */
+    void slotReceiveTempMessage(const QString &strMessage);
+
+    /**
      * @brief slotQuery   发送询问信号
      * @param query 询问类型
      */

--- a/translations/deepin-compressor.ts
+++ b/translations/deepin-compressor.ts
@@ -36,6 +36,19 @@
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
         <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
@@ -455,7 +468,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="577"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,427 +483,427 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="307"/>
-        <location filename="../src/source/mainwindow.cpp" line="317"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="340"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="347"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="354"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="361"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="375"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="482"/>
-        <location filename="../src/source/mainwindow.cpp" line="647"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="537"/>
-        <location filename="../src/source/mainwindow.cpp" line="3151"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="547"/>
-        <location filename="../src/source/mainwindow.cpp" line="2255"/>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
-        <location filename="../src/source/mainwindow.cpp" line="2318"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
-        <location filename="../src/source/mainwindow.cpp" line="3181"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="641"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1365"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1371"/>
-        <location filename="../src/source/mainwindow.cpp" line="1498"/>
-        <location filename="../src/source/mainwindow.cpp" line="1514"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1413"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1624"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1780"/>
-        <location filename="../src/source/mainwindow.cpp" line="1859"/>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
-        <location filename="../src/source/mainwindow.cpp" line="2322"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1921"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
         <location filename="../src/source/mainwindow.cpp" line="2154"/>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
         <source>Failed to create temporary directory, please check and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2170"/>
-        <location filename="../src/source/mainwindow.cpp" line="2180"/>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
         <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2232"/>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2234"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2263"/>
-        <location filename="../src/source/mainwindow.cpp" line="2346"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2267"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2271"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
         <source>No compression support in current directory. Download the files to a local device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2305"/>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
         <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2315"/>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2275"/>
-        <location filename="../src/source/mainwindow.cpp" line="2334"/>
-        <location filename="../src/source/mainwindow.cpp" line="2362"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2359"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2679"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2830"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2845"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3459"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2259"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2228"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2252"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2751"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2286"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2517"/>
-        <location filename="../src/source/mainwindow.cpp" line="2537"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1707"/>
-        <location filename="../src/source/mainwindow.cpp" line="1785"/>
-        <location filename="../src/source/mainwindow.cpp" line="1864"/>
-        <location filename="../src/source/mainwindow.cpp" line="1919"/>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/source/mainwindow.cpp" line="165"/>
-        <location filename="../src/source/mainwindow.cpp" line="482"/>
-        <location filename="../src/source/mainwindow.cpp" line="547"/>
-        <location filename="../src/source/mainwindow.cpp" line="580"/>
-        <location filename="../src/source/mainwindow.cpp" line="641"/>
-        <location filename="../src/source/mainwindow.cpp" line="647"/>
-        <location filename="../src/source/mainwindow.cpp" line="656"/>
-        <location filename="../src/source/mainwindow.cpp" line="696"/>
-        <location filename="../src/source/mainwindow.cpp" line="1397"/>
-        <location filename="../src/source/mainwindow.cpp" line="2517"/>
-        <location filename="../src/source/mainwindow.cpp" line="2537"/>
-        <location filename="../src/source/mainwindow.cpp" line="2845"/>
-        <location filename="../src/source/mainwindow.cpp" line="3010"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="656"/>
-        <location filename="../src/source/mainwindow.cpp" line="689"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2238"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2549"/>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2553"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2561"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2569"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2581"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3335"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="382"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="368"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1397"/>
-        <location filename="../src/source/mainwindow.cpp" line="2342"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1603"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1711"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1795"/>
-        <location filename="../src/source/mainwindow.cpp" line="2338"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
-        <location filename="../src/source/mainwindow.cpp" line="2326"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2330"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2350"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
         <source>No extraction support in current directory. Download the compressed package to a local device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2557"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3181"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3359"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3375"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3376"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3377"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3378"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3379"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3380"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3390"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3421"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="686"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
@@ -900,7 +913,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1274,7 +1287,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3178"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="555"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="606"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="607"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="617"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1430,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3641"/>
-        <location filename="../src/source/mainwindow.cpp" line="3696"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3644"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3700"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-compressor_ar.ts
+++ b/translations/deepin-compressor_ar.ts
@@ -4,12 +4,12 @@
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">كلمة سر خاطىة</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -46,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>التالي</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>الرجاء إضافة ملف</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">موافق</translation>
@@ -65,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation type="unfinished">الخيارات المتقدمة</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation type="unfinished">تشفير اﻵرشيف</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation type="unfinished">تشفير قائمة الملفات أيضاً</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation type="unfinished">تقسيم إلى كتل</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation type="unfinished">ضغط</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation type="unfinished">يدعم ملفات zip و 7z tr فقط</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation type="unfinished">يدعم ملف 7z فقط</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation type="unfinished">الاسم</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation type="unfinished">حفظ إلى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation type="unfinished">اسم الملف غير صالح</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation type="unfinished">الرجاء إدخال المسار</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation type="unfinished">المسار غير موجود ، يرجى إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">موافق</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">استبدال</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">يوجد ملف آخر بنفس الاسم بالفعل ، هل تريد استبداله ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation type="unfinished"></translation>
     </message>
@@ -275,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation type="unfinished">حذف</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">التأكيد</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -338,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -363,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation type="unfinished">فشل الاستخراج</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation type="unfinished">ملف تالف ، تعذر استخراجه</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation type="unfinished">رجوع</translation>
     </message>
@@ -396,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>قم بسحب ملفاص أو مجلداً هنا</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>تحديد ملف</translation>
     </message>
@@ -409,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
@@ -428,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -436,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>مدير اﻷرشيفات</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>مدير الأرشيفات هو تطبيق سريع وخفيف الوزن لإنشاء واستخراج اﻷرشيفات</translation>
     </message>
@@ -450,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>فتح ملف</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>اﻹعدادات</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>إنشاء أرشيف جديد</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>تم الضغط بنجاح</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 تم تغييره على القرص ، يرجى استيراده مرة أخرى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>مدير اﻷرشيفات</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">موافق</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>يتم الضغط</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>يتم الاستخراج</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">التأكيد</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation type="unfinished">تم الاستخراج بنجاح</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation type="unfinished">تم الاستخراج بنجاح</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>تعذر الضغط</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">استبدال</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>بحث عن دليل</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>كلمة سر خاطىة</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation type="unfinished">حذف</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation type="unfinished">فشل الاستخراج</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">يوجد ملف آخر بنفس الاسم بالفعل ، هل تريد استبداله ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation type="unfinished">الحجم</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation type="unfinished">النوع</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation type="unfinished">وقت التعديل</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation type="unfinished">أرشيف</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>تم تغيير الأرشيف على القرص ، يرجى استيراده مرة أخرى.</translation>
     </message>
@@ -878,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>دليل</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>تطبيق</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>فيديو</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>صوت</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>صورة</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>أرشيف</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>ملف تنفيذي</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>مستند</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>ملف نسخة احتياطية</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>غير معروف</translation>
     </message>
@@ -931,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">التأكيد</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation type="unfinished"></translation>
     </message>
@@ -971,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation type="unfinished">الملف مشفر ، يرجى إدخال كلمة المرور</translation>
     </message>
@@ -979,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -992,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 من المهام قيد المعالجة</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>مهمة</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>يتم الاستخراج</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation type="unfinished">هل أنت متأكد من أنك تريد إيقاف الاستخراج؟</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">التأكيد</translation>
@@ -1029,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation type="unfinished">يتم الحساب ...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation type="unfinished">يتم الضغط</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation type="unfinished">يتم الاستخراج</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">التأكيد</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation type="unfinished">هل أنت متأكد من أنك تريد إيقاف الضغط ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1171,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>وقت التعديل</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>النوع</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>الحجم</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>عام</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>الاستخراج</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>إضافة مجلد تلقائياً للمهام المتعدة للملفات المستخرجة </translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>ملفات مرتبطة</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>نوع الملف</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">يوجد ملف آخر بنفس الاسم بالفعل ، هل تريد استبداله ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">استبدال</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">موافق</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">موافق</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1316,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>الدليل الحالي</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>مسح الكل</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation type="unfinished">تحديد الكل</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>استخراج إلى</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>دليل آخر</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>سطح المكتب</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1381,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation type="unfinished">تم الضغط بنجاح</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation type="unfinished">عرض</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation type="unfinished">رجوع</translation>
     </message>
@@ -1399,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation type="unfinished">فتح ملف</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation type="unfinished">رجوع</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1418,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>استخراج إلى :</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation type="unfinished">استخراج</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation type="unfinished">مسار الاستخراج الافتراضي غير موجود ، يرجى إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">موافق</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>بحث عن دليل</translation>
     </message>
@@ -1455,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">موافق</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation type="unfinished">استخراج</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation type="unfinished">استخراج إلى الدليل الحالي</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation type="unfinished">حذف</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">التأكيد</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-compressor_ast.ts
+++ b/translations/deepin-compressor_ast.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ast">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ast">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Amiesta ficheros al archivu actual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Usar una contraseña</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>El ficheru orixinal de %1 nun esiste, compruébalo y volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 nun esiste nel discu, compruébalo y volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nun tienes permisu pa comprimir %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">La contraseña nun ye correuta</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Anovando&apos;l comentariu…</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Amiesta ficheros</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acuerdu</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Archivu nuevu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Opciones avanzaes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Métodu de compresión</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Cifrar l&apos;archivu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Cifrar tamién la llista de ficheros</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Dixebrar en volúmenes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Comentariu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Comprimir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Nengún</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>El más rápidu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Rápidu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Bonu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>El meyor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>2 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>4 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>8 threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>2 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>4 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>8 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Namás sofita zip y 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Namás sofita 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Introduz hasta %1 caráuteres</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Guardar en</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>El nome nun ye válidu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Introduz un camín</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>El camín nun esiste, volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nun tienes permisu pa guardar ficheros nesti direutoriu, cámbialu y volvi tentalu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Hai milenta volúmenes, usa un valor más baxu y volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 nun esiste nel discu, compruébalo y volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nun tienes permisu pa comprimir %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>El ficheru orixinal de %1 nun esiste, compruébalo y volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acuerdu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Trocar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Tamañu total: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>El nome ye igual que&apos;l del archivu, usa otru</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Les contraseñes de los ficheros ZIP nun puen tar en chinu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Yá esiste un ficheru col mesmu nome, ¿trocalu?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Namás se sofiten los caráuteres chinos, llatinos y dalgunos símbolos</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Desaniciar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Abrir con</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Otru programa</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Esto va desaniciar permanentemente los ficheros. ¿De xuru que quies siguir?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Amestar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>¿Quies amestar l&apos;archivu a la llista o abrilu nuna ventana nueva?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Abrir nuna ventana nueva</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Nun se sofiten los cambeos a los archivos d&apos;esti tipu. Convierti l&apos;archivu pa guardar los cambeos.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Convertir a:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Convertir</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>elementu/os</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>La estraición falló</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>El ficheru ta dañáu y nun ye posible estrayelu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Retentar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Arrastra un ficheru o una carpeta hasta equí</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Esbillar ficheros</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>L&apos;archivu ta dañáu</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Abrir nel mou de namás llectura</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Cargando, espera…</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Xestor d&apos;archivos</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Deepin Archive Manager ye una aplicación rápida y llixera pa crear y estrayer archivos.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Abrir ficheros</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Axustes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Creación d&apos;un archivu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Convirtiendo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Anovando&apos;l comentariu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Fallu de los plugins</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>L&apos;amiestu tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Nun hai datos dientro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Encaboxóse l&apos;amiestu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>L&apos;amiestu falló</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Hebo un fallu al crear «%1»</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>La compresión tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Nun hai abondu espaciu nel discu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Falten dalgunos volúmenes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>La contraseña ye incorreuta, volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Esbillar ficheros</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Introduz hasta %1 caráuteres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Información del ficheru</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>¿Quies desaniciar l&apos;archivu?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 camudó, volvi importar el ficheru.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Xestor d&apos;archivos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nun tienes permisu pa guardar ficheros nel direutoriu esbilláu, cámbialu y volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Amestando ficheros a %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Comprimiendo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Estrayendo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Desaniciando</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Cargando, espera…</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>¿De xuru que quies parar la xera en cursu?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Anovando, espera…</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>El nome ye perllongu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Hebo un fallu al crear el ficheru</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>La compresión falló</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Trocar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Busca d&apos;un direutoriu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>L&apos;apertura falló</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>La contraseña nun ye correuta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>El xestor d&apos;archivos nun sofita esti formatu de ficheru</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acuerdu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Nun tienes permisu pa cargar %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>El ficheru o la carpeta nun esiste</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>La estraición tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Encaboxóse la estraición</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>L&apos;archivu ta dañáu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>La descompresión tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>La conversión tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>La descompresión falló</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Zarrar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Desaniciar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Amosar los atayos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Atayos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>El nome ye igual que&apos;l del archivu, usa otru</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Yá esiste otru ficheru col mesmu nome, ¿trocalu?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Nun pues amestar l&apos;archivu a sigo mesmu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Nun pues amestar ficheros a los archivos d&apos;esti tipu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Anovar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Información básica</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Tamañu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Tipu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Allugamientu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Data de creación</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Data d&apos;accesu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Data de modificación</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archivu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Comentariu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Comprueba les asociaciones de ficheros nos axustes del xestor d&apos;archivos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>L&apos;archivu camudó, volvi importalu.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Direutoriu</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Aplicación</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Videu</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audiu</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Imaxe</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archivu</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Executable</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Documentu</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Desconozse</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Abrir con</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Amestar otros programes</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Predeterminar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Aplicaciones aconseyaes</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Otres aplicaciones</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>El ficheru ta cifráu, introduz la contraseña</translation>
     </message>
@@ -977,48 +1022,48 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Camín actual:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>Númberu de xeres en cursu: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Xera</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Estrayendo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>¿De xuru que quies parar la estraición?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Velocidá</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Calculando…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Velocidá</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Velocidá</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Velocidá</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Velocidá</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Tiempu que queda</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Comprimiendo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Desaniciando</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Convirtiendo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Anovando&apos;l comentariu…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Estrayendo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Posar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Siguir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>¿De xuru que quies parar la descompresión?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>¿De xuru que quies parar el desaniciu?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>¿De xuru que quies parar la compresión?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>¿De xuru que quies parar la conversión?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Data de modificación</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Tipu</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Tamañu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 camudó, ¿Quies guardar los cambeos nel archivu?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Xeneral</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Estraición</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Crear automáticamennte una carpeta al estrayer múltiples ficheros</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Amosar los ficheros estrayíos al estrayelos</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Xestión de ficheros</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Desaniciar los ficheros darréu de comprimilos</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Asociaciones de ficheros</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Tipos de ficheros</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Saltar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Mecer</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Yá esiste otru ficheru col mesmu nome, ¿trocalu?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Trocar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acuerdu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Yá esiste otra carpeta col mesmu nome, ¿trocala?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Aplicar a too</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">D&apos;acuerdu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Direutoriu actual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Desmarcar too</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Marcar too</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Marcar lo aconseyao</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Estrayer los ficheros en</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Otru direutoriu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Escritoriu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Desaniciar los archivos darréu d&apos;estrayelos</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Enxamás</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Pidir la confirmación</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Siempres</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>La compresión tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abrir ficheros</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Atrás</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Información del ficheru</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Estrayer en:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Estrayer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>El camín d&apos;estraición predetermináu nun esiste, volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nin tienes permisu pa guardar ficheros nesti direutoriu, cámbialu y volvi tentalo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acuerdu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Busca d&apos;un direutoriu</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Nun pues amestar l&apos;archivu a sigo mesmu</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acuerdu</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Estrayer</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Estrayer nel direutoriu actual</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Desaniciar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Abrir con</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Otru programa</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>¿Quies desaniciar los ficheros esbillaos?</translation>
     </message>

--- a/translations/deepin-compressor_az.ts
+++ b/translations/deepin-compressor_az.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Fayyları mövcud qovluğa daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Şifrəni istifadə edin</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>%1 orijinal faylı mövcud deyil, lütfən, yoxlayın və yenidən cəhd edin</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 diskdə mövcud deyil, lütfən, yoxlayın və yenidən cəhd edin</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Sizin %1 sıxmağa icazəniz yoxdur</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Səhv şifrə</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Şərh yenilənir...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Növbəti</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Fayllar əlavə edin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Yeni arxiv</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Əlavə seçimlər</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Sıxılma üsulu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Arxivi şifrələmək</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>CPU axınları</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Fayl siyahısını da şifrələmək</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Həcmlərə bölmək</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Şərh</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Sıxmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Ən tez</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Sürətli</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Yaxşı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Ən yaxşı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Tək axın</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 axın</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 axın</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 axın</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Yalnız zip, 7z növləri dəstəklənir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Yalnız 7z növü dəstəklənir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>%1 və daha çox işarə daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Adı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Burada saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Səhv fayl adı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Lütfən yolu daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Yol yoxdur, lütfən, təkrarlayın</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Faylları burada saxlamağa icazəniz yoxdur, dəyişdirin və yenidən cəhd edin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Həddindən çox həcmlər, lütfən, dəyişin və yrnidən təkrar edin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>Diskdə %1 mövcud deyil, lütfən, yoxlayın və təkrar edin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>%1 sıxmaöa icazəniz yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>%1 faylının əsli mövcud deyil,lütfən, yoxlayın və təkrar edin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Əvəz etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Ümumi ölçü: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Ad, sıxışdırılmış arxiv adı ilə eynidir, lütən başqasını seçin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>ZİP tutumları üçün şifrə Çin dilində ola bilməz </translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Bu adla başqa bir fayl mövcuddur, o əvəz edilsin?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Yalnız Çin və İngilis işarələri və bəzi simvollar dəstəklənir</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Açmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Adını dəyişin</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Bununla açmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Standart proqramı seçin</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Bununla fayl(lar) birdəfəlik silinəcək. Davam etmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Təsdiq etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Əlavə etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Siz arxivi siyahıya əlavə etmək yoxsa onu yeni pəncərədə açmaq istəyirsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Ueni pəncərədə açmaq</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Bu fayl növündəki arxivlərdə dəyişiklik etmək dəstəklənmir. Dəyişiklikləri saxlamaq üçün arxivin formatını dəyişin.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Bu formata çevirmək:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Çevirmək</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>element(lər)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Çıxarıla bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Pozulmuş fayl, çıxarıla bilmir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Təkrar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Geriyə</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Faylı və ya qovluğu buraya atın</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Fayl seçimi</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Arxiv zədələnib</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Yalnız oxumaq üçün açmaq</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Yüklənir, lütfən, gözləyin</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Arxiv meneceri</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Arxiv Meneceri faylları arxivləmək və arxivdən çıxartmaq üçün sürətli və yüngül tətbiqdir.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Faylı açmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Yeni arxiv yaratmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Çevrilir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Şərhlər yenilənir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Qoşma xətası</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Uğurla əlavə olunur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Bunda verilən yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Əlavə edilmə ləğv edildi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Əlavə edilə bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Çıxarmaq mümkün olmadı: fayl adı çox uzundur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>&quot;%1&quot; yaradıla bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Açmaq mümkün olmadı: fayl adı çox uzundur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Sıxılma uğurlu oldu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Fayl adı çox uzundur, belə ki, ilk 60 işarə fayl adı kimi qəbul olundu.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Yetərsiz disk sahəsi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Bəzi həcmlər mövcud deyil</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Səhv şifrə, lütfən təkrar edin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Fayl adı çox uzundur. Adı, 60 işarə olmadan saxlayın.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Çevirmək mümkün olmadı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Faylı seçin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>%1 və daha çox işarə daxil edin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Fayl məlumatı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Bu arxivi silmək istəyirsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1, bu diskdə dəyişdirildi, lütfən onu yenidən idxal edin.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Arxiv Meneceri</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Faylları burada saxlamağa icazəniz yoxdur, dəyişdirin və yenidən cəhd edin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Fayllar %1-ə/a əlavə olunur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Sıxılır</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Çıxarılır</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Silinir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Yüklənir, lütfən, gözləyin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Davam edən əməliyyatı dayandırmaq istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Yenilənir, lütfən, gözləyin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Fayl adı çox uzundur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Fayl yaradıla bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Sıxılma alınmadı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Əvəz etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Qovluğu tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Açıla bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Səhv şifrə</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Fayl formatı Arxiv Meneceri tərəfindən dəstəklənmir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Addəyişmə</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>%1 yükləməyə icazəniz yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Təsdiq etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Belə fayl və ya qovluq yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Uğurla çıxarıldı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Çıxarılma ləğv edildi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Arxiv zədələnib</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Uğurla çıxarıldı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Çevirilmə uğurlu oldu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Sıxılmış tutumlar artıq mövcuddur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Çıxarıla bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Kömək</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Qısayolları göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Qısayollar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Ad, sıxışdırılmış arxiv adı ilə eynidir, lütən başqasını seçin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Bu adla başqa bir fayl mövcuddur, o əvəz edilsin?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Arxiv öz saxilinə əlavə edilə bilməz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Bu fayl növündəki arxivlərə fayllar əlavə edə bilməzsiniz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Yeniləmək</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Əsas məlumat</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Növ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Yer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Yaradılma vaxtı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Müdaxilə vaxtı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Dəyişdirilmə vaxtı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arxiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Şərh</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Lütfən, fayl əlaqələri növünü Arxiv Meneceri ayarlarında yoxlayın</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Bu arxiv bu diskdə dəyişdirildi, lütfən onu yenidən idxal edin.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Qovluq</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Tətbiq</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Şəkil</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arxiv</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>İcra edilə bilən</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Sənəd</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Ehtiyyat nüsxə faylı</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Naməlum</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Bununla açmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Başqa proqramlar əlavə etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Standart kimi təyin etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Təsdiq etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Tövsiyyə olunan tətbiqlər</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Başqa tətbiqlər</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Şifrələnmiş fayl, lütfən, şifrəni daxil edin</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Cari yol:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Geriyə: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 tapşırıq(lar) yerinə yetirilir</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Tapşırıq</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Çıxarılır</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Çıxarılmanı dayandırmaq istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Təsdiq etmək</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Hesablanır...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Qalan vaxt</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Sıxılır</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Silinir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Addəyişmə</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Çevrilir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Şərh yenilənir...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Çıxarılır</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Fasilə</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Davam etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Təsdiq etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Arxivi boşalmasını dayandırmaq istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Silinməni dayandırmaq istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Sıxılmanı dayandırmaq istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Çevrilməni dayandırmaq istədiyinizə əminsiniz?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Adı</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Dəyişdirilmə vaxtı</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Növü</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 dəyişdirildi. Dəyişiklikləri arxivdə saxlamaq istəyirsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Əsas</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Çıxarılmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Çıxarılan çoxsaylı fayllar üçün avtomatik qovluq yaratmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Başa çatdıqda çıxarılan faylları göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Fayl İdarəedilməsi</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Sıxıldıqdan sonra faylları silmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Fayl əlaqələri</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Fayl növü</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Ötürmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Birləşdirmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Bu adla başqa bir fayl mövcuddur, o əvəz edilsin?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Əvəz etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Bu adla başqa bir qovluq mövcuddur, o əvəz edilsin?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Hamısına tətbiq etmək</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Adını dəyişin</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>Bu ad artıq mövcuddur</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Cari qoluq</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Hamısını silmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Hamısını seçmək</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Tovsiyyə olunan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Arxivləri buraya çıxartmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Başqa qovluq</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>İş Masası</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Çıxarıldıqdan sonra arxiv silinsin</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Heç vaxt</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Tədiq edilməsi soruşulsun</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Həmişə</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Sıxılma uğurlu oldu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Baxış</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Geriyə</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Faylı açın</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Geriyə</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Fayl məlumatı</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Buraya çıxartmaq:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Çıxartmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Standart çıxarılma yolu mövcud deyil, yenidən cəhd edin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Faylları burada saxlamağa icazəniz yoxdur, dəyişdirin və yenidən cəhd edin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Qovluğu tapmaq</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Arxivi öz daxilinə əlavə edə bilməzsiniz</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Çıxartmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Cari qovluğa çıxartmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Açmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Adını dəyişin</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Bununla açmaq</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Standart proqramı seçin</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Təsdiq etmək</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Seçilmiş fayl(lar)ı silmək istəyirsiniz?</translation>
     </message>

--- a/translations/deepin-compressor_bo.ts
+++ b/translations/deepin-compressor_bo.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>ཡིག་ཆ་མིག་སྔའི་སྡུད་སྒྲིལ་ཁུག་མའི་ནང་འཇོག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>གསང་ཨང་སྤྱོད་པ།</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>“%1”དམིགས་འཛུགས་བྱས་པའི་ཁུངས་ཡིག་ཆ་མེད་པས། ཞིབ་བཤེར་བྱས་རྗེས་ཡང་བསྐྱར་ཚོད་ལྟ་བྱོས། </translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>“%1”མེད་པས། ཞིབ་བཤེར་བྱས་རྗེས་ཡང་བསྐྱར་ཚོད་ལྟ་བྱོས། </translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>ཁྱེད་ལ་ཡིག་ཆ་“%1”གནོན་བཙིར་བྱེད་པའི་དབང་ཚད་མེད།</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">གསང་ཨང་ནོར་འདུག</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>མཆན་འགྲེལ་གསར་པ་བརྗེ་བཞིན་ཡོད་པས། ཏོག་ཙམ་སྒུག་རོགས།</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>ཡིག་ཆ་སྣོན་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ཆོག</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>ཡིག་ཚགས་སུ་ཉར་བའི་ཡིག་ཆ་གསར་བཟོ་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>མཐོ་རིམ་གདམ་ག</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>སྡུད་སྒྲིལ་བྱ་ཐབས།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>གསང་སྡོམ་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>CPUསྐུད་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>གསང་སྡོམ་ཡིག་ཆའི་རེའུ་མིག</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>བམ་པོ་དབྱེ་ནས་གནོན་བཙིར་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>མཆན་འགྲེལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>གནོད་བཙིར།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>ཉར་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>མགྱོགས་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>ཅུང་མགྱོགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>ཚད་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>ཅུང་བཟང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>ཡག་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>སྐུད་རིམ་རྐྱང་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>4 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>8 threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>4 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>8 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>རྣམ་གཞག་zip, 7zགཅིག་པུར་རྒྱབ་སྐྱོར་བྱ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>རྣམ་གཞག་7zགཅིག་པུར་རྒྱབ་སྐྱོར་བྱ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>མཆན་འགྲེལ་གྱི་ནང་དོན་ཡིག་རྟགས་%1ལས་བརྒལ་མི་རུང་། </translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>ཡིག་ཆའི་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>དུ་ཉར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>གོ་ཆོད་པའི་ཡིག་ཆའི་མིང་འཇུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>ཉར་བའི་ལམ་བུ་འབྲི་རོགས་གནང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>མིག་སྔའི་ལམ་བུ་མེད་པས། ཡང་བསྐྱར་ཚོད་ལྟ་གནང་དང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>ཁྱེད་ལ་ལམ་བུ་འདི་བརྒྱུད་ནས་ཡིག་ཆ་ཉར་བའི་དབང་ཚད་མེད་པས། ཡང་བསྐྱར་ཚོད་ལྟ་གྱིས་དང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>བམ་པོ་མང་དྲགས་པས། བསྒྱུར་བ་བཏང་རྗེས་ཚོད་ལྟ་གནང་དང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>“%1”མེད་པས། ཞིབ་བཤེར་བྱས་རྗེས་ཡང་བསྐྱར་ཚོད་ལྟ་བྱོས། </translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>ཁྱེད་ལ་ཡིག་ཆ་“%1”གནོན་བཙིར་བྱེད་པའི་དབང་ཚད་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>“%1”དམིགས་འཛུགས་བྱས་པའི་ཁུངས་ཡིག་ཆ་མེད་པས། ཞིབ་བཤེར་བྱས་རྗེས་ཡང་བསྐྱར་ཚོད་ལྟ་བྱོས། </translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>ཡིག་ཆའི་སྤྱིའི་ཆེ་ཆུང་། %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>ཡིག་ཆའི་མིང་དང་གནོན་བཙིར་བྱས་པའི་ཡིག་ཆའི་མིང་གཅིག་པ་རེད་འདུག་པས། ཡིག་ཆའི་མིང་བརྗེ་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>zipཡན་ལག་གིས་རྒྱ་ཡིག་གི་གསང་ཨང་ལ་རྒྱབ་སྐྱོར་མི་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ཡིག་ཆ་ཡོད་ཟིན་པས། བརྗེས་སམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>རྒྱ་ཡིག་དང་དབྱིན་ཡིག་གི་ཡིག་རྟགས་དང་ཡིག་རྟགས་འགའ་ཞིག་ལ་རྒྱབ་སྐྱོར་བྱེད་པ།</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>ཁ་ཕྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>ཁ་ཕྱེ་སྟངས།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>སོར་བཞག་བྱ་རིམ་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>བཀོལ་སྤྱོད་འདིས་བདམས་ཟིན་པས་ཡིག་ཆ་རྦད་དེ་སུབ་སྲིད། ཁྱེད་ཀྱིས་སུབ་རྒྱུ་གཏན་འཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>གཏན་འཁེལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>གནོན་བཙིར་ཡིག་ཆ་དེ་དཀར་ཆག་གམ་སྒེའུ་ཁུང་གསར་པའི་ནང་དུ་བཞག་ནས་ཡིག་ཆ་འདི་ཁ་ཕྱེ་འམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>སྒེའུ་ཁུང་གསར་པའི་ནང་དུ་ཁ་ཕྱེ།</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>གནོན་བཙིར་རྣམ་གཞག་འདིའི་བཟོ་བཅོས་ལ་རྒྱབ་སྐྱོར་མི་བྱེད། ཡིག་ཆ་འདིའི་བཟོ་བཅོས་རྒྱུན་འཁྱོངས་བྱེད་ཆེད། ཁྱེད་ཀྱིས་གནོད་བཙིར་རྣམ་གཞག་བརྗེ་སྒྱུར་གནང་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>གནོན་བཙིར་རྣམ་གཞག་：  ལ་བརྗེ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>བརྗེ་སྒྱུར།</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>རྣམ་གྲངས།(གཅིག)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>བསྡུས་འགྲོལ་བྱེད་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>ཡིག་ཆ་སྐྱོན་ཤོར་བས། བསྡུས་འགྲོལ་བྱེད་ཐབས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>ཡང་བསྐྱར་ཚོད་ལྟ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>ཡིག་ཆ་འདི་རུ་འཇོག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>ཡིག་ཆ་འདེམས་པ།</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>མིག་སྔའི་སྡུད་སྒྲིལ་ཡིག་ཆ་འཕྲོ་བརླག་ཕྱིན་འདུག </translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>ཀློག་ཙམ་གྱི་དཔེ་རྣམ་ལས་ཁ་ཕྱེ་བ།</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>སྣོན་འཇུག་བྱེད་བཞིན་པས། ཏོག་ཙམ་སྒུག་རོགས།</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>ཡིག་ཚགས་དོ་དམ་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>ཡིག་ཚགས་དོ་དམ་ཆས་ནི་མགྱོགས་ལ་སྟབས་བདེ་བའི་ཡིག་ཆ་གནོན་བཙིར་དང་བསྡུས་འགྲོལ་བྱེད་པའི་ཡོ་བྱད་ཞིག་རེད། ཡིག་ཆ་གནོན་བཙིར་དང་བསྡུས་འགྲོལ་བྱེད་པའི་རྒྱུན་གཏན་བྱེད་ནུས་མཁོ་འདོན་བྱེད་ཀྱི་ཡོད།</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>ཡིག་ཆ་ཁ་ཕྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>ཡིག་ཚགས་སུ་ཉར་བའི་ཡིག་ཆ་གསར་བཟོ་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>བརྗེ་སྒྱུར་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>མཆན་འགྲེལ་གསར་སྒྱུར་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>བར་འཇུག་རྒྱུན་འགལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>བསྐྱར་སྣོན་བྱེད་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>སྡུད་སྒྲིལ་ནང་གཞི་གྲངས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>བསྐྱར་སྣོན་བྱེད་མཚམས་བཞག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>བསྐྱར་སྣོན་བྱེད་མ་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>ཡིག་ཆ་“%1”བཟོ་མ་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>གནོན་བཙིར་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>སྡུད་སྡེར་གྱི་བར་སྟོང་མི་འདང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>དེབ་བགོས་མ་ཚང་མེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>བསྡུས་འགྲོལ་གསང་ཨང་ནོར་བས། ཡང་བསྐྱར་ཚོད་ལྟ་བྱོས། </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>ཡིག་ཆ་འདེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>མཆན་འགྲེལ་གྱི་ནང་དོན་ཡིག་རྟགས་%1ལས་བརྒལ་མི་རུང་། </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>ཡིག་ཆའི་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>ཁྱེད་ཀྱིས་གནོན་བཙིར་ཡིག་ཆ་འདི་སུབ་རྒྱུ་གཏན་འཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>“%1”ལ་འགྱུར་བ་བྱུང་ཟིན་པས། ཡང་བསྐྱར་ཡིག་ཆ་འདྲེན་འཇུག་གནང་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>ཡིག་ཚགས་དོ་དམ་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>ཁྱེད་ལ་ལམ་བུ་འདི་བརྒྱུད་ནས་ཡིག་ཆ་ཉར་བའི་དབང་ཚད་མེད་པས། ཡང་བསྐྱར་ཚོད་ལྟ་གྱིས་དང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>%1ལ་ཡིག་ཆ་སྣོན་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>གནོན་བཙིར་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>བསྡུས་འགྲོལ་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>སུབ་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>སྣོན་འཇུག་བྱེད་བཞིན་པས། ཏོག་ཙམ་སྒུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>ཁྱེད་ཀྱིས་བཀོལ་སྤྱོད་བྱེད་བཞིན་པའི་ལས་འགན་མཚམས་འཇོག་བྱ་རྒྱུ་གཏན་འཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>གསར་སྒྱུར་བྱེད་བཞིན་ཡོད་པས། སྒུག་རོགས། </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>ཡིག་ཆའི་མིང་རིང་དྲགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>ཡིག་ཆ་བཟོ་མ་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>གནོན་བཙིར་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>དཀར་ཆག་ཏུ་བསྡུས་འགྲོལ་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>ཁ་ཕྱེ་མ་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>གསང་ཨང་ནོར་འདུག</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>རྣམ་གཞག་འདིའ་ཡིག་ཆ་ཁ་ཕྱེ་བར་རྒྱབ་སྐྱོར་མེད། </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>ཁྱོད་ལ་ཡིག་ཆ་“%1”སྣོན་འཇུག་བྱེད་དབང་མེད། </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>གཏན་འཁེལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>ཡིག་ཆའམ་དཀར་ཆག་དེ་མི་འདུག </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>བསྡུས་འགྲོལ་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>ལེན་མཚམས་བཞག་པ། </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>མིག་སྔའི་སྡུད་སྒྲིལ་ཡིག་ཆ་འཕྲོ་བརླག་ཕྱིན་འདུག </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>བསྡུས་འགྲོལ་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>བརྗེ་སྒྱུར་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>བསྡུས་འགྲོལ་བྱེད་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>རོགས་རམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>མྱུར་མཐེབ་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>མྱུར་མཐེབ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>ཡིག་ཆའི་མིང་དང་གནོན་བཙིར་བྱས་པའི་ཡིག་ཆའི་མིང་གཅིག་པ་རེད་འདུག་པས། ཡིག་ཆའི་མིང་བརྗེ་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ཡིག་ཆ་ཡོད་ཟིན་པས། བརྗེས་སམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>གནོན་བཙིར་ཡིག་ཆ་འདི་རང་ཉིད་ཐོག་ཏུ་སྣོན་ཐབས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>གནོན་བཙིར་ཡིག་ཆ་འདིའི་རྣམ་གཞག་གིས་ཡིག་ཆར་སྣོན་པར་རྒྱབ་སྐྱོར་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>གསར་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>གཞི་རྩའི་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>གནས་ས།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>དུས་ཚོད་བཟོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>ལྟ་སྤྱོད་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>བཅོས་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>གནོན་བཙིར་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>མཆན་འགྲེལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>ཡིག་ཚགས་དོ་དམ་ཆས་ཀྱི་སྒྲིག་འགོད་ཁྲོད་དུ་ཡིག་ཆ་དེའི་རིགས་གྲས་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>མིག་སྔའི་གནོན་བཙིར་ཡིག་ཆ་ལ་འགྱུར་བ་བྱུང་ཟིན་པས། ཡང་བསྐྱར་ཡིག་ཆ་འདྲེན་འཇུག་གནང་རོགས།</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>དཀར་ཆག</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>ཉེར་སྤྱོད་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>བརྙན་ཟློས།</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>སྒྲ་ཟློས།</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>པར་རིས།</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>གནོན་བཙིར་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>ལག་ལེན་བསྟར་རུང་བའི་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>ཡིག་ཚགས།</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>གྲབས་ཉར་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>མི་ཤེས།</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>ཁ་ཕྱེ་སྟངས།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>བྱ་རིམ་གཞན་དག་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>སོར་བཞག་བྱ་རིམ་སྒྲིག་འགོད་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>གཏན་འཁེལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>འོས་སྦྱོར་ཉེར་སྤྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>ཉེར་སྤྱོད་གཞན་དག</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>ཡིག་ཆ་འདི་གསང་སྡོམ་བྱས་ཟིན་པས། བསྡུས་འགྲོལ་གསང་ཨང་འཇུག་རོགས།</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>མིག་སྔའི་འགྲོ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>%1ཕྱིར་ལོག </translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>ལས་འགན1%(གང་རུང)བཀོལ་སྤྱོད་བྱེད་བཞིན་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>མིག་སྔའི་ལས་འགན།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>བསྡུས་འགྲོལ་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>ཁྱེད་ཀྱིས་ཡིག་ཆ་འདི་བསྡུས་འགྲོལ་བྱེད་མཚམས་འཇོག་རྒྱུ་གཏན་འཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>གཏན་འཁེལ།</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>བསྡུས་འགྲོལ་མྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>རྩིས་རྒྱག་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>བསྡུས་འགྲོལ་མྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">བསྡུས་འགྲོལ་མྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>བསྡུས་འགྲོལ་མྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>བསྡུས་འགྲོལ་མྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>ལྷག་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>གནོན་བཙིར་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>སུབ་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>བརྗེ་སྒྱུར་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>མཆན་འགྲེལ་གསར་པ་བརྗེ་བཞིན་ཡོད་པས། ཏོག་ཙམ་སྒུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>བསྡུས་འགྲོལ་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>མཚམས་འཇོག</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>མུ་མཐུད།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>གཏན་འཁེལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>ཁྱོད་ཀྱི་ཡིག་ཆ་བསྡུས་འགྲོལ་བྱེད་མཚམས་འཇོག་རྒྱུ་གཏན་ཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>ཁྱོད་ཀྱིས་སུབ་མཚམས་འཇོག་རྒྱུ་གཏན་འཁེལ་ལམ། </translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>ཁྱེད་ཀྱིས་ཡིག་ཆ་གནོན་བཙིར་བྱེད་མཚམས་འཇོག་རྒྱུ་གཏན་འཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>ཁྱེད་ཀྱིས་རྣམ་གཞག་སྒྱུར་མཚམས་འཇོག་རྒྱུ་གཏན་འཁེལ་ལམ།</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>བཅོས་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>ཡིག་ཆ་“%1”བཅོས་ཟིན་པས། བཟོ་བཅོས་འདི་གནོན་བཙིར་ཁུག་ཏུ་གསར་སྒྱུར་བྱེད་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>བསྡུས་འགྲོལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>རང་འགུལ་ངང་ཡིག་ཁུག་གསར་བཟོ་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>བསྡུས་འགྲོལ་ཚར་རྗེས་རང་འགུལ་ངང་དོ་ཟླའི་ཡིག་ཁུག་ཁ་ཕྱེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>ཡིག་ཆ་དོ་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>གནོད་བཙིར་བྱས་རྗེས་ཐོག་མའི་ཡིག་ཆ་སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>འབྲེལ་ལྡན་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>ཡིག་ཆའི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>མཆོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>ཟླ་སྒྲིལ། </translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ཡིག་ཆ་ཡོད་ཟིན་པས། བརྗེས་སམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>ཡིག་ཆ་ཡོད་ཟིན་པས། བརྗེས་སམ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>ཡིག་ཆ་ཚང་མར་སྤྱོད་པ།</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>མིག་སྔའི་དཀར་ཆག</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>ཡོངས་འདེམས་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>ཡོངས་འདེམས།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>འོས་སྦྱོར་གདམ་ག</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>སོར་བཞག་གི་བསྡུས་འགྲོལ་བྱེད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>དཀར་ཆག་གཞན་དག་ </translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>ཅོག་ངོས།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>བསྡུས་འགྲོལ་བྱས་རྗེས་གནོན་བཙིར་ཡིག་ཆ་སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>གཏན་ནས་མིན།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>གཏན་འཁེལ་མིན་འདྲི་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>རྟག་ཏུ།</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>གནོན་བཙིར་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>ཡིག་ཆ་ལྟ་བཤེར།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ཡིག་ཆ་ཁ་ཕྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ཡིག་ཆའི་ཆ་འཕྲིན།</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>དུ་བསྡུས་འགྲོལ་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>བསྡུས་འགྲོལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>སོར་བཞག་གི་བསྡུས་འགྲོལ་ལམ་བུ་མེད་པས། ཡང་བསྐྱར་འཇུག་རོགས་གནང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>ཁྱེད་ལ་ལམ་བུ་འདི་བརྒྱུད་ནས་ཡིག་ཆ་ཉར་བའི་དབང་ཚད་མེད་པས། ཡང་བསྐྱར་ཚོད་ལྟ་གྱིས་དང་།</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>དཀར་ཆག་ཏུ་བསྡུས་འགྲོལ་བྱེད་པ།</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>གནོན་བཙིར་ཡིག་ཆ་འདི་རང་ཉིད་ཐོག་ཏུ་སྣོན་ཐབས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>འདོན་ལེན།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>མིག་སྔའི་ཡིག་ཁུག་ཏུ་འདོན་ལེན་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>ཁ་ཕྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>ཁ་ཕྱེ་སྟངས།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>སོར་བཞག་བྱ་རིམ་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>གཏན་འཁེལ།</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>བདམས་ཟིན་པའི་ཡིག་ཆ་སུབ་བམ།</translation>
     </message>

--- a/translations/deepin-compressor_ca.ts
+++ b/translations/deepin-compressor_ca.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Afegeix fitxers a l&apos;arxiu actual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Usa la contrasenya</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>El fitxer original de %1 no existeix. Si us plau, comproveu-ho i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 no existeix al disc. Si us plau, comproveu-ho i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>No teniu permís per comprimir %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Contrasenya incorrecta</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>S&apos;actualitza el comentari...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Següent</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Si us plau, afegiu-hi fitxers.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Arxiu nou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Opcions avançades</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Mètode de compressió</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Xifra el fitxer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Fils de la CPU</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Xifra també la llista de fitxers</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Divideix en volums</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Comentari</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Comprimeix</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Emmagatzematge</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Rapidíssim</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Ràpid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Bo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Millor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Fil únic</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 fils</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 fils</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 fils</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Només compatible amb zip i 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Només compatible amb 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Escriviu fins a %1 caràcters.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Desa a</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Nom de fitxer no vàlid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Si us plau, introduïu el camí.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>El camí no existeix. Torneu-ho a provar!</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>No teniu permís per desar fitxers aquí. Si us plau, canvieu-ho i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Massa volums. Si us plau, canvieu-ho i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 no existeix al disc. Si us plau, comproveu-ho i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>No teniu permís per comprimir %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>El fitxer original de %1 no existeix. Si us plau, comproveu-ho i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Mida total: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>El nom és igual al de l&apos;arxiu comprimit. Si us plau, useu-ne un altre.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>La contrasenya per als volums ZIP no pot ser en xinès.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ja existeix un altre fitxer amb el mateix nom. Voleu reemplaçar-lo?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Només s&apos;admeten caràcters xinesos i anglesos i alguns símbols.</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Obre</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Canvia&apos;n el nom</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Obre amb</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Trieu el programa per defecte</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>S&apos;eliminaran permanentment els fitxers. Segur que voleu continuar?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmeu-ho</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Afegeix</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Voleu afegir el fitxer a la llista o obrir-lo en una finestra nova?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Obre en una finestra nova</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Els canvis dels arxius d&apos;aquest tipus de fitxers no són compatibles. Convertiu el format d’arxiu per desar els canvis.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Converteix-ne el format a:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Converteix</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>element/s</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>L&apos;extracció ha fallat.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Fitxer malmès, no es pot extreure.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Torna-ho a provar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Enrere</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Arrossegueu un fitxer o una carpeta aquí.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Trieu un fitxer</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>L&apos;arxiu està danyat.</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>L&apos;obertura és només de lectura.</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Es carrega. Espereu, si us plau...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Gestor d&apos;arxius</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>El Gestor d&apos;arxius és una aplicació lleugera i ràpida per crear i descomprimir arxius.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Obre el fitxer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Configuració</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Crea un nou fitxer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Es converteix</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>S&apos;actualitzen els comentaris.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Error del connector</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Addició correcta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>No hi ha dades.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>S&apos;ha cancel·lat l&apos;addició.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Ha fallat l&apos;addició.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Ha fallat l&apos;extracció: el nom del fitxer és massa llarg.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Ha fallat crear &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Ha fallat obrir-lo: el nom del fitxer és massa llarg.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Compressió correcta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>El nom del fitxer és massa llarg, de manera que els primers 60 caràcters s&apos;han pres com a nom del fitxer.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Espai de disc insuficient</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Manquen alguns volums</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Contrasenya incorrecta. Torneu-ho a provar.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>El nom del fitxer és massa llarg. Si us plau, manteniu el nom amb un màxim de 60 caràcters.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Ha fallat la conversió.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Seleccioneu un fitxer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Escriviu fins a %1 caràcters.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Informació del fitxer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Voleu eliminar l&apos;arxiu?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 ha canviat al disc. Si us plau, torneu-lo a importar.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Gestor d&apos;arxius</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>No teniu permís per desar fitxers aquí. Si us plau, canvieu-ho i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>S&apos;afegeixen fitxers a %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Es comprimeix</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>S&apos;extreu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>S&apos;elimina</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Es carrega. Espereu, si us plau...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Segur que voleu interrompre la tasca activa?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>S&apos;actualitza. Espereu, si us plau...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Nom del fitxer massa llarg.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Ha fallat crear el fitxer.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>La compressió ha fallat.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Troba un directori</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Ha fallat l&apos;obertura.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Contrasenya incorrecta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>El format del fitxer no l&apos;admet el Gestor d&apos;arxius.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Canvi de nom</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>No teniu permís per carregar %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmeu-ho</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>No hi ha tal fitxer o directori.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Extracció correcta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>S&apos;ha cancel·lat l&apos;extracció.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>L&apos;arxiu està danyat.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Extracció correcta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Conversió correcta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Els volums comprimits ja existeixen.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>L&apos;extracció ha fallat.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Tanca</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Suprimeix</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Mostra les dreceres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Dreceres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>El nom és igual al de l&apos;arxiu comprimit. Si us plau, useu-ne un altre.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ja existeix un altre fitxer amb el mateix nom. Voleu reemplaçar-lo?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>No podeu afegir un arxiu a si mateix.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>No podeu afegir fitxers d&apos;aquest tipus a arxius.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Actualitza</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Informació bàsica</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Ubicació</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Hora de creació</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Hora d&apos;accés</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Modificat</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arxiva</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Comentari</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Si us plau, comproveu el tipus d&apos;associació de fitxers a la configuració del Gestor d&apos;arxius.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>L&apos;arxiu ha canviat al disc. Si us plau, torneu-lo a importar.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Directori</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Aplicació</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Àudio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Imatge</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arxiva</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Executable</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Document</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Fitxer de còpia de seguretat</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Desconegut</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Obre amb</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Afegeix altres programes</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Estableix-lo per defecte</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmeu-ho</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Aplicacions recomanades</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Altres aplicacions</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Fitxer encriptat. Si us plau, introduïu-ne la contrasenya.</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Camí actual:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Enrere a: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 tasca/ques en curs</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Tasca</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>S&apos;extreu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Segur que voleu interrompre&apos;n l&apos;extracció?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmeu-ho</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Es calcula...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Temps restant</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Es comprimeix</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>S&apos;elimina</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Canvi de nom</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Es converteix</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>S&apos;actualitza el comentari...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>S&apos;extreu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Interromp</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continua</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmeu-ho</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Segur que voleu interrompre&apos;n la descompressió?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Segur que voleu interrompre&apos;n la supressió?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Segur que voleu interrompre&apos;n la compressió?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Segur que voleu interrompre&apos;n la conversió?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Modificat</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 ha canviat. Voleu desar els canvis a l&apos;arxiu?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Extracció</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Crea una carpeta automàticament per a l&apos;extracció de múltiples fitxers.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Mostra els fitxers extrets en acabar.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Gestió de fitxers</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Elimina els fitxers després de la compressió.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Fitxers associats</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Tipus de fitxer</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Omet</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Fusiona</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ja existeix un altre fitxer amb el mateix nom. Voleu reemplaçar-lo?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Ja existeix una altra carpeta amb el mateix nom. Voleu reemplaçar-la?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Aplica-ho a tot</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Canvia&apos;n el nom</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>El nom ja existeix.</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Directori actual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Neteja-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Selecciona-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Recomanat</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Extreu els arxius a</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Altre directori</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Escriptori</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Elimina els arxius després de l&apos;extracció.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Mai</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Demana&apos;n la confirmació.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Sempre</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Compressió correcta</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Vista</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Enrere</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Obre el fitxer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Enrere</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Informació del fitxer</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Extreu a:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Extreu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>El camí d&apos;extracció per defecte no existeix. Torneu-ho a provar, si us plau.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>No teniu permís per desar fitxers aquí. Si us plau, canvieu-ho i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Troba un directori</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>No podeu afegir un arxiu a si mateix.</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Extreu</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Extreu-ho al directori actual</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Obre</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Canvia&apos;n el nom</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Obre amb</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Trieu el programa per defecte</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmeu-ho</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Voleu eliminar el/s fitxer/s seleccionat/s?</translation>
     </message>

--- a/translations/deepin-compressor_cs.ts
+++ b/translations/deepin-compressor_cs.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="cs">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Přidat soubory do stávajícího archivu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Použít heslo</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Původní soubor %1 neexistuje – zkontrolujte a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 neexistuje na disku – ověřte a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nemáte oprávnění pro zkomprimování %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Chybné heslo</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Aktualizace komentáře…</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Přidejte soubory</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Nový archiv</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Pokročilé volby</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Metoda komprese</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Zašifrovat archiv</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Vláken procesoru</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Zašifrovat také seznam souborů</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Rozdělit na části</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Komentář</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Zkomprimovat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Úložiště</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Nejrychlejší</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Rychlé</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Dobrá</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Nejlepší</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Jedno vlákno</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 vlákna</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 vlákna</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 vláken</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Podpora pro formát ZIP, pouze typ 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Podpora pouze pro typ 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Zadejte až %1 znaků</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Uložit do</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Neplatný název souboru</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Zadejte popis umístění</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Daný popis umístění neexistuje – zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nemáte oprávnění ukládat sem soubory. Změňte umístění a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Příliš mnoho svazků – přejděte jinam a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 neexistuje na disku – ověřte a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nemáte oprávnění pro zkomprimování %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Původní soubor %1 neexistuje – zkontrolujte a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Celková velikost: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Název je stejný jako komprimovaného archivu – použijte jiný</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Heslo pro ZIP svazky nemůže být v čínštině</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Už existuje jiný soubor se stejným názvem. Nahradit ho?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Podporovány jsou pouze znaky z anglické a čínské abecedy a některé symboly</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Otevřít</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Otevřít s</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Vyberte výchozí program</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Toto soubory natrvalo smaže. Opravdu chcete pokračovat?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdit</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Přidat</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Chcete archiv přidat do seznamu nebo ho otevřít v novém okně?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Otevřít v novém okně</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>V případě tohoto typu souboru nejsou změny v archivu podporovány. Pro uložení změn převeďte do jiného formátu archivu.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Převést formát na:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Převést</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>položka/y</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Rozbalení se nezdařilo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Poškozený soubor. Nelze rozbalit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Zkusit znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Zpět</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Sem přetáhněte soubor nebo složku</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Vybrat soubor</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Archiv je poškozený</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Otevřít pouze pro čtení</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Načítání – čekejte prosím…</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Správce archivů</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Správce archivů je rychlá a na systémové prostředky nenáročná aplikace pro vytváření a rozbalování archivů.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Otevřít soubor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Vytvořit nový archiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Převádí se</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Aktualizují se komentáře</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Chyba zásuvného modulu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Úspěšně přidáno</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Nejsou v něm data</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Přidání zrušeno</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Přidání se nezdařilo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Rozbalování se nezdařilo: název souboru je příliš dlouhý</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Nepodařilo se vytvořit „%1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Otevření se nezdařilo: název souboru je příliš dlouhý</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Úspěšně zkomprimováno</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Název souboru je příliš dlouhý, takže jako název bylo použito pouze prvních 60 znaků.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Nedostatek místa na disku</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Některé svazky chybí</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Nesprávné heslo, zkuste ho zadat znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Název souboru je příliš dlouhý. Zkraťte název na nejvýše 60 znaků prosím.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Konverze se nezdařila</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Vybrat soubor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Zadejte až %1 znaků</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Informace o souboru</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Opravdu chcete archiv smazat?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 byl mezitím změněn na disku. Otevřete ho znovu.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Správce archivů</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nemáte oprávnění ukládat sem soubory. Změňte umístění a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Přidávají se soubory do %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Komprimuje se</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Rozbaluje se</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Maže se</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Načítání – čekejte prosím…</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Opravdu chcete probíhající úlohu zastavit?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Aktualizuje se, čekejte prosím</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Název souboru je příliš dlouhý</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Nepodařilo se vytvořit soubor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Komprimace se nezdařila</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Najít složku</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Otevření se nezdařilo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Chybné heslo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Formát souboru není podporován Správcem archivů</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Nemáte oprávnění pro načtení %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdit</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Žádný takový soubor či složka</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Rozbalení úspěšné</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Rozbalení zrušeno</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Archiv je poškozený</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Rozbalení úspěšné</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Převedení úspěšné</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Rozbalení se nezdařilo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Zobrazit klávesové zkratky</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Klávesové zkratky</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Název je stejný jako komprimovaného archivu – použijte jiný</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Už existuje jiný soubor se stejným názvem. Nahradit ho?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Není možné přidat archiv do sama sebe</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>V případě tohoto typu souboru není možné přidávat soubory do archivu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aktualizovat</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Základní informace</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Umístění</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Okamžik vytvoření</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Okamžik přístupu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Čas změny</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Komentář</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Zkontrolujte přiřazení typu souborů v nastavení Správce archivů</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Archiv byl mezitím změněn na disku. Otevřete ho znovu.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Složka</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Aplikace</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Zvuk</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Obrázek</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archiv</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Spustitelný</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Dokument</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Záložní soubor</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Neznámý</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Otevřít s</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Přidat ostatní programy</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Nastavit jako výchozí</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdit</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Doporučené aplikace</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Ostatní aplikace</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Zašifrovaný soubor – zadejte heslo</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Stávající popis umístění:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Zpět na: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 úkol(y) probíhá</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Úloha</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Rozbaluje se</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Opravdu chcete rozbalování zastavit?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdit</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Počítá se…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Zbývající čas</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Komprimuje se</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Maže se</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Převádí se</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Aktualizace komentáře…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Rozbaluje se</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pozastavit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Pokračovat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Opravdu chcete rozbalování rozbalit?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Opravdu chcete mazání zastavit?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Opravdu chcete komprimaci zastavit?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Opravdu chcete převádění zastavit?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Čas změny</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 se změnilo. Chcete uložit změny do archivu?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Obecné</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Rozbalení</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Pro vícero rozbalených souborů automaticky vytvořit složku</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Po dokončení ukázat rozbalené soubory</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Správa souboru</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Po zkomprimování smazat zdrojové soubory</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Přiřazené soubory</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Typ souboru</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Přeskočit</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Sloučit</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Už existuje jiný soubor se stejným názvem. Nahradit ho?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Už existuje jiná složka se stejným názvem – přejete si ho nahradit?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Použít na vše</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Stávající složka</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Vyprázdnit vše</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Doporučeno</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Rozbalit archivy do</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Jiná složka</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Plocha</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Po rozbalení smazat archivy</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Nikdy</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Ptát se na potvrzení</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Vždy</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Úspěšně zkomprimováno</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Pohled</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Zpět</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Otevřít soubor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Zpět</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Informace o souboru</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Rozbalit do:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Rozbalit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Výchozí popis umístění pro rozbalení neexistuje – zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nemáte oprávnění ukládat sem soubory. Změňte umístění a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Najít složku</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Není možné přidat archiv do sama sebe</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Rozbalit</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Rozbalit do stávající složky</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Otevřít</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Otevřít s</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Vyberte výchozí program</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potvrdit</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Opravdu chcete označené soubory smazat?</translation>
     </message>

--- a/translations/deepin-compressor_da.ts
+++ b/translations/deepin-compressor_da.ts
@@ -4,12 +4,12 @@
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Forkert adgangskode</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -46,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Næste</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Tilføj venligst filer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -65,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation type="unfinished">Avancerede valgmuligheder</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation type="unfinished">Kryptér arkivet</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation type="unfinished">Kryptér også fillisten</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation type="unfinished">Opdel i bind</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation type="unfinished">Komprimer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation type="unfinished">Understøt kun type zip, 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation type="unfinished">Understøt kun type 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation type="unfinished">Navn</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation type="unfinished">Gem til</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation type="unfinished">Ugyldigt filnavn</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation type="unfinished">Indtast venligst stien</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation type="unfinished">Stien findes ikke — prøv venligst igen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">Erstat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">Der findes allerede en anden fil med det samme navn — erstat den?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation type="unfinished"></translation>
     </message>
@@ -275,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation type="unfinished">Slet</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Bekræft</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -338,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -363,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation type="unfinished">element(er)</translation>
     </message>
@@ -371,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation type="unfinished">Udpakning mislykkedes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation type="unfinished">Beskadiget fil — kan ikke udpakke</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation type="unfinished">Prøv igen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation type="unfinished">Tilbage</translation>
     </message>
@@ -396,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Træk fil eller mappe hertil</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Vælg fil</translation>
     </message>
@@ -409,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
@@ -428,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -436,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Arkivhåndtering</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Arkivhåndtering er et hurtigt og letvægts program til oprettelse og udpakning af arkiver.</translation>
     </message>
@@ -450,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Åbn fil</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Indstillinger</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Opret nyt arkiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Komprimering lykkedes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 blev ændret på disken — importér den venligst igen.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Arkivhåndtering</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Komprimerer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Udpakker</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Bekræft</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation type="unfinished">Udpakning lykkedes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation type="unfinished">Udpakning lykkedes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Komprimering mislykkedes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">Erstat</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Find mappe</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Forkert adgangskode</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation type="unfinished">Slet</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation type="unfinished">Udpakning mislykkedes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">Der findes allerede en anden fil med det samme navn — erstat den?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation type="unfinished">Størrelse</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation type="unfinished">Ændringstidspunkt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation type="unfinished">Arkiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Arkivet blev ændret på disken — importér det venligst igen.</translation>
     </message>
@@ -878,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Mappe</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Program</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Lyd</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Billede</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arkiv</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Eksekverbar</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Dokument</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Sikkerhedskopieringsfil</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Ukendt</translation>
     </message>
@@ -931,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Bekræft</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation type="unfinished"></translation>
     </message>
@@ -971,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation type="unfinished">Krypteret fil — indtast venligst adgangskoden</translation>
     </message>
@@ -979,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -992,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 opgave(r) i gang</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Opgave</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Udpakker</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation type="unfinished">Er du sikker på, at du vil stoppe udpakningen?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Bekræft</translation>
@@ -1029,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation type="unfinished">Udregner ...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation type="unfinished">Komprimerer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation type="unfinished">Udpakker</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Bekræft</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation type="unfinished">Er du sikker på, at du vil stoppe komprimeringen?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1171,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Ændringstidspunkt</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Størrelse</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Generelt</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Udpakning</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Opret automatisk en mappe til flere udpakkede filer</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Filer tilknyttede</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Filtype</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">Der findes allerede en anden fil med det samme navn — erstat den?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">Erstat</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1316,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Nuværende mappe</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Ryd alle</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation type="unfinished">Vælg alle</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Udpak arkiver til</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Anden mappe</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Skrivebord</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1381,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation type="unfinished">Komprimering lykkedes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation type="unfinished">Vis</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation type="unfinished">Tilbage</translation>
     </message>
@@ -1399,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation type="unfinished">Åbn fil</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation type="unfinished">Tilbage</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1418,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Udpak til:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation type="unfinished">Udpak</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation type="unfinished">Standardudpakningsstien findes ikke — prøv venligst igen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Find mappe</translation>
     </message>
@@ -1455,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation type="unfinished">Udpak</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation type="unfinished">Udpak til nuværende mappe</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation type="unfinished">Slet</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Bekræft</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-compressor_de.ts
+++ b/translations/deepin-compressor_de.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Dateien zum aktuellen Archiv hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Passwort verwenden</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Die Originaldatei von %1 existiert nicht, bitte überprüfen und erneut versuchen</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Sie haben keine Berechtigung zum Komprimieren von %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Falsches Passwort</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Kommentar wird aktualisiert ...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Weiter</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Bitte fügen Sie Dateien hinzu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Neues Archiv</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Erweiterte Optionen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Komprimierungsverfahren</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Archiv verschlüsseln</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>CPU-Threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Dateiliste ebenfalls verschlüsseln</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>In Volumes aufteilen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Komprimieren</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Schnellste</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Schnell</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Gut</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Beste</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Einzelner Thread</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 Threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 Threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 Threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Unterstützt zip, nur Typ 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Unterstützt nur Typ 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Bis zu %1 Zeichen eingeben</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Speichern unter</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Ungültiger Dateiname</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Bitte den Pfad eingeben</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Der Pfad existiert nicht, bitte versuchen Sie es erneut</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Sie haben keine Berechtigung, hier Dateien zu speichern, bitte ändern und erneut versuchen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Zu viele Volumen, bitte ändern und erneut versuchen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Sie haben keine Berechtigung zum Komprimieren von %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Die Originaldatei von %1 existiert nicht, bitte überprüfen und erneut versuchen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Gesamtgröße: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Der Name ist der gleiche wie der des komprimierten Archivs, bitte verwenden Sie einen anderen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Das Passwort für ZIP-Volumen darf nicht auf Chinesisch sein</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Eine andere Datei mit dem gleichen Namen existiert bereits, möchten Sie sie ersetzen?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Es werden nur chinesische und englische Zeichen und einige Symbole unterstützt</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Öffnen mit</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Standardprogramm auswählen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Dadurch werden die Datei(en) endgültig gelöscht. Sind Sie sicher, dass Sie fortfahren möchten?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Bestätigen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Möchten Sie das Archiv zur Liste hinzufügen oder in einem neuen Fenster öffnen?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>In neuem Fenster öffnen</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Änderungen an Archiven dieses Dateityps werden nicht unterstützt. Bitte konvertieren Sie das Archivformat, um die Änderungen zu speichern.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Format konvertieren nach:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Konvertieren</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>Element(e)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Entpacken fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Beschädigte Datei, kann nicht entpackt werden</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Datei oder Ordner hierher ziehen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Datei auswählen</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Das Archiv ist beschädigt</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Schreibgeschützt öffnen</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Wird geladen, bitte warten ...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Archivverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Archive Manager ist eine schnelle und einfache Anwendung zum erstellen und entpacken von Archiven.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Neues Archiv erstellen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Wird konvertiert</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Kommentare werden aktualisiert</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Hinzufügen erfolgreich</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Keine Daten enthalten</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Hinzufügen abgebrochen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Hinzufügen fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Entpacken fehlgeschlagen: Der Dateiname ist zu lang</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Öffnen fehlgeschlagen: Der Dateiname ist zu lang</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Komprimierung erfolgreich</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Der Dateiname ist zu lang, daher wurden die ersten 60 Zeichen als Dateiname abgefangen.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Unzureichender Festplattenplatz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Falsches Passwort, bitte erneut versuchen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Der Dateiname ist zu lang. Bitte halten Sie den Namen auf 60 Zeichen begrenzt.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Konvertierung fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Datei auswählen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Bis zu %1 Zeichen eingeben</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Dateiinformation</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Möchten Sie das Archiv löschen?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 wurde auf dem Laufwerk geändert, bitte importieren Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Archivverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Sie haben keine Berechtigung, hier Dateien zu speichern, bitte ändern und erneut versuchen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Dateien werden zu %1 hinzugefügt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Wird komprimiert</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Wird entpackt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Wird gelöscht</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Wird geladen, bitte warten ...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Sind Sie sicher, dass Sie die laufende Aufgabe stoppen möchten?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Wird aktualisiert, bitte warten ...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Dateiname zu lang</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Komprimierung fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Verzeichnis suchen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Öffnen fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Falsches Passwort</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Das Dateiformat wird von der Archivverwaltung nicht unterstützt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Wird umbenannt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Sie haben keine Berechtigung zum Laden von %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Bestätigen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Keine solche Datei oder Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Entpacken erfolgreich</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Entpacken abgebrochen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Das Archiv ist beschädigt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Entpacken erfolgreich</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Konvertierung erfolgreich</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Das komprimierte Volumen existiert bereits</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Entpacken fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Tastenkombinationen anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Tastenkombinationen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Der Name ist der gleiche wie der des komprimierten Archivs, bitte verwenden Sie einen anderen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Eine andere Datei mit dem gleichen Namen existiert bereits, möchten Sie sie ersetzen?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Sie können das Archiv nicht zu sich selbst hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>In diesem Dateityp können Sie keine Dateien zu Archiven hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aktualisierung</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Grundlegende Informationen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Ort</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Erstellungszeit</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Zugriffszeit</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Änderungszeit</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Bitte überprüfen Sie den Dateizuordnungstyp in den Einstellungen der Archivverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Das Archiv wurde auf dem Laufwerk geändert, bitte importieren Sie es erneut.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Anwendung</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Abbild</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archiv</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Ausführbar</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Dokument</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Sicherungsdatei</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Unbekannt</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Öffnen mit</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Andere Programme hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Als Standard festlegen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Bestätigen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Empfohlene Anwendungen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Andere Anwendungen</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Verschlüsselte Datei, bitte geben Sie das Passwort ein</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Aktueller Pfad:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Zurück zu: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 Aufgabe(n) in Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Aufgabe</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Wird entpackt</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Möchten Sie das Entpacken wirklich stoppen?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Bestätigen</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Wird berechnet ...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Verbleibende Zeit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Wird komprimiert</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Wird gelöscht</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Wird umbenannt</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Wird konvertiert</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Kommentar wird aktualisiert ...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Wird entpackt</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Fortsetzen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Bestätigen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Sind Sie sicher, dass Sie die Dekomprimierung stoppen möchten?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Sind Sie sicher, dass Sie die Löschung stoppen möchten?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Sind Sie sicher, dass Sie die Komprimierung stoppen möchten?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Sind Sie sicher, dass Sie die Konvertierung stoppen möchten?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Änderungszeit</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 geändert. Möchten Sie die Änderungen im Archiv speichern?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Entpacken</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Erstellen Sie automatisch einen Ordner für mehrere extrahierte Dateien</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Extrahierte Dateien nach Fertigstellung anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Dateiverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Dateien nach der Komprimierung löschen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Zugeordnete Dateien</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Dateityp</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Überspringen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Zusammenführen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Eine andere Datei mit dem gleichen Namen existiert bereits, möchten Sie sie ersetzen?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Ein anderer Ordner mit demselben Namen ist bereits vorhanden, soll er ersetzt werden?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Auf alle anwenden</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>Der Name existiert bereits</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Aktuelles Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Alles löschen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Alles auswählen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Empfohlen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Archive entpacken nach</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Anderes Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Dateien nach dem Entpacken löschen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Nach Bestätigung fragen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Immer</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Komprimierung erfolgreich</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Dateiinformation</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Entpacken nach:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Entpacken</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Der Standard-Entpackungspfad existiert nicht, bitte versuchen Sie es erneut</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Sie haben keine Berechtigung, hier Dateien zu speichern, bitte ändern und erneut versuchen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Verzeichnis suchen</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Sie können das Archiv nicht zu sich selbst hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Entpacken</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>In aktuelles Verzeichnis entpacken</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Öffnen mit</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Standardprogramm auswählen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Bestätigen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Möchten Sie die ausgewählte(n) Datei(en) löschen?</translation>
     </message>

--- a/translations/deepin-compressor_en.ts
+++ b/translations/deepin-compressor_en.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="en">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Add files to the current archive</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Use password</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>The original file of %1 does not exist, please check and try again</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 does not exist on the disk, please check and try again</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>You do not have permission to compress %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Wrong password</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Updating the comment...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Please add files</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>New Archive</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Advanced Options</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Compression method</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Encrypt the archive</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>CPU threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Encrypt the file list too</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Split to volumes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Comment</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Compress</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Store</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Fastest</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Fast</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Good</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Best</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Single thread</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Support zip, 7z type only</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Support 7z type only</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Enter up to %1 characters</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Save to</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Invalid file name</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Please enter the path</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>The path does not exist, please retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>You do not have permission to save files here, please change and retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Too many volumes, please change and retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 does not exist on the disk, please check and try again</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>You do not have permission to compress %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>The original file of %1 does not exist, please check and try again</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Total size: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>The name is the same as that of the compressed archive, please use another one</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>The password for ZIP volumes cannot be in Chinese</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Another file with the same name already exists, replace it?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Only Chinese and English characters and some symbols are supported</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Open with</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Select default program</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>It will permanently delete the file(s). Are you sure you want to continue?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Add</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Do you want to add the archive to the list or open it in new window?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Open in new window</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Convert the format to:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Convert</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>item(s)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Extraction failed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Damaged file, unable to extract</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Drag file or folder here</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Select File</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>The archive is damaged</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Open as read-only</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Loading, please wait...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Archive Manager</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Archive Manager is a fast and lightweight application for creating and extracting archives.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Create New Archive</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Converting</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Updating comments</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Plugin error</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Adding successful</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>No data in it</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Adding canceled</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Adding failed</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Extraction failed: the file name is too long</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Failed to create &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Open failed: the file name is too long</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Compression successful</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>The file name is too long, so the first 60 characters have been intercepted as the file name.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Insufficient disk space</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Some volumes are missing</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Wrong password, please retry</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>The file name is too long. Keep the name within 60 characters please.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Conversion failed</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Select file</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Enter up to %1 characters</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>File info</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Do you want to delete the archive?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 was changed on the disk, please import it again.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Archive Manager</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>You do not have permission to save files here, please change and retry</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Adding files to %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Compressing</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Extracting</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Deleting</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Loading, please wait...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Are you sure you want to stop the ongoing task?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Updating, please wait...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>File name too long</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Failed to create file</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Compression failed</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Find directory</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Open failed</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Wrong password</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>The file format is not supported by Archive Manager</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Renaming</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>You do not have permission to load %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>No such file or directory</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Extraction successful</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Extraction canceled</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>The archive is damaged</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Extraction successful</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Conversion successful</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>The compressed volumes already exist</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Extraction failed</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>The name is the same as that of the compressed archive, please use another one</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Another file with the same name already exists, replace it?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>You cannot add the archive to itself</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>You cannot add files to archives in this file type</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Basic info</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Location</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Time created</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Time accessed</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Time modified</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archive</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Comment</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Please check the file association type in the settings of Archive Manager</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>The archive was changed on the disk, please import it again.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Directory</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Application</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Image</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archive</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Executable</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Document</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Backup file</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Unknown</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Open with</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Add other programs</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Set as default</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Recommended Applications</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Other Applications</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Encrypted file, please enter the password</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Current path:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Back to: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 task(s) in progress</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Task</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Extracting</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Are you sure you want to stop the extraction?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirm</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Calculating...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Time left</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Compressing</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Deleting</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Renaming</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Converting</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Updating the comment...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Extracting</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Are you sure you want to stop the decompression?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Are you sure you want to stop the deletion?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Are you sure you want to stop the compression?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Are you sure you want to stop the conversion?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Time modified</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 changed. Do you want to save changes to the archive?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Extraction</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Auto create a folder for multiple extracted files</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Show extracted files when completed</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>File Management</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Delete files after compression</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Files Associated</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>File Type</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Skip</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Merge</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Another file with the same name already exists, replace it?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Another folder with the same name already exists, replace it?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Apply to all</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>The name already exists</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Current directory</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Clear All</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Select All</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Recommended</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Extract archives to</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Other directory</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Delete archives after extraction</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Never</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Ask for confirmation</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Always</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Compression successful</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>View</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>File info</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Extract to:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Extract</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>The default extraction path does not exist, please retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>You do not have permission to save files here, please change and retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Find directory</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>You cannot add the archive to itself</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Extract</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Extract to current directory</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Open with</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Select default program</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Do you want to delete the selected file(s)?</translation>
     </message>

--- a/translations/deepin-compressor_en_GB.ts
+++ b/translations/deepin-compressor_en_GB.ts
@@ -4,12 +4,12 @@
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation type="unfinished">You do not have permission to compress %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Wrong password</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -46,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Please add files</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -65,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation type="unfinished">Advanced Options</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation type="unfinished">Encrypt the archive</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation type="unfinished">Encrypt the file list too</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation type="unfinished">Split to volumes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation type="unfinished">Compress</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation type="unfinished">Supports .zip and .7z file types only</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation type="unfinished">Supports .7z file type only</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation type="unfinished">Save to</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation type="unfinished">Invalid file name</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation type="unfinished">Please enter the path</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation type="unfinished">The path does not exist, please try again</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished">You do not have permission to save files here, please change and retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation type="unfinished">Too many volumes, please change and retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation type="unfinished">You do not have permission to compress %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">Replace</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">Another file with the same name already exists, do you want to replace it?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation type="unfinished"></translation>
     </message>
@@ -275,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation type="unfinished">Open with</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -338,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation type="unfinished">Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation type="unfinished">Convert the format to:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation type="unfinished">Convert</translation>
@@ -363,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation type="unfinished">item(s)</translation>
     </message>
@@ -371,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation type="unfinished">Extraction failed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation type="unfinished">Damaged file, unable to extract</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation type="unfinished">Back</translation>
     </message>
@@ -396,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Drag file or folder here</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Select File</translation>
     </message>
@@ -409,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
@@ -428,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -436,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Archive Manager</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Archive Manager is a fast and lightweight application for creating and extracting archives.</translation>
     </message>
@@ -450,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Create New Archive</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Converting</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Compression successful</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Do you want to delete the archive?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 was changed on the disk, please import it again.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Archive Manager</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished">You do not have permission to save files here, please change and retry</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Compressing</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Extracting</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation type="unfinished">Extraction successful</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation type="unfinished">Extraction successful</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Compression failed</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">Replace</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Find directory</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Wrong password</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation type="unfinished">Extraction failed</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">Another file with the same name already exists, do you want to replace it?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation type="unfinished">Update</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation type="unfinished">Time modified</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation type="unfinished">Archive</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>The archive was changed on the disk, please import it again.</translation>
     </message>
@@ -878,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Directory</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Application</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Image</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archive</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Executable</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Document</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Backup file</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Unknown</translation>
     </message>
@@ -931,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Open with</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Add other programs</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Set as default</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Recommended Applications</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Other Applications</translation>
     </message>
@@ -971,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation type="unfinished">File is Encrypted, please enter the password</translation>
     </message>
@@ -979,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -992,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 task(s) in progress</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Task</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Extracting</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Confirm</translation>
@@ -1029,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation type="unfinished">Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation type="unfinished">Calculating...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation type="unfinished">Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation type="unfinished">Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation type="unfinished">Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation type="unfinished">Speed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation type="unfinished">Time left</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation type="unfinished">Compressing</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation type="unfinished">Converting</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation type="unfinished">Extracting</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation type="unfinished">Pause</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation type="unfinished">Continue</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation type="unfinished">Are you sure you want to stop the compression?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1171,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Time modified</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Extraction</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Auto create a folder for multiple extracted files</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>File Management</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Delete files after compression</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Associated Files</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>File Type</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">Another file with the same name already exists, do you want to replace it?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">Replace</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1316,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Recommended</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Current directory</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Clear All</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation type="unfinished">Select All</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Extract archives to</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Other directory</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Delete archives after extraction</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Never</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Ask for confirmation</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Always</translation>
     </message>
@@ -1381,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation type="unfinished">Compression successful</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation type="unfinished">View</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation type="unfinished">Back</translation>
     </message>
@@ -1399,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation type="unfinished">Open file</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation type="unfinished">Back</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1418,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Extract to:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation type="unfinished">Extract</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>The default extraction path does not exist, please try again</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>You do not have permission to save files here, please change and retry</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Find directory</translation>
     </message>
@@ -1455,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation type="unfinished">Extract</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation type="unfinished">Extract to current directory</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation type="unfinished">Open with</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">Confirm</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-compressor_es.ts
+++ b/translations/deepin-compressor_es.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Añadir archivos al archivo actual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Usar contraseña</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>El archivo original de %1 no existe, por favor verifique y vuelve a intentarlo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 no existe en el disco, por favor verifique y vuelve a intentarlo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>No tiene permiso para comprimir %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Contraseña incorrecta</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Actualizando comentario...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Por favor añada archivos</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Nuevo archivo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Opciones avanzadas</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Método de compresión</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Cifrar el archivo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Hilos de CPU</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Cifrar la lista de archivo también</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Dividir en volúmenes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Comprimir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Sin compresión</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Muy rápida</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Rápida</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Buena</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Superior</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Un hilo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 hilos</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 hilos</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 hilos</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Soporte zip, solo tipo 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Soporte solo de tipo 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Introduzca hasta %1 caracteres</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Guardar en</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Nombre de archivo inválido</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Por favor ingrese la ruta</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>La ruta no existe, por favor vuelva a intentarlo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>No tiene permisos para guardar archivos aquí, por favor cámbielos e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Demasiados volúmenes, por favor cámbielos e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 no existe en el disco, por favor verifique y vuelve a intentarlo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>No tiene permisos para comprimir %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>El archivo original de %1 no existe, por favor verifique y vuelve a intentarlo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Tamaño total: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>El nombre es el mismo que el del archivo comprimido, por favor utilice otro</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>La contraseña de los volúmenes ZIP no puede estar en chino</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ya existe otro archivo con el mismo nombre, ¿desea remplazarlo?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Solo símbolos y caracteres en inglés y chino están admitidos</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Abrir con</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Seleccionar programa predeterminado</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Eliminará permanentemente los archivos. ¿Está seguro que quiere continuar?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Añadir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>¿Desea añadir el archivo a la lista o abrirlo en una nueva ventana?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Abrir en una nueva ventana</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>No se admiten cambios en este tipo de archivos. Por favor convierta el archivo a otro formato para guardar los cambios.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Convertir el formato a:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Convertir</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>elemento(s)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>La extracción falló</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Archivo dañado, no se puede extraer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Arrastre archivo o carpeta aquí</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Seleccionar archivo</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>El archivo está dañado</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Abierto solo para lectura</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Cargando, por favor espere...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Compresor de archivos</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Compresor de archivos de Deepin es una ligera y rápida aplicación para comprimir y extraer archivos.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Crear nuevo fichero</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Convirtiendo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Actualizando comentarios</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Error de plugin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Agregado exitosamente</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>No hay datos en él</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Agregado abortado</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Error al añadir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>La extracción falló: el nombre del archivo es demasiado largo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Error al crear &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Error al abrir: el nombre del archivo es demasiado largo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Compresión exitosa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>El nombre del archivo es demasiado largo, por lo que los primeros 60 caracteres se utilizaron como nombre del archivo.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Espacio de disco insuficiente</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Algunos volúmenes están desaperecidos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Contraseña incorrecta, por favor reintente</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>El nombre del archivo es demasiado largo. Mantenga el nombre dentro de los 60 caracteres, por favor.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>La conversión falló</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Seleccionar archivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Introduzca hasta %1 caracteres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>¿Desea borrar el archivo?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 fué cambiado en el disco, por favor vuelva a importarlo.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Compresor de archivos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>No tiene permisos para guardar archivos aquí, por favor cámbielos e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Añadiendo archivos a %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Comprimiendo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Extrayendo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Borrando</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Cargando, por favor espere...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>¿Está seguro que quiere detener la tarea en curso?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Actualizando, por favor espere...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>El nombre del archivo es muy largo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Error al crear archivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>La compresión falló</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Buscar carpeta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Error al abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Contraseña incorrecta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>El formato de archivo no es compatible con el compresor de archivos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Renombrando</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>No tiene permiso para cargar %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>No hay tal archivo o directorio</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Extracción exitosa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Extracción cancelada</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>El archivo está dañado</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Extracción exitosa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Conversión exitosa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Los volúmenes comprimidos ya existen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>La extracción falló</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atajos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Atajos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>El nombre es el mismo que el del archivo comprimido, por favor utilice otro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ya existe otro archivo con el mismo nombre, ¿desea remplazarlo?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>No se puede añadir el archivo a sí mismo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>No se pueden añadir archivos para este tipo de compresión</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Información básica</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Ubicación</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Fecha de creación</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Fecha de acceso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Fecha de modificación</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Verifique la asociación del tipo de archivo en la configuración del Administrador de archivos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>El fichero fué cambiado en el disco, por favor vuelva a intentarlo.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Carpeta</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Aplicación</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Imagen</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archivo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Ejecutable</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Documento</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Archivo de respaldo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Abrir con</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Añadir otros programas</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Establecer como predeterminado</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Aplicaciones recomendadas</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Otras aplicaciones</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Archivo cifrado, por favor ingrese la contraseña</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Ruta actual:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Volver a: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 tarea(s) en progreso</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Tarea</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Extrayendo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>¿Está seguro que desea detener la extracción?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Calculando…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Tiempo restante</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Comprimiendo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Borrando</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Renombrando</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Convirtiendo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Actualizando comentario...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Extrayendo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pausar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>¿Está seguro que desea detener la descompresión?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>¿Está seguro de que desea detener el borrado eliminación?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>¿Está seguro que desea detener la compresión?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>¿Está seguro que quiere detener la conversión?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Fecha de modificación</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 cambió. ¿Desea guardar los cambios en el archivo?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Extracción</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Crear automáticamente una carpeta para múltiples archivos extraidos</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Mostrar archivos extraídos al terminar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Administración de archivos</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Borrar archivos después de comprimir</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Archivos asociados</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Tipo de archivo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Omitir</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Fusionar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ya existe otro archivo con el mismo nombre, ¿desea remplazarlo?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Ya existe otra carpeta con el mismo nombre, ¿desea reemplazarla?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Aplicar a todos</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>El nombre ya existe</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Carpeta actual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Limpiar todos</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Recomendado</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Extraer ficheros en</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Otra carpeta</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Escritorio</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Borrar archivos después de extraer</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Nunca</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Pedir confirmación</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Siempre</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Compresión exitosa</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Información</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Extraer en:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Extraer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>La ruta de extracción por defecto no existe, por favor vuelva a intentarlo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>No tiene permisos para guardar archivos aquí, por favor cámbielos e inténtelo de nuevo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Buscar carpeta</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>No se puede añadir un archivo a sí mismo</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Extraer</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Extraer en la carpeta actual</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Abrir con</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Seleccionar programa predeterminado</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>¿Desea borrar los archivos seleccionados?</translation>
     </message>

--- a/translations/deepin-compressor_fi.ts
+++ b/translations/deepin-compressor_fi.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Lisää tietostoja nykyiseen pakettiin</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Käytä salasanaa</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Alkuperäistä tiedostoa %1 ei ole, tarkista ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 ei ole levyllä, tarkista ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Sinulla ei ole oikeuksia pakata kohdetta %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Väärä salasana</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Päivitetään kommenttia...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Seuraava</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Lisää tiedostoja</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Uusi arkisto</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Lisäasetukset</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Pakkausmenetelmä</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Salaa arkisto</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Prosessorin säikeet</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Salaa myös tiedostoluettelo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Jaa osiin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Kommentti</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Pakkaa</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Varasto</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Nopein</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Nopea</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normaali</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Hyvä</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Paras</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Yksi säie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>Säikeitä 2</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>Säikeitä 4</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>Säikeitä 8</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Zip tuki, vain 7z-tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Tuki vain 7z-tyypille</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Kirjoita enintään %1 merkkiä</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Tallenna kohteeseen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Virheellinen tiedostonimi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Anna kohteen polku</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Polkua ei ole, yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Sinulla ei ole oikeuksia tallentaa tiedostoja täällä, vaihda ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Liian monta asemaa, vaihda ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 ei ole levyllä, tarkista ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Sinulla ei ole oikeuksia pakata kohdetta %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Alkuperäistä tiedostoa %1 ei ole, tarkista ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Koko yhteensä: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Nimi on sama kuin valmiiksi pakatun nimi, käytä toista</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Salasana ei voi olla kiinaksi ZIP-asemissa</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Toinen samanniminen tiedosto on jo olemassa, korvataanko se?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Vain kiinalaisia ja englanninkielisiä merkkejä ja joitakin symboleja tuetaan</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Avaa</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Nimeä</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Avaa ohjelmalla</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Valitse oletusohjelma</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Se poistaa tiedostot pysyvästi. Haluatko varmasti jatkaa?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Vahvista</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Haluatko lisätä arkiston luetteloon vai avata se uudessa ikkunassa?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Avaa uudessa ikkunassa</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Tämän tiedostotyypin muutoksia ei tueta. Muunna paketti oikeaan muotoon ja tallenna muutokset.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Muunna muotoon:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Muunna</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>kohdetta</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Purku epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Vaurioitunut tiedosto, ei voi purkaa</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Uudestaan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Takaisin</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Vedä tiedosto tai kansio tähän</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Valitse tiedosto</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Paketti on vahingoittunut</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Avaa &quot;vain luku&quot; -tilaan</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Ladataan. odota...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Pakkaaja</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Pakkaaja on nopea ja kevyt sovellus arkistojen luomiseen ja purkamiseen.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Avaa tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Luo uusi arkisto</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Muuntaminen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Päivitetään kommentteja</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Lisäosan virhe</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Lisääminen onnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Sisältö on tyhjä</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Lisääminen peruutettu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Lisääminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Purkaminen epäonnistui: tiedostonimi on liian pitkä</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Virhe luodessa &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Avaaminen epäonnistui: tiedostonimi on liian pitkä</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Pakkaus onnistunut</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Tiedostonimi on liian pitkä, joten ensimmäiset 60 merkkiä on käytetty tiedostonimeksi.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Liian vähän levytilaa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Jotkut asemat puuttuvat</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Väärä salasana, yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Tiedostonimi on liian pitkä. Pidä nimi 60 merkin sisällä.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Muuntaminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Valitse tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Kirjoita enintään %1 merkkiä</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Tiedoston tiedot</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Haluatko poistaa paketin?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 on muuttunut levyllä, tuo se uudelleen.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Arkiston hallinta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Sinulla ei ole oikeuksia tallentaa tiedostoja täällä, vaihda ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Tiedostojen lisääminen %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Pakataan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Purkaminen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Poistaminen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Ladataan. odota...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Haluatko varmasti lopettaa meneillään olevan tehtävän?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Päivitetään, odota...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Tiedoston nimi on liian pitkä</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Tiedoston luominen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Pakkaus epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Etsi hakemisto</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Avaaminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Väärä salasana</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Pakkaaja ei tue tiedostomuotoa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Nimeä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Sinulla ei ole oikeuksia ladata kohdetta %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Vahvista</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Ei tällaista tiedostoa tai hakemistoa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Purkaminen onnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Purku peruutettu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Paketti on vahingoittunut</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Purkaminen onnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Muuntaminen onnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Pakatut asemat ovat jo olemassa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Purku epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Sulje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Apua</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Näytä kuvakkeet</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Pikakuvakkeet</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Nimi on sama kuin valmiiksi pakatun nimi, käytä toista</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Toinen samanniminen tiedosto on jo olemassa, korvataanko se?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Et voi lisätä pakettia itseensä</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Et voi lisätä tiedostoja tämän pakkaustyypin paketteihin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Päivitä</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Perustiedot</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Sijainti</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Valmistunut</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Käytetty aika</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Muokkauspäivä</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arkisto</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Kommentti</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Tarkista tiedoston kytkemisen tyyppi asetuksista</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Paketti on muuttunut levyllä, tuo se uudelleen.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Hakemisto</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Sovellus</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Ääni</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Kuva</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arkisto</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Suoritettava</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Asiakirja</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Varmuuskopio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Tuntematon</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Avaa ohjelmalla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Lisää muita ohjelmia</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Aseta oletukseksi</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Vahvista</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Suositellut sovellukset</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Muut sovellukset</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Salattu tiedosto, kirjoita salasana</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Nykyinen polku:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Paluu: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 tehtävää meneillään</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Tehtävä</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Purkaminen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Haluatko varmasti lopettaa purkamisen?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Vahvista</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Lasketaan...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Aikaa jäljellä</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Pakataan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Poistaminen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Nimeä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Muuntaminen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Päivitetään kommenttia...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Purkaminen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Tauko</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Jatka</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Vahvista</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Haluatko varmasti lopettaa pakkaamisen?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Haluatko varmasti lopettaa poiston?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Haluatko varmasti lopettaa pakkaamisen?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Haluatko varmasti lopettaa muuntamisen?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Muokkauspäivä</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 muuttui. Haluatko tallentaa muutokset pakettiin?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Yleinen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Purku</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Luo kansio automaattisesti purettuja tiedostoja varten</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Näytä puretut tiedostot, kun valmis</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Tiedostonhallinta</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Poista tiedostot pakkaamisen jälkeen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Tiedostot liitetty</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Tiedosto tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Ohita</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Yhdistä</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Toinen samanniminen tiedosto on jo olemassa, korvataanko se?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Toinen samanniminen kansio on jo olemassa, korvataanko se?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Koskee kaikkia</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Nimeä</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>Nimi on jo olemassa</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Nykyinen hakemisto</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Pyyhi kaikki</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Suositeltava</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Pura arkistot kohteeseen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Muu hakemisto</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Työpöytä</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Poista paketit pakkaamisen jälkeen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Ei koskaan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Pyydä vahvistus</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Aina</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Pakkaus onnistunut</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Katso</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Takaisin</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Avaa tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Takaisin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Tiedoston tiedot</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Pura kohteeseen:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Pura</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Oletuksena olevaa purkukohdetta ei ole, yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Sinulla ei ole oikeuksia tallentaa tiedostoja täällä, vaihda ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Etsi hakemisto</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Et voi lisätä pakettia itseensä</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Pura</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Pura nykyiseen kansioon</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Avaa</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Nimeä</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Avaa ohjelmalla</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Valitse oletusohjelma</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Vahvista</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Haluatko poistaa valitut tiedostot?</translation>
     </message>

--- a/translations/deepin-compressor_fr.ts
+++ b/translations/deepin-compressor_fr.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Ajouter des fichiers à l&apos;archive actuelle</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Utiliser un mot de passe</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Le fichier d&apos;origine de %1 n&apos;existe pas, veuillez vérifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 n&apos;existe pas sur le disque, veuillez vérifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Vous n&apos;êtes pas autorisé à compresser %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Mot de passe incorrect</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Mise à jour du commentaire...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Suivant</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Veuillez ajouter des fichiers</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Nouvelle archive</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Options avancées</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Méthode de compression</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Crypter l&apos;archive</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>CPU threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Chiffrer également la liste des fichiers</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Fractionner en volumes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Commentaire</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Compresser</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Magasin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Le plus rapide</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Rapide</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Bon</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Meilleur</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Single thread</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Prise en charge du type zip, 7z uniquement</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Prise en charge du type 7z uniquement</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Entrer jusqu&apos;à %1 caractères</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Enregistrer dans</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Nom de fichier invalide</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Veuillez entrer le chemin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Le chemin n&apos;existe pas, veuillez réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Vous n&apos;êtes pas autorisé à enregistrer des fichiers ici, veuillez modifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Trop de volumes, veuillez modifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 n&apos;existe pas sur le disque, veuillez vérifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Vous n&apos;êtes pas autorisé à compresser %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Le fichier d&apos;origine de %1 n&apos;existe pas, veuillez vérifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Taille totale: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Le nom est le même que celui de l&apos;archive compressée, veuillez en utiliser un autre</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Le mot de passe des volumes ZIP ne peut pas être en chinois</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Un autre fichier du même nom existe déjà, le remplacer ?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Seuls les caractères chinois, anglais et certains symboles sont pris en charge</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Ouvrir avec</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Sélectionner le programme par défaut</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Cela supprimera définitivement le(s) fichier(s). Êtes-vous sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmer</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Voulez-vous ajouter l&apos;archive à la liste ou l&apos;ouvrir dans une nouvelle fenêtre ?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Ouvrir dans une nouvelle fenêtre</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Les modifications apportées aux archives dans ce type de fichier ne sont pas prises en charge. Veuillez convertir le format d&apos;archive pour enregistrer les modifications.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Convertir le format en :</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Convertir</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>élément(s)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Échec de l&apos;extraction</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Fichier endommagé, impossible d&apos;extraire</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Retour</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Faites glisser le fichier ou le dossier ici</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Sélectionner un fichier</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>L&apos;archive est endommagée</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Ouvrir en lecture seule</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Chargement, veuillez patienter...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Gestionnaire d&apos;archives</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Archive Manager est une application rapide et légère pour créer et extraire des archives.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Ouvrir un fichier</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Créer une nouvelle archive</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Conversion</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Mise à jour des commentaires</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Erreur de plug-in</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Ajout réussi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Aucune donnée dedans</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Ajout annulé</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>L&apos;ajout a échoué</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
-        <translation>Échec de l&apos;extraction : le nom du fichier est trop long</translation>
+        <translation>Échec de l&apos;extraction&#xa0;: le nom du fichier est trop long</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Échec de la création de &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
-        <translation>Échec de l&apos;ouverture : le nom du fichier est trop long</translation>
+        <translation>Échec de l&apos;ouverture&#xa0;: le nom du fichier est trop long</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Compression réussie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Le nom de fichier est trop long, les 60 premiers caractères ont donc été interceptés comme nom de fichier.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Espace disque insuffisant</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Certains volumes manquent</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Mot de passe incorrect, veuillez réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Le nom du fichier est trop long. Garder le nom dans les 60 caractères, s&apos;il vous plaît.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Échec de la conversion</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Sélectionner un fichier</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Entrez jusqu&apos;à %1 caractères</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Informations sur le fichier</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Voulez-vous supprimer l&apos;archive ?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 a été modifié sur le disque, veuillez l&apos;importer à nouveau.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Gestionnaire d&apos;archives</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Vous n&apos;êtes pas autorisé à enregistrer des fichiers ici, veuillez modifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Ajout de fichiers à %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Compression</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Extraire</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Suppression</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Chargement, veuillez patienter...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Voulez-vous vraiment arrêter la tâche en cours ?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Mise à jour, veuillez patienter...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Nom de fichier trop long</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>La création du fichier a échoué</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Échec de la compression</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Rechercher un répertoire</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Échec de l&apos;ouverture</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Mot de passe incorrect</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Le format de fichier n&apos;est pas pris en charge par Archive Manager</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Vous n&apos;êtes pas autorisé à charger %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Aucun fichier ou répertoire de ce nom</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Extraction réussie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Extraction annulée</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>L&apos;archive est endommagée</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Extraction réussie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Conversion réussie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Échec de l&apos;extraction</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Afficher les raccourcis</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Raccourcis</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Le nom est le même que celui de l&apos;archive compressée, veuillez en utiliser un autre</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Un autre fichier du même nom existe déjà, le remplacer ?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Vous ne pouvez pas ajouter l&apos;archive à elle-même</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Vous ne pouvez pas ajouter de fichiers aux archives dans ce type de fichier</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Mettre à jour</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Info de base</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Emplacement</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Heure de création</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Temps d&apos;accès</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Heure de modification</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archive</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Commentaire</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Veuillez vérifier le type d&apos;association de fichiers dans les paramètres d&apos;Archive Manager</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>L&apos;archive a été modifiée sur le disque, veuillez l&apos;importer à nouveau.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Répertoire</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Application</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Vidéo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Image</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archive</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Exécutable</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Document</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Fichier de sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Ouvrir avec</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Ajouter d&apos;autres programmes</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Définir par défaut</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmer</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Applications recommandées</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Autres applications</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Fichier crypté, veuillez saisir le mot de passe</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Répertoire actuel:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Retour à : %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 tâche(s) en cours</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Tâche</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Extraire</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Voulez-vous vraiment arrêter l&apos;extraction ?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmer</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Calcul en cours...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Temps restant</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Compression</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Suppression</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Conversion</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Mise à jour du commentaire...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Extraire</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continuer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Voulez-vous vraiment arrêter la décompression ?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Voulez-vous vraiment arrêter la suppression ?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Voulez-vous vraiment arrêter la compression ?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Voulez-vous vraiment arrêter la conversion ?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Heure modifiée</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 a changé. Voulez-vous enregistrer les modifications apportées à l&apos;archive ?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Configuration</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Extraction</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Créer automatiquement un dossier pour les fichiers extraits</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Afficher les fichiers extraits une fois terminé</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Gestionnaire de fichiers</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Supprimer les fichiers après compression</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Association de fichiers</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Type de fichier</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Passer</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Fusionner</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Un autre fichier du même nom existe déjà, le remplacer ?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Un autre dossier avec le même nom existe déjà, le remplacer ?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Appliquer à tous</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Répertoire actuel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Tout effacer</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Conseillé</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Extraire les archives vers</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Autre répertoire</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Bureau</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Supprimer les archives après l&apos;extraction</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Jamais</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Demander confirmation</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Toujours</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Compression réussie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Retour</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Ouvrir un fichier</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Retour</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Informations sur le fichier</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Extraire vers :</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Extraire</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Le chemin d&apos;extraction par défaut n&apos;existe pas, veuillez réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Vous n&apos;êtes pas autorisé à enregistrer des fichiers ici, veuillez modifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Rechercher un répertoire</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Vous ne pouvez pas ajouter l&apos;archive à elle-même</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Extraire</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Extraire dans le répertoire courant</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Ouvrir avec</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Sélectionner le programme par défaut</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmer</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Voulez-vous supprimer le(s) fichier(s) sélectionné(s) ?</translation>
     </message>

--- a/translations/deepin-compressor_hu.ts
+++ b/translations/deepin-compressor_hu.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Fájlok hozzáadása az aktuális archívumhoz</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Jelszó használata</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>A %1 eredeti fájl nem létezik, kérjük ellenőrizze, és próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>A %1 nem létezik a lemezen, kérjük ellenőrizze és próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nincs engedélye a %1 tömörítésére</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Érvénytelen jelszó</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Hozzászólások frissítése...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Következő</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Kérjük adjon hozzá fájlokat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Új archívum</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Haladó beállítások</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Tömörítési módszer</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Archívum titkosítása</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Processzor szálak</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Titkosítsa a fájllistát is</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Kötetekre darabolás</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Hozzászólás</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Tömörítés</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Áruház</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Leggyorsabb</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Gyors</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normál</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Jó</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Legjobb</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Egy szál</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 szál</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 szál</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 szál</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Zip formátum támogatása ,csak a 7z típusé</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Csak 7z formátum támogatása</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Adjon meg legfeljebb %1 karaktert</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Mentés ide</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Érvénytelen fájlnév</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Kérjük adja meg az elérési útvonalat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Az elérési útvonal nem létezik, kérjük próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nincs engedélye fájlok ide mentésére, kérjük módosítsa és próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Túl sok kötet, kérjük változtasson és próbálkozzon újra</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>A %1 nem létezik a lemezen, kérjük ellenőrizze és próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nincs engedélye a %1 tömörítésére</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>A %1 eredeti fájl nem létezik, kérjük ellenőrizze, és próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Teljes méret: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>A név megegyezik a tömörített archívum nevével, kérjük használjon másikat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>A ZIP kötetek jelszava nem lehet kínai</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Már létezik egy ugyanilyen nevű fájl, lecseréli?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Csak a kínai, és az angol karakterek, valamint néhány szimbólum támogatott </translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Megnyitás</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Átnevezés</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Megnyitás ezzel</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Alapértelmezett program választása</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>A fájl(ok) véglegesen törlésre kerülnek. Biztos benne, hogy folytatni akarja?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Hozzáadás</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Hozzá szeretné adni az archívumot a listához, vagy új ablakban szeretné megnyitni?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Megnyitás új ablakban</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Az ilyen típusú archívumok módosításai nem támogatottak. A változások mentéséhez kérjük konvertálja át az archívum formátumát.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Konvertálja a formátumot a következőre:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Konvertálás</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>elem(ek)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>A kicsomagolás sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Sérült fájl, a kicsomagolás sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Újra</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Vissza</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Húzza ide a fájlokat és / vagy a mappákat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Fájl kiválasztása</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Az archívum sérült</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Megnyitás csak olvasható módban</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Betöltés, kérjük várjon...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Archívumkezelő</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Az Archívumkezelő egy gyors és kis erőforrás igényű alkalmazás, tömörített fájlok létrehozásához és kibontásához.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Fájl megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Új archívum létrehozása</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Konvertálás</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Hozzászólások frissítése</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Bővítmény hiba</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>A hozzáadás sikeres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Nem tartalmaz adatot</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>A hozzáadás megszakítva</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>A hozzáadás sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>A kicsomagolás sikertelen: a fájl neve túl hosszú</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>A &quot;%1&quot; létrehozása sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>A megnyitás sikertelen: a fájl neve túl hosszú</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>A tömörítés sikeres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>A fájlnév túl hosszú, ezért az első 60 karaktert fájlnévként használtuk.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Nincs elég lemezterület</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Néhány kötet hiányzik</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Érvénytelen jelszó, kérjük próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>A fájl neve túl hosszú. Kérjük, ne lépje túl a 60 karaktert.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>A konvertálás sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Fájl kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Adjon meg legfeljebb %1 karaktert</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Fájl információ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Biztos, hogy törli az archívumot?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>A %1 megváltozott a lemezen, kérjük importálja újra.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Archívumkezelő</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nincs engedélye fájlok ide mentésére, kérjük módosítsa és próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Fájlok hozzáadása a %1 fájlhoz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Tömörítés</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Kicsomagolás</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Betöltés, kérjük várjon...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Biztosan le akarja állítani a folyamatban lévő feladatot?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Frissítés, kérjük várjon...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>A fájlnév túl hosszú</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>A fájl létrehozása sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>A tömörítés sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Mappa keresése</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>A megnyitás sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Érvénytelen jelszó</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Ez a fájl formátum nem támogatott az Archívumkezelő által</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Átnevezés folyamatban</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Nincs engedélye a %1 betöltésére</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Nem létezik ilyen fájl, vagy könyvtár</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>A kicsomagolás sikeres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>A kicsomagolás megszakítva</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Az archívum sérült</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>A kicsomagolás sikeres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>A konvertálás sikeres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>A tömörített kötetek már léteznek</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>A kicsomagolás sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Bezárás</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Segítség</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Gyorsbillentyűk megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Gyorsbillentyűk</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>A név megegyezik a tömörített archívum nevével, kérjük használjon másikat</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Már létezik egy ugyanilyen nevű fájl, lecseréli?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Az archívum nem adható hozzá önmagához</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Nem adhat hozzá fájlokat az ilyen típusú archívumokhoz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Alapvető információ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Típus</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Hely</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Létrehozás ideje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Hozzáférés ideje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Módosítás időpontja</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archívum</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Hozzászólás</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Kérjük ellenőrizze a fájl társítási típusát az Archívumkezelő beállításaiban</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Az archívum megváltozott a lemezen, kérjük importálja újra.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Mappa</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Alkalmazás</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Videó</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audió</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Kép</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archívum</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Futtatható állomány</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Dokumentum</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Biztonsági mentés fájlja</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Ismeretlen</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Megnyitás ezzel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Más programok hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Beállítás alapértelmezettként</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Javasolt alkalmazások</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Egyéb alkalmazások</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Titkosított fájl, kérjük adja meg a jelszót</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Jelenlegi útvonal:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Vissza ide: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 feladat(ok) végrehajtása folyamatban</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Feladat</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Kicsomagolás</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Biztosan meg akarja szakítani a kicsomagolást?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Megerősítés</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Számítás...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Hátralévő idő</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Tömörítés</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Átnevezés folyamatban</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Konvertálás</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Hozzászólások frissítése...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Kicsomagolás</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Szüneteltetés</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Folytatás</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Biztosan le szeretné állítani a kicsomagolást?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Biztosan meg akarja szakítani a törlést?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Biztosan le szeretné állítani a tömörítést?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Biztosan meg akarja szakítani a konvertálást?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Módosítás időpontja</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Típus</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>A %1 megváltozott. El akarja menteni az archívum módosításait?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Általános</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Kicsomagolás</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Automatikusan hozzon létre egy mappát a többszörösen kibontott fájlok számára</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>A kibontott fájlok megjelenítése befejezés után</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Fájlkezelés</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>A fájlok törlése a tömörítés után</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Társított fájltípusok</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Fájltípus</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Kihagyás</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Összevonás</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Már létezik egy ugyanilyen nevű fájl, lecseréli?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Már létezik egy ugyanilyen nevű könyvtár, lecseréli?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Alkalmazás az összesre</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Átnevezés</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>A név már létezik</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Jelenlegi mappa</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Összes elvetése</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Összes kijelölése</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Javasolt</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Archívumok kicsomagolása ide</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Más mappa</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Asztal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Az archívumok törlése a kibontás után</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Soha</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Kérjen megerősítést</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Mindig</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>A tömörítés sikeres</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Megtekintés</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Vissza</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Fájl megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Vissza</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Fájl információ</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Kicsomagolás ide:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Kicsomagolás</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Az alapértelmezett kicsomagolási útvonal nem létezik, kérjük próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nincs engedélye fájlok ide mentésére, kérjük, módosítsa és próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Mappa keresése</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Az archívum nem adható hozzá önmagához</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Kicsomagolás</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Kicsomagolás az aktuális mappába</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Megnyitás</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Átnevezés</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Megnyitás ezzel</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Alapértelmezett program választása</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Törli a kijelölt fájl(oka)t?</translation>
     </message>

--- a/translations/deepin-compressor_it.ts
+++ b/translations/deepin-compressor_it.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="it">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Aggiungi file all&apos;archivio attuale</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Utilizza una password</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Il file originale di %1 non esiste, verifica e riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 non esiste sul disco, verifica e riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Non hai l&apos;autorizzazione per comprimere %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Password errata</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Aggiornamento commenti...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Prossimo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Aggiungi file</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Nuovo Archivio</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Opzioni avanzate</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Metodo di compressione</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Crittografa l&apos;archivio</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Thread CPU</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Crittografa anche la lista dei file</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Suddividi in volumi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Commenti</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Comprimi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Archivia</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Più veloce</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Veloce</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Buona</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Migliore</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Thread singolo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 thread</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 thread</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 thread</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Supporta zip, solo in formato 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Supporta solo il formato 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Inserisci più di %1 caratteri</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Salva in</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Nome file non valido</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Inserisci il percorso</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Il percorso non esiste, riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Non hai l&apos;autorizzazione per salvare il file qui, scegli un altro percorso e riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Troppi volumi, riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 non esiste sul disco, verifica e riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Non hai l&apos;autorizzazione per comprimere %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Il file originale di %1 non esiste, verifica e riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Dimensione totale: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Il nome è il medesimo dell&apos;archivio compresso, per cortesia utilizza un nome differente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>La password per gli archivi ZIP non può essere in Cinese</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Esiste già un file con lo stesso nome, desideri sostituirlo?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Sono supportati solo caratteri tradizionali e cinesi, oltre che alcuni simboli</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Apri con</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Scegli il programma di default</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Eliminerà definitivamente il(i) file in questione. Sicuro di voler continuare?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Desideri aggiungere l&apos;archivio alla lista oppure aprirlo in una nuova finestra?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Apri in una nuova finestra</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Le modifiche agli archivi con questa estensione non sono supportati. Convertilo prima in un formato gestibile per salvare le modifiche effettuate.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Converti nel formato:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Converti</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>elemento(i)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Estrazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>File danneggiato, impossibile procedere con l&apos;estrazione</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Trascina qui un file o una cartella</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Seleziona file</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>L&apos;archivio è danneggiato</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Apri in sola lettura</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Caricamento, attendere prego...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Gestore Archivi</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Archive Manager è un&apos;applicazione veloce e leggera per la creazione e l&apos;estrazione di archivi.
 Localizzazione italiana a cura di Massimo A. Carofano.</translation>
@@ -449,427 +464,457 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Apri file</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Crea nuovo Archivio</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Conversione</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Aggiornamento commenti</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Errore plugin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Inserimento riuscito</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Nessuna data</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Aggiunta annullata</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Aggiunta fallits</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Estrazione non riuscita: il nome del file è troppo lungo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Creazione fallita di &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Apertura fallita: il nome del file è troppo lungo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Compressione riuscita</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Il nome del file è troppo lungo, quindi i primi 60 caratteri sono stati intercettati come nome del file.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Spazio su fisco insufficiente</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Alcuni volumi non sono presenti</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Password errata, riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Il nome del file è troppo lungo. Mantieni il nome entro 60 caratteri per favore.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Conversione fallita</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Seleziona file</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Inserisci più di %1 caratteri</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Desideri eliminare l&apos;archivio?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 è stata modificata sul Disco, importala nuovamente.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Gestore Archivi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Non hai l&apos;autorizzazione per salvare il file qui, scegli un altro percorso e riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Aggiunta file in %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Compressione in corso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Estrazione in corso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Eliminazione</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Caricamento, attendere prego...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Sicuro di voler interrompere l&apos;operazione in corso?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Aggiornamento in corso, attendere prego...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Il nome file è troppo lungo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Creazione file fallita</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Compressione fallita</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Trova percorso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Apertura fallita</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Password errata</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Il formato del file non è supportato dal Gestore Archivi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Ridenominazione in corso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Non hai l&apos;autorizzazione per caricare %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Nessun file o percorso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Estrazione riuscita</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Estrazione annullata</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>L&apos;archivio è danneggiato</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Estrazione riuscita</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Conversione riuscita</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>I volumi compressi esistono già</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Estrazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Visualizza scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Il nome è il medesimo dell&apos;archivio compresso, per cortesia utilizza un nome differente</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Esiste già un file con lo stesso nome, desideri sostituirlo?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Non puoi aggiungere l&apos;archivio al tuo lavoro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Non puoi aggiungere elementi ad un archivio di questo tipo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Info base</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Tipologia</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Percorso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Data creazione</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Data ultimo accesso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Data modifica</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archivio</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Commenti</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Controlla il tipo di associazione nelle impostazioni del Gestore Archivi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>L&apos;archivio è stato modificato sul Disco, importalo nuovamente.</translation>
     </message>
@@ -877,52 +922,52 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Percorso</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Applicazione</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Immagine</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archivio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Eseguibile</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Documento</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>File di backup</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Sconosciuto</translation>
     </message>
@@ -930,39 +975,39 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Apri con</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Aggiungi altri programmi</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Imposta come default</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>App raccomandate</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Altre App</translation>
     </message>
@@ -970,7 +1015,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>File crittografato, inserisci la password</translation>
     </message>
@@ -978,12 +1023,12 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Percorso corrente;</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Torna a: %1</translation>
     </message>
@@ -991,35 +1036,35 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 operazione(i) in corso</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Attività</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Estrazione in corso</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Sicuro di voler interrompere l&apos;estrazione?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Conferma</translation>
@@ -1028,141 +1073,142 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Calcolo in corso...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Tempo rimanente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Compressione in corso</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Eliminazione</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Ridenominazione in corso</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Conversione</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Aggiornamento commenti...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Estrazione in corso</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pausa</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continua</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Sicuro di voler interrompere l&apos;estrazione?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Sicuro di voler annullare l&apos;eliminazione?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Sicuro di voler interrompere la compressione?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Sicuro di voler interrompere la conversione?</translation>
     </message>
@@ -1170,119 +1216,119 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Data modifica</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Tipologia</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 modificato. Desideri salvare le modifiche nell&apos;archivio?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Generali</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Estrazione</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Crea automaticamente una cartella contenente i file estratti</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Mostra file estratti al termine</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Gestione file</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Elimina i file dopo la compressione</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>File associati</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Tipo file</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Salta</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Unisci</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Esiste già un file con lo stesso nome, desideri sostituirlo?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Esiste già un file con lo stesso nome nella cartella di destinazione, sostituirlo?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Applica a tutti</translation>
     </message>
@@ -1290,24 +1336,24 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>Il nome esiste già.</translation>
     </message>
@@ -1315,64 +1361,64 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Cartella corrente</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Annulla Tutto</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Seleziona Tutto</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Raccomandato</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Estrai archivi in</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Un&apos;altra cartella</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Elimina gli archivi dopo l&apos;estrazione</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Mai</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Chiedi ogni volta</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Sempre</translation>
     </message>
@@ -1380,17 +1426,17 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Compressione riuscita</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Visualizza</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
@@ -1398,18 +1444,18 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Apri file</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Info</translation>
     </message>
@@ -1417,36 +1463,36 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Estrai in:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Estrai</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Il percorso di estrazione di default non esiste, riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Non hai l&apos;autorizzazione per salvare il file qui, scegli un altro percorso e riprova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Trova percorso</translation>
     </message>
@@ -1454,67 +1500,67 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Non puoi aggiungere l&apos;archivio al tuo lavoro</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Estrai</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Estrai nella cartella corrente</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Apri con</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Scegli il programma di default</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Desideri eliminare i file selezionati?</translation>
     </message>

--- a/translations/deepin-compressor_ja.ts
+++ b/translations/deepin-compressor_ja.ts
@@ -4,12 +4,12 @@
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation type="unfinished">%1を圧縮する権限がありません</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">パスワードが違います</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -46,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>次へ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>ファイルを追加してください</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
@@ -65,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>新規アーカイブ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>詳細設定</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>アーカイブを暗号化する</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>ファイル一覧も暗号化する</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>ボリュームに分割する</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation type="unfinished">圧縮</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>ZIP、7z形式のみ対応</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>7z形式のみ対応</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>名前</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>保存先</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>無効なファイル名です</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>パスを入力してください</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>パスが存在しません。再試行してください</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>その場所にファイルを保存する権限がありません。変更して再試行してください</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>ボリュームが多すぎます。変更して再試行してください</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>%1を圧縮する権限がありません</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">置き換え</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>合計サイズ: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>同じ名前の別ファイルが既に存在します。置き換えますか？</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation type="unfinished"></translation>
     </message>
@@ -275,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>以下で開く:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>既定のプログラムを選択してください</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>ファイルは完全に削除されます。続行してもよろしいですか？</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">確定</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">追加</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>アーカイブをリストに追加しますか、それとも新規ウィンドウで開きますか？</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>新規ウィンドウで開く</translation>
     </message>
@@ -338,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>このファイル形式のアーカイブへの変更には対応していません。変更を保存するには、アーカイブ形式を変換してください。</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>変換後の形式:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation type="unfinished">変換</translation>
@@ -363,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>項目</translation>
     </message>
@@ -371,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>伸張に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>ファイルが破損しています。伸張できません</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
@@ -396,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>ここにファイルまたはフォルダをドラッグ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>ファイルの選択</translation>
     </message>
@@ -409,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
@@ -428,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>読み込んでいます。しばらくお待ちください...</translation>
     </message>
@@ -436,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>アーカイブ マネージャー</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>アーカイブ マネージャーは、アーカイブの作成および伸張するための高速で軽量なアプリケーションです。</translation>
     </message>
@@ -450,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>ファイルを開く</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>新規アーカイブの作成</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>変換中</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>圧縮が完了しました</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>アーカイブを削除しますか？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1はディスク上で変更されました。再度インポートしてください。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>アーカイブ マネージャー</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>その場所にファイルを保存する権限がありません。変更して再試行してください</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>%1 にファイルを追加中</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>圧縮中</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>伸張中</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>削除中</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>読み込んでいます。しばらくお待ちください...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>進行中のタスクを停止してもよろしいですか？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>圧縮に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">置き換え</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>ディレクトリを検索</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>パスワードが違います</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">確定</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>伸張が完了しました</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>伸張が完了しました</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>変換が完了しました</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>伸張に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>ショートカットを表示する</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>ショートカット</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">同じ名前の別ファイルが既に存在します。置き換えますか？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished">アーカイブに本体を追加することはできません</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation type="unfinished">更新</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>サイズ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>種類</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>更新日時</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>アーカイブ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>アーカイブ マネージャーの設定でファイルの関連付けの種類を確認してください</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>アーカイブはディスク上で変更されました。再度インポートしてください。</translation>
     </message>
@@ -878,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>ディレクトリ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>アプリケーション</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>ビデオ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>オーディオ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>画像</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>アーカイブ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>実行ファイル</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>文書</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>バックアップファイル</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>不明</translation>
     </message>
@@ -931,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>以下で開く:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>他のプログラムを追加</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>既定として設定</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">確定</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>推奨されたアプリケーション</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>他のアプリケーション</translation>
     </message>
@@ -971,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>暗号化されたファイルです。パスワードを入力してください</translation>
     </message>
@@ -979,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -992,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1件のタスクが進行中です</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>タスク</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>伸張中</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>伸張を停止してもよろしいですか？</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">確定</translation>
@@ -1029,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>計算中...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation type="unfinished">速度</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>残り時間</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>圧縮中</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>削除中</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>変換中</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>伸張中</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation type="unfinished">一時停止</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation type="unfinished">続行</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">確定</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>圧縮を停止してもよろしいですか？</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>変換を停止してもよろしいですか？</translation>
     </message>
@@ -1171,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>名前</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>更新日時</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>種類</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>サイズ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1を変更しました。アーカイブに変更を保存しますか？</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>伸張</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>複数の伸張されたファイル用のフォルダを自動で作成する</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>完了時に伸張されたファイルを表示する</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>ファイル管理</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>圧縮後にファイルを削除する</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>関連するファイル</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>ファイル形式</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation type="unfinished">スキップ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>同じ名前の別ファイルが既に存在します。置き換えますか？</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">置き換え</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>すべてに適用</translation>
     </message>
@@ -1291,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1316,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>カレントディレクトリ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation type="unfinished">すべて選択</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>推奨</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>アーカイブの伸張先</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>他のディレクトリ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>デスクトップ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>伸張後にアーカイブを削除する</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>常にしない</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>確認を求める</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>常にする</translation>
     </message>
@@ -1381,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>圧縮が完了しました</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>表示</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
@@ -1399,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation type="unfinished">ファイルを開く</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation type="unfinished">戻る</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1418,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>伸張先:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation type="unfinished">伸張</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>既定の伸張パスが存在しません。再試行してください</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>その場所にファイルを保存する権限がありません。変更して再試行してください</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>ディレクトリを検索</translation>
     </message>
@@ -1455,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>アーカイブに本体を追加することはできません</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>伸張</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>カレントディレクトリへ伸張</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>以下で開く:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>既定のプログラムを選択してください</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">確定</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>選択したファイルを削除しますか？</translation>
     </message>

--- a/translations/deepin-compressor_ka.ts
+++ b/translations/deepin-compressor_ka.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ka">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ka">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>არსებულ არქივში ფაილების დამატება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>პაროლის გამოყენება</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>%1 ორიგინალი ფაილი არ არსებობს, გთხოვთ შეამოწმეთ და სცადე თავიდან</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 ვერ მოიძებნა დისკზე, გთხოვთ შეამოწმეთ და სცადეთ თავიდან</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>თქვენ არ გაქვთ საკმარისი უფლება %1 კომპრესიისთვის</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">არასწორი პაროლი</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>კომენტარის განახლება</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>შემდეგი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>გთხოვთ დაამატეთ ფაილები</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,210 +78,210 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>ახალი არქივი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>დამატებითი პარამეტრები</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>შეკუმშვის მეთოდი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>პაროლის დაყენება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>ფაილების დაშიფვრა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>არქივის დაყოფა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>კომენტარის დამატება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>კომპრესია</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>განთავსება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>უსწრაფესი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>სწრაფი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>ნორმალური</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>კარგი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>საუკეთესო</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>2 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>4 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>8 threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>2 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>4 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>8 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>დასაშვებია მხოლოდ zip, 7z ტიპი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>ნებადართულია მხოლოდ 7z ტიპი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>შეიყვანეთ %1 სიმბოლო</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>სახელი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>შენახვის ადგილი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>არასწორი ფაილის სახელი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>გთხოვთ მიუთითეთ გზა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>მითითებული წყარო არ არსებობს, გთხოვთ შეასწოროთ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>თქვენ არ გაქვთ საკმარისი უფლება ფაილების აქ შესანახად. გთხოვთ მიუთითეთ სხვა გზა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>ძალიან ბევრი ტომი, გთხოვთ შეცვლაოთ და სცადოთ განმეორებით</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 არ მოიძებნა დისკზე. გთხოვთ შეამოწმოთ და სცადოთ თავიდან</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>თქვენ არ გაქვთ უფლება %1 კომპრესირებისათვის</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>%1 ფაილის ორიგინალი ვერ მოიძებნა. გთხოვთ სცადოთ თავიდან</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>ჩანაცვლება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>საერთო ზომა: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>სახელი იგივეა რაც არქივის, გთხოვთ მიუთითოთ სხვა სახელი</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>ZIP ტომის პაროლი არ შეიძლება იყოს ჩინურ ენაზე</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ფაილი ასეთ სახელით უკვე დამატებულია, 
 ჩავანაცვლოთ?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>მხოლოდ ჩინური და ლათინური სიმბოლოების მხარდაჭერა</translation>
     </message>
@@ -274,62 +289,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>გახსნა</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>პროგრამით გახსნა</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>აირჩიეთ ძირითადი პროგრამა</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>აღნიშნული ფაილები წაიშლება სამუდამოდ, დარწმუნებული ხართ, რომ გსურთ გაგრძელება?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>დადასტურება</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>დამატება</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>გსურთ არქივის სიაში დამატება ან ახალ ფანჯარაში გახსნა?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>ახალ ფანჯარაში გახსნა</translation>
     </message>
@@ -337,23 +352,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>არქივის ამ ტიპში ცვლილებების შეტანა არ არის შესაძლებელი. გთხოვთ დააკონვერტიროთ არიქივ და შეინახოთ ცვლილება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>კონვერტაციის ფორმატი:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>კონვერტაცია</translation>
@@ -362,7 +377,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>ობიექტები</translation>
     </message>
@@ -370,24 +385,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>ამოარქივება შეწყდა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>ფაილი დაზიანებულია, ამოარქივება შეუძლებელია</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>ხელახლა ცდა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>უკან</translation>
     </message>
@@ -395,12 +410,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>გადმოიტანეთ ფაილი ან საქაღალდე აქ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>აირჩიეთ ფაილი</translation>
     </message>
@@ -408,17 +423,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>არქივი დაზიანებულია</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>მხოლოდ წაკითხვის ულფებით გახსნა</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
@@ -427,7 +442,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>იტვირთება, გთხოვთ დაელოდოთ...</translation>
     </message>
@@ -435,13 +450,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>არქივის მენეჯერი</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>აქრივების მენეჯერი სწრაფი და მარტივი აპლიკაციაა არქივის შესაქმნელად და გასახნელად</translation>
     </message>
@@ -449,428 +464,458 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>ფაილის გახსნა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>პარამეტრები</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>ახალი არქივის შექმნა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>კონვერტაცია</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>კომენტარების განახლება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>პლაგინის შეცდომა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>დამატება წარმატებით დასრულდა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>მასში მონაცემები არ მოიძებნა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>დამატება გაუქმებულია</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>შეცდომა ამოარქივებისას</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>შეცდომა &quot;%1&quot; შექმნისას</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>არქივი წარმატებით შეიქმნა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>მყარ დისკზე არასაკმარისი მოცულება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>ზოგიერთი ტომი არ მოიძებნა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>არასწორი პაროლი, გთხოვთ სცადოთ განმეორებით</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>აირჩიეთ ფაილი</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>შეიყვანეთ %1 სიმბოლო</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>ფაილის ინფორმაცია</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>ნამდვილად გსურთ არქივის წაშლა?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 შეიცვლა დისკზე. გთხოვთ დააიმპორტიროთ განმეორებით</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>არქივის მენეჯერი</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>თქვენ არ გაქვთ საკმარისი უფლება ფაილების აქ შესანახად. გთხოვთ მიუთითეთ სხვა გზა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>%1-ში ფაილების დამატება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>კომპრესირება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>ამოარქივება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>იტვირთება, გთხოვთ დაელოდოთ...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>დარწმუნებული ხართ, რომ ნამდვილად გსურთ მიმდინარე დავალების გაჩერება?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>განახლება, გთხოვთ დაელოდოთ...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>ფაილის სახელი ძალიან გრძელია</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>შეცდომა ფაილის შექმნისას</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>კომპრესირება შეწყდა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>ჩანაცვლება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>საქაღალდის ძებნა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>შეცდომა გახსნისას</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>არასწორი პაროლი</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>არქივის მენეჯერს არ გააჩნია აღნიშნული ფორმატის მხარდაჭერა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>თქვენ არ გაქვთ საკმარისი უფლება %1 ჩასატვირთად</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>დადასტურება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>არ არის ასეთი ფაილი ან საქაღალდე</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>ამოარქივება დასრულდა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>ამოარქივება გაუქმებულია</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>არქივი დაზიანებულია</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>ამოარქივება დასრულდა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>კონვერსა წარმატებით დასრულდა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>ამოარქივება შეწყდა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>დახურვა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>დახმარება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>იარლიყის ჩვენება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>იარლიყი</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>აღნიშნული ფაილის სახელი იგივეა რაც არქივის სახელი, გთხოვთ გამოიყენოთ სხვა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ფაილი ასეთ სახელით უკვე დამატებულია, 
 ჩავანაცვლოთ?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>თქვენ ვერ დაამატებთ არქივს თავის თავში</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>აღნიშნულ არქივში ამ ტიპის ფაილის დამატება შეუძლებელია</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>განახლება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>საბაზო ინფორმაცია</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>ზომა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>ტიპი</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>ადგილმდებარეობა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>შექმნის დრო</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>შემოწმების დრო</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>შეცვლის დრო</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>არქივი</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>კომენტარის დამატება</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>გთხოვთ გადაამოწმოთ ასოცირებული ფაილების არქივების მენეჯერის პარამეტრებში</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>არქივი შეიცვლა დისკზე. გთხოვთ დააიმპორტოთ განმეორებით</translation>
     </message>
@@ -878,52 +923,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>საქაღალდე</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>აპლიკაცია</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>ვიდეო</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>აუდიო</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>ფოტო</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>არქივი</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>გაშვებადი</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>დოკუმენტი</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>რეზერვირების ფაილი</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>უცნობი</translation>
     </message>
@@ -931,39 +976,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>პროგრამით გახსნა</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>სხვა პროგრამის დამატება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>აირჩიეთ ძირითადად</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>დადასტურება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>რეკომენდირებული აპლიკაცია</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>სხვა აპლიკაციები</translation>
     </message>
@@ -971,7 +1016,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>დაცული ფაილი, გთხოვთ შეიყვანოთ პაროლი</translation>
     </message>
@@ -979,12 +1024,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>აღნიშნული გზა:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>%1-ზე დაბრუნება</translation>
     </message>
@@ -992,35 +1037,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 დავალება მიმდინარეობს</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>დავალება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>ამოარქივება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>დარწმუნებული ხართ, რომ გსურთ ამოარქივების პროცესის გაჩერება?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>დადასტურება</translation>
@@ -1029,141 +1074,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>სიჩქარე</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>დათვლა...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>სიჩქარე</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">სიჩქარე</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>სიჩქარე</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>სიჩქარე</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>დარჩენილი დრო</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>კომპრესირება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>კონვერტაცია</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>კომენტარის განახლება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>ამოარქივება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>შეჩერება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>გაგრძელება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>დადასტურება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>დარწმნებული ხართ, რომ ნამდვილად გსურთ დეკომპრესირების გაჩერება?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>დარწმუნებული ხართ, რომ ნამდვილად გსურთ წაშლის პროცესის გაჩერება?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>დარწმუნებული ხართ, რომ ნამდვილად გსურთ კომპრესირების გაჩერება?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>დარწმუნებული ხართ, რომ ნამდვილად გსურთ კონვერსიის გაჩერება?</translation>
     </message>
@@ -1171,121 +1217,121 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>სახელო</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>შეცვლის დრო</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>ტიპი</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>ზომა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 შეიცვლა, გსურთ ცვლილების შენახვა?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>ძირითადი</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>ამოარქივება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>ამოარქივებული ფაილებისათვის საქაღალდის ავტომატური შექმნა</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>ამოარქივების დასრულების შემდეგ ფაილების ჩვენება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>ფაილების მენეჯმენტი</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>ფაილების წაშლა დაარქივების შემდეგ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>ასოცირებული ფაილები</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>ფაილის ტიპი</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>გამოტოვება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>გაერთიანება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ფაილი ასეთ სახელით უკვე დამატებულია, 
 ჩავანაცვლოთ?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>ჩანაცვლება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>საქაღალდე ასეთ სახელით უკვე დამატებულია, 
 ჩავანაცვლოთ?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>ყველას დადასტურება</translation>
     </message>
@@ -1293,89 +1339,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>მიმდინარე საქაღალდე</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>გასუფთავება</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>ყველას მონიშვნა</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>რეკომენდირებული</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>ამოარქივდეს ადგილი</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>სხვა საქაღალდე</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>დესკტოპი</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>ამოარქივების შემდეგ არქივის წაშლა</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>არასდროს</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>დადასტურების მოთხოვნა</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>ყოველთვის</translation>
     </message>
@@ -1383,17 +1429,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>არქივი წარმატებით შეიქმნა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>ნახვა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>უკან</translation>
     </message>
@@ -1401,55 +1447,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ფაილის გახსნა</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">უკან</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ფაილის ინფორმაცია</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>ამოარქივდეს:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>ამოარქივება</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>სტანდარტული ამოარქივების გზა არ არსებობს, გთხოვთ სცადოთ განმეორებით</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>თქვენ არ გაქვთ საკმარისი უფლება ფაილების აქ შესანახად. გთხოვთ მიუთითეთ სხვა გზა</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>საქაღალდის ძებნა</translation>
     </message>
@@ -1457,67 +1503,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>თქვენ ვერ დაამატებთ არქივს თავის თავში</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>ამოარქივება</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>მიმდინარე საქაღალდეში ამოარქივება</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>გახსნა</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>პროგრამით გახსნა</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>აირჩიეთ სტანდარტული პროგრამა</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>დადასტურება</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>ნამდვილად გსურთ არჩეული ფაილების წაშლა?</translation>
     </message>

--- a/translations/deepin-compressor_km_KH.ts
+++ b/translations/deepin-compressor_km_KH.ts
@@ -4,12 +4,12 @@
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation type="unfinished">អ្នកគ្មានសិទ្ធិបង្រួម %1 ទេ</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">លេខសំងាត់​ខុស</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>កំពុងធ្វើបច្ចុប្បន្នភាពមតិយោបល់...</translation>
     </message>
@@ -46,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>បន្ទាប់</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>សូមបន្ថែមឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">យល់ព្រម</translation>
@@ -65,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>ប័ណ្ណសារថ្មី</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>ជម្រើសកម្រិតខ្ពស់</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>វិធីសាស្ត្របង្ហាប់</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>អ៊ិនគ្រីបប័ណ្ណសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>អ៊ិនគ្រីបបញ្ជីឯកសារផងដែរ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>ពុះជាភាគ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>យោបល់</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation type="unfinished">បង្រួម</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>ហាង</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>លឿនបំផុត</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>លឿន</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>ធម្មតា</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>ល្អ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>ល្អបំផុត</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>គាំទ្រប្រភេទ zip, 7z តែប៉ុណ្ណោះ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>គាំទ្រប្រភេទ 7z តែប៉ុណ្ណោះ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>ឈ្មោះ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>រក្សាទុកនៅ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>ឈ្មោះឯកសារមិនត្រឹមត្រូវ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>សូមបញ្ចូលទីតាំង</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>ទីតាំងមិនមានទេសូមព្យាយាមម្តងទៀត</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>អ្នកមិនមានសិទ្ធិរក្សាទុកឯកសារនៅទីនេះទេ សូមផ្លាស់ប្តូរហើយព្យាយាមម្តងទៀត</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>បរិមាណច្រើនពេក សូមប្តូរហើយព្យាយាមម្តងទៀត</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>អ្នកគ្មានសិទ្ធិបង្រួម %1 ទេ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">យល់ព្រម</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">ជំនួស</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>ទំហំសរុប៖ %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ឯកសារមួយទៀតដែលមានឈ្មោះដូចគ្នាមានរួចហើយជំនួសវា?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation type="unfinished"></translation>
     </message>
@@ -275,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>បើក</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>លុប</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>បើក​ជាមួយ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>ជ្រើសរើសកម្មវិធីលំនាំដើម</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>វានឹងលុបឯកសារជាអចិន្ត្រៃយ៍។ តើអ្នកប្រាកដជាចង់បន្តឬ?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">បញ្ជាក់</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished">បន្ថែម</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>តើអ្នកចង់បន្ថែមប័ណ្ណសារទៅក្នុងបញ្ជីឬបើកវានៅក្នុងបង្អួចថ្មីទេ?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>បើកនៅក្នុងបង្អួចថ្មី</translation>
     </message>
@@ -338,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>ការផ្លាស់ប្តូរប័ណ្ណសារក្នុងប្រភេទឯកសារនេះមិនត្រូវបានគាំទ្រទេ។ សូមបំលែងទ្រង់ទ្រាយប័ណ្ណសារដើម្បីរក្សាទុកការផ្លាស់ប្តូរ។</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>បំលែងទ្រង់ទ្រាយទៅជាៈ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation type="unfinished">បំលែង</translation>
@@ -363,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>ធាតុ()</translation>
     </message>
@@ -371,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>ការស្រង់ចេញបានបរាជ័យ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>ឯកសារខូច មិនអាចដកស្រង់បានទេ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation type="unfinished">ព្យាយាមម្តងទៀត</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>ថយក្រោយ</translation>
     </message>
@@ -396,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>ទាញឯកសារឬថតឯកសារនៅទីនេះ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>ជ្រើសឯកសារ</translation>
     </message>
@@ -409,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
@@ -428,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>កំពុងផ្ទុក សូមរង់ចាំ...</translation>
     </message>
@@ -436,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>អ្នកគ្រប់គ្រងបណ្ណសារ</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>កម្មវិធីគ្រប់គ្រងប័ណ្ណសារគឺជាកម្មវិធីលឿននិងស្រាលសម្រាប់បង្កើតនិងស្រង់ចេញប័ណ្ណសារ។</translation>
     </message>
@@ -450,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>បើក​ឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>ការកំណត់</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>បង្កើតប័ណ្ណសារថ្មី</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>កំពុងបំលែង</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>ការបង្ហាប់បានជោគជ័យ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>ព័ត៌មានឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>តើអ្នកចង់លុបប័ណ្ណសារទេ?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 ត្រូវបានផ្លាស់ប្ដូរនៅលើឌីស សូមនាំចូលម្តងទៀត។</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>អ្នកគ្រប់គ្រងបណ្ណសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>អ្នកមិនមានសិទ្ធិរក្សាទុកឯកសារនៅទីនេះទេ សូមផ្លាស់ប្តូរហើយព្យាយាមម្តងទៀត</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>បន្ថែមឯកសារទៅ %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>កំពុងបង្ហាប់</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>កំពុងស្រង់ចេញ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>កំពុងលុប</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>កំពុងផ្ទុក សូមរង់ចាំ...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>តើអ្នកពិតជាចង់បញ្ឈប់កិច្ចការដែលកំពុងដំណើរការមែនទេ?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>ការបង្ហាប់បានបរាជ័យ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">ជំនួស</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>រកថតឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>ការបើកបានបរាជ័យ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>លេខសំងាត់​ខុស</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">យល់ព្រម</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">បញ្ជាក់</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>ការស្រង់ចេញបានជោគជ័យ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>ការស្រង់ចេញបានជោគជ័យ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>ការបំលែងជោគជ័យ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>ការស្រង់ចេញបានបរាជ័យ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>បិទ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>ជំនួយ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>លុប</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>បង្ហាញផ្លូវកាត់</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>ផ្លូវកាត់</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ឯកសារមួយទៀតដែលមានឈ្មោះដូចគ្នាមានរួចហើយជំនួសវា?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished">អ្នកមិនអាចបន្ថែមប័ណ្ណសារទៅខ្លួនវាបានទេ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation type="unfinished">ធ្វើបច្ចុប្បន្នភាព</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>ព័ត៌មានមូលដ្ឋាន</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>ទំហំ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>ប្រភេទ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>ទីតាំង</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>ពេលវេលាបានបង្កើត</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>ពេលវេលាបានចូល</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>ពេលវេលាកែប្រែ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>ប័ណ្ណសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>យោបល់</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>សូមពិនិត្យមើលប្រភេទឯកសារនៅក្នុងការកំណត់របស់អ្នកគ្រប់គ្រងប័ណ្ណសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>ប័ណ្ណសារត្រូវបានផ្លាស់ប្តូរនៅលើឌីស សូមនាំចូលម្តងទៀត។</translation>
     </message>
@@ -878,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>ថតឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>កម្មវិធី</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>វីដេអូ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>សំឡេង</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>រូបភាព</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>ប័ណ្ណសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>អាចប្រតិបត្តិបាន</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>ឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>ឯកសារបម្រុងទុក</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>មិនស្គាល់</translation>
     </message>
@@ -931,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>បើក​ជាមួយ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>បន្ថែមកម្មវិធីផ្សេងទៀត</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>កំណត់ជាលំនាំដើម</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">បញ្ជាក់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>កម្មវិធីដែលបានណែនាំ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>កម្មវិធីផ្សេងទៀត</translation>
     </message>
@@ -971,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>ឯកសារដែលបានអ៊ិនគ្រីប សូមបញ្ចូលពាក្យសម្ងាត់</translation>
     </message>
@@ -979,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -992,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 ការងារ(s) កំពុង​ដំណើរការ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>ការងារ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>កំពុងស្រង់ចេញ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>តើអ្នកពិតជាចង់បញ្ឈប់ការស្រង់ចេញមែនទេ?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">បញ្ជាក់</translation>
@@ -1029,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>ល្បឿន</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>កំពុងគណនា...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>ល្បឿន</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation type="unfinished">ល្បឿន</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>ល្បឿន</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>ល្បឿន</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>ពេលវេលានៅសល់</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>កំពុងបង្ហាប់</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>កំពុងលុប</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>កំពុងបំលែង</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>កំពុងធ្វើបច្ចុប្បន្នភាពមតិយោបល់...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>កំពុងស្រង់ចេញ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation type="unfinished">ផ្អាក</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation type="unfinished">បន្ត</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">បញ្ជាក់</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>តើអ្នកពិតជាចង់បញ្ឈប់ការបង្ហាប់មែនទេ?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>តើអ្នកពិតជាចង់បញ្ឈប់ការបំលែងមែនទេ?</translation>
     </message>
@@ -1171,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>ឈ្មោះ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>ពេលវេលាកែប្រែ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>ប្រភេទ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>ទំហំ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>បានផ្លាស់ប្ដូរ %1។ តើអ្នកចង់រក្សាទុកការផ្លាស់ប្តូរក្នុងប័ណ្ណសារទេ?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>ទូទៅ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>ការស្រង់ចេញ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>បង្កើតថតឯកសារដោយស្វ័យប្រវត្តិសម្រាប់ឯកសារដកស្រង់ច្រើន</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>បង្ហាញឯកសារដែលបានស្រង់ចេញនៅពេលបញ្ចប់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>ការគ្រប់គ្រងឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>លុបឯកសារបន្ទាប់ពីបង្ហាប់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>ឯកសារពាក់ព័ន្ធ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>ប្រភេទឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation type="unfinished">រំលង</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ឯកសារមួយទៀតដែលមានឈ្មោះដូចគ្នាមានរួចហើយជំនួសវា?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">ជំនួស</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">យល់ព្រម</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>អនុវត្តទៅទាំងអស់</translation>
     </message>
@@ -1291,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">យល់ព្រម</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1316,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>ថតបច្ចុប្បន្ន</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>លុបចេញ​ទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation type="unfinished">ជ្រើស​យក​ទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>បានណែនាំ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>ស្រង់ចេញប័ណ្ណសារទៅ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>ថតផ្សេងទៀត</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>ផ្ទៃតុ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>លុបបណ្ណសារបន្ទាប់ពីស្រង់ចេញ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>មិនដែល</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>សុំការបញ្ជាក់</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>ជានិច្ច</translation>
     </message>
@@ -1381,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>ការបង្ហាប់បានជោគជ័យ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>មើល</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>ថយក្រោយ</translation>
     </message>
@@ -1399,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation type="unfinished">បើក​ឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation type="unfinished">ថយក្រោយ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation type="unfinished">ព័ត៌មានឯកសារ</translation>
     </message>
@@ -1418,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>ស្រង់ចេញទៅ៖</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation type="unfinished">ស្រង់ចេញ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>មិនមានទីតាំងស្រង់ចេញលំនាំដើមទេ សូមព្យាយាមម្តងទៀត</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>អ្នកមិនមានសិទ្ធិរក្សាទុកឯកសារនៅទីនេះទេ សូមផ្លាស់ប្តូរហើយព្យាយាមម្តងទៀត</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">យល់ព្រម</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>រកថតឯកសារ</translation>
     </message>
@@ -1455,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>អ្នកមិនអាចបន្ថែមប័ណ្ណសារទៅខ្លួនវាបានទេ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">យល់ព្រម</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>ស្រង់ចេញ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>ស្រង់ទៅថតបច្ចុប្បន្ន</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>បើក</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>លុប</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>បើក​ជាមួយ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>ជ្រើសរើសកម្មវិធីលំនាំដើម</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">បោះបង់</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">បញ្ជាក់</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>តើអ្នកចង់លុបឯកសារ()ដែលបានជ្រើសរើសទេ?</translation>
     </message>

--- a/translations/deepin-compressor_ko.ts
+++ b/translations/deepin-compressor_ko.ts
@@ -4,12 +4,12 @@
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">잘못된 비밀번호</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -46,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>다음</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>파일을 추가하십시오</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
@@ -65,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation type="unfinished">고급 옵션</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation type="unfinished">압축파일 암호화</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation type="unfinished">파일 목록도 암호화</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation type="unfinished">볼륨으로 분할</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation type="unfinished">압축</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation type="unfinished">zip, 7z 유형만 지원</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation type="unfinished">7z 유형만 지원</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation type="unfinished">이름</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation type="unfinished">저장 위치</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation type="unfinished">잘못된 파일 이름</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation type="unfinished">경로를 입력하십시오</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation type="unfinished">경로가 존재하지 않으므로 다시 시도하십시오</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">교체</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">동일한 이름의 다른 파일이 이미 존재합니다, 교체 하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation type="unfinished"></translation>
     </message>
@@ -275,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation type="unfinished">삭제</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -338,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -363,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation type="unfinished">항목(들)</translation>
     </message>
@@ -371,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation type="unfinished">추출 실패함</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation type="unfinished">손상된 파일, 추출할 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation type="unfinished">재시도</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation type="unfinished">뒤로</translation>
     </message>
@@ -396,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>파일 또는 폴더를 여기로 끌어다 놓기</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>파일 선택</translation>
     </message>
@@ -409,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
@@ -428,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -436,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>압축파일 관리자</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>압축파일 관리자는 압축파일을 만들고, 추출하기 위한 빠르고 가벼운 응용 프로그램입니다.</translation>
     </message>
@@ -450,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>파일 열기</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>새 압축파일 만들기</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>압축 성공</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>디스크에서 %1이 변경되었으므로 다시 가져오십시오.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>압축파일 관리자</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>압축중</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>추출중</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation type="unfinished">추출 성공</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation type="unfinished">추출 성공</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>압축 실패함</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">교체</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>디렉토리 찾기</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>잘못된 비밀번호</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation type="unfinished">삭제</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation type="unfinished">추출 실패함</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">동일한 이름의 다른 파일이 이미 존재합니다, 교체 하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation type="unfinished">크기</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation type="unfinished">유형</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation type="unfinished">수정된 시간</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation type="unfinished">압축파일</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>압축파일이 디스크에서 변경되었습니다. 다시 가져오십시오.</translation>
     </message>
@@ -878,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>디렉토리</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>응용프로그램</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>비디오</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>오디오</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>이미지</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>압축파일</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>실행 가능</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>문서</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>백업 파일</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>알 수 없음</translation>
     </message>
@@ -931,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation type="unfinished"></translation>
     </message>
@@ -971,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation type="unfinished">암호화된 파일, 비밀번호를 입력하십시오</translation>
     </message>
@@ -979,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -992,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>진행 중인 작업 %1개</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>작업</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>추출중</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation type="unfinished">추출을 중지하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
@@ -1029,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation type="unfinished">계산 중...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation type="unfinished">압축중</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation type="unfinished">추출중</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation type="unfinished">압축을 중지하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1171,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>수정된 시간</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>유형</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>크기</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>일반</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>추출</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>추출된 여러 파일에 대한 폴더 자동 생성</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>연결된 파일</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>파일 유형</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation type="unfinished">동일한 이름의 다른 파일이 이미 존재합니다, 교체 하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation type="unfinished">교체</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1316,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>현재 디렉토리</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>모두 지우기</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation type="unfinished">모두 선택</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>압축파일 추출 위치</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>다른 디렉토리</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>바탕화면</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1381,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation type="unfinished">압축 성공</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation type="unfinished">보기</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation type="unfinished">뒤로</translation>
     </message>
@@ -1399,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation type="unfinished">파일 열기</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation type="unfinished">뒤로</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1418,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>압축풀 위치:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation type="unfinished">압축풀기</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation type="unfinished">기본 추출 경로가 없으면 다시 시도하십시오</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>디렉토리 찾기</translation>
     </message>
@@ -1455,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation type="unfinished">압축풀기</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation type="unfinished">현재 디렉토리로 추출</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation type="unfinished">삭제</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-compressor_ms.ts
+++ b/translations/deepin-compressor_ms.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ms">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Tambah fail ke dalam arkib semasa</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Guna kata laluan</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Fail asal %1 tidak wujud, sila periksa dan cuba sekali lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 tidak wujud dalam cakera, sila periksa dan cuba sekali lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Anda tiada keizinan untuk memampatkan %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Kata laluan salah</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Mengemas kini ulasan...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Sila tambah fail</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Arkib Baharu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Pilihan Lanjutan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Kaedah pemampatan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Sulitkan arkib</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Jaluran CPU</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Sulitkan senarai fail juga</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Pisah mengikut volum</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Ulasan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Mampat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Terpantas</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Pantas</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Biasa</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Baik</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Terbaik</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Jaluran tunggal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 jaluran</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 jaluran</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 jaluran</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Sokong jenis zip, 7z sahaja</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Sokong jenis 7z sahaja</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Masukkan sehingga %1 aksara</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Simpan ke</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Nama fail tidak sah</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Sila masukkan laluan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Laluan tidak wujud, cuba sekali lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Anda tidak memiliki keizinan untuk menyimpan fail di sini, sila ubah dan cuba lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Terlalu banyak volum, sila ubah dan cuba lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 tidak wujud dalam cakera, sila periksa dan cuba sekali lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Anda tidak memiliki keizinan untuk memampatkan %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Fail asal %1 tidak wujud, sila periksa dan cuba sekali lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Jumlah saiz: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Nama adalah serupa dengan arkib termampat, sila guna nama lain</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Kata laluan bagi volum ZIP tidak boleh dalam bahasa Cina</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ada fail lain dengan nama yang serupa telah wujud, gantikannya?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Hanya aksara bahasa Cina dan Inggeris dan beberapa simbol disokong</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Buka</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Buka dengan</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Pilih program lalai</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Tindakan ini akan memadam fail-fail tersebut. Anda pasti mahu teruskan?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Sah</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Tambah</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Anda mahu menambah arkib ke dalam senarai atau buka ia dengan tetingkap baharu?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Buka dalam tetingkap baharu</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Perubahan kepada arkib bagi jenis fail ini tidak disokong. Sila tukar format arkib supaya dapat menyimpan perubahan.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Tukar format ke:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Tukar format</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>item</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Pengekstrakan gagal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Fail rosak, tidak boleh diekstrak</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Cuba lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Undur</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Seret fail atau folder di sini</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Pilih Fail</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Arkib sudah rosak</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Buka sebagai baca-sahaja</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Memuatkan, tunggu sebentar...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Pengurus Arkib</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Pengursu Arkib ialah sebuah aplikasi yang ringan dan pantas untuk mencipta dan mengekstrak arkib.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Buka fail</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Tetapan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Cipta Arkib Baharu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Menukarkan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Mengemas kini ulasan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Ralat pemalam</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Berjaya ditambah</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Tiada data di dalamnya</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Penambahan dibatalkan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Penambahan gagal</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Pengekstrakan gagal: Nama fail terlalu panjang</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Gagal mencipta &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Gagal dibuka: Nama fail terlalu panjang</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Pemampatan berjaya</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Nama fail terlalu panjang, jadi hanya 60 aksara terawal digunakan sebagai nama fail.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Ruang cakera tidak mencukupi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Beberapa volum hilang</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Kata laluan salah, cuba lagi sekali</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Nama fail terlalu panjang. Sila pastikan nama yang mengandungi 60 aksara sahaja.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Penukaran gagal</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Pilih fail</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Masukkan sehingga %1 aksara</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Maklumat fail</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Anda pasti mahu memadam arkib?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 telah berubah dalam cakera, sila import ia sekali lagi.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Pengurus Arkib</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Anda tidak memiliki keizinan untuk menyimpan fail di sini, sila ubah dan cuba lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Menambah fail ke dalam %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Memampat</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Mengekstrak</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Memadam</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Memuatkan, tunggu sebentar...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Anda pasti mahu menghentikan tugas yang masih berlangsung?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Mengemas kini, tunggu sebentar...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Nama fail terlalu panjang</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Gagal mencipta fail</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Pemampatan gagal</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Cari direktori</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Gagal buka</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Kata laluan salah</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Format fail tidak disokong oleh Pengurus Arkib</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Anda tiada keizinan untuk memuatkan %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Sah</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Tiada fail atau direktori sebegitu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Pengekstrakan berjaya</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Pengekstrakan dibatalkan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Arkib sudah rosak</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Pengekstrakan berjaya</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Penukaran format berjaya</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Pengekstrakan gagal</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Bantuan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Papar pintasan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Pintasan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Nama adalah serupa dengan arkib termampat, sila guna nama lain</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ada fail lain dengan nama yang serupa telah wujud, gantikannya?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Anda tidak boleh menambah arkib kepada dirinya sendiri</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Anda tidak boleh menambah fail ke dalam arkib dengan jenis fail ini</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Kemas kini</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Maklumat asas</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Saiz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Lokasi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Masa dicipta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Masa dicapai</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Masa ubah suai</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arkib</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Ulasan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Sila periksa jenis perkaitan fail dalam tetapan Pengurus Arkib</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Arkib ini telah berubah dalam cakera, sila import ia sekali lagi.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Direktori</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Aplikasi</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Imej</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arkib</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Boleh laku</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Dokumen</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Fail sandar</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Tidak diketahui</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Buka dengan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Tambah program lain</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Tetap sebagai lalai</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Sah</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Aplikasi Disarankan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Aplikasi lain</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Fail disulitkan, sila masukkan kata laluan</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Laluan semasa:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Undur ke: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 tugas masih berlansung</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Tugas</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Mengekstrak</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Anda pasti mahu menghentikan pengekstrakan?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Sah</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Mengira...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Masa berbaki</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Memampat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Memadam</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Menukarkan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Mengemas kini ulasan...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Mengekstrak</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Jeda</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Teruskan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Sah</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Anda pasti mahu menghentikan penyahmampatan?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Anda pasti mahu menghentikan pemadaman?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Anda pasti mahu menghentikan pemampatan?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Anda pasti mahu menghentikan penukaran?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Masa ubah suai</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Saiz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 telah berubah. Anda pasti mahu menyimpan perubahan yang berlaku kepada arkib?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Am</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Pengekstrakan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Cipta satu folder secara automatik untuk fail-fail diekstrak berbilang</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Tunjuk fail-fail diekstrak setelah selesai</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Pengurusan Fail</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Padam fail selepas pemampatan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Fail-fail Berkaitan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Jenis Fail</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Langkau</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Gabung</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ada fail lain dengan nama yang serupa telah wujud, gantikannya?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Ada folder lain dengan nama yang serupa telah wujud, gantikannya?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Terap untuk semua</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Direktori semasa</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Kosongkan Semua</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Pilih Semua</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Disarankan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Ekstrak arkib ke</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Lain-lain direktori</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Atas Meja</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Padam arkib selepas pengekstrakan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Tidak sesekali</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Tanya pengesahan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Sentiasa</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Pemampatan berjaya</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Lihat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Undur</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Buka fail</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Undur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Maklumat fail</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Ekstrak ke:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Ekstrak</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Laluan pengekstrakan lalai tidak wujud, cuba sekali lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Anda tidak memiliki keizinan untuk menyimpan fail di sini, sila ubah dan cuba lagi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Cari direktori</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Anda tidak boleh menambah arkib kepada dirinya sendiri</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Ekstrak</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Ekstrak ke direktori semasa</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Buka</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Buka dengan</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Pilih program lalai</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Sah</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Anda pasti mahu memadam fail-fail terpilih?</translation>
     </message>

--- a/translations/deepin-compressor_nl.ts
+++ b/translations/deepin-compressor_nl.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Bestanden toevoegen aan huidig archief</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Wachtwoord gebruiken</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Het oorspronkelijke bestand van ‘%1’ bestaat niet. Loop alles na en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 is niet aanwezig op de schijf. Controleer het bestand en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Je bent niet bevoegd om %1 in te pakken</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Onjuist wachtwoord</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Bezig met bijwerken van opmerking…</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Volgende</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Voeg bestanden toe</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Nieuw archief</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Geavanceerde opties</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Inpakmethode</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Archief versleutelen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Aantal cpu-kernen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Bestandslijst eveneens versleutelen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Opsplitsen in volumes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Opmerking</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Inpakken</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Opslag</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Snelste</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Snel</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normaal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Goed</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Beste</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Eén kern</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 kernen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 kernen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 kernen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Alleen zip en 7z worden ondersteund</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Alleen 7z wordt ondersteund</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Voer maximaal %1 tekens in</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Opslaan in</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Ongeldige bestandsnaam</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Voer het pad in</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Het pad bestaat niet. Probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Je bent niet bevoegd om hier bestanden op te slaan. Kies een andere locatie.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Te veel schijven - pas aan en probeer opnieuw</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 is niet aanwezig op de schijf. Controleer het bestand en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Je bent niet bevoegd om %1 in te pakken</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Het oorspronkelijke bestand van ‘%1’ bestaat niet. Loop alles na en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Totale grootte: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>De naam is dezelfde als die van een ander archief. Kies een andere naam.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Wachtwoorden van zip-archieven mogen niet in het Chinees zijn</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Er is al een bestand met deze naam. Wil je het vervangen?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Bestandsnamen mogen alleen Chinese, Engelse en Nederlandse tekens bevatten</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Naam wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Openen met</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Standaardprogramma kiezen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>De bestanden worden permanent verwijderd. Weet je zeker dat je wilt doorgaan?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Wil je het archief toevoegen aan de lijst of openen in een nieuw venster?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Openen in nieuw venster</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Archieven van dit bestandstype kunnen niet worden aangepast. Zet het archief om om de aanpassingen op te slaan.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Omzetten naar:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Converteren</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>item(s)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Het uitpakken is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Uitpakken mislukt: bestand is beschadigd.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Sleep een bestand of map hierheen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Bestand kiezen</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Het archief is beschadigd</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Openen als alleen-lezen</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Bezig met laden…</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Archiefbeheer</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Archiefbeheer is een snel en licht programma om archieven mee samen te stellen en uit te pakken.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Bestand openen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Archief samenstellen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Bezig met omzetten</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Bezig met bijwerken van opmerkingen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Plug-infout</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Toegevoegd</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Het archief is blanco</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Toevoegen afgebroken</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Toevoegen mislukt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Uitpakken mislukt: de bestandsnaam is te lang.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>‘%1’ kan niet worden aangemaakt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Openen mislukt: de bestandsnaam is te lang.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Inpakken voltooid</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>De bestandsnaam is te lang, dus alleen de eerste 60 tekens worden gebruikt.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Onvoldoende vrije schijfruimte</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Enkele schijven ontbreken</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Onjuist wachtwoord - probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>De bestandsnaam is te lang - voer niet meer dan 60 tekens in.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Het converteren is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Bestand kiezen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Voer maximaal %1 tekens in</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Bestandsinformatie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Wil je het archief verwijderen?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 is ondertussen aangepast. Open het bestand opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Archiefbeheer</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Je bent niet bevoegd om hier bestanden op te slaan. Kies een andere locatie.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Bezig met toevoegen aan %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Bezig met inpakken</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Bezig met uitpakken</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Bezig met verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Bezig met laden…</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Weet je zeker dat je de taak wilt afbreken?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Bezig met bijwerken…</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>De bestandsnaam is te lang</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Het bestand kan niet worden aangemaakt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Het inpakken is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Map zoeken</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Openen mislukt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Onjuist wachtwoord</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Dit bestandsformaat wordt niet ondersteund</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Naam wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Je bent niet bevoegd om %1 te laden</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Bestand of map bestaat niet</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Uitpakken voltooid</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Uitpakken afgebroken</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Het archief is beschadigd</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Uitpakken voltooid</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Omzetten voltooid</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>De gecomprimeerde volumes bestaan al</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Het uitpakken is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Hulp</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Sneltoetsen tonen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Sneltoetsen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>De naam is dezelfde als die van een ander archief. Kies een andere naam.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Er is al een bestand met deze naam. Wil je het vervangen?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Je kunt het archief niet toevoegen aan hetzelfde archief</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Je kunt geen bestanden toevoegen aan archieven met dit bestandstype.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Bijwerken</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Soort</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Locatie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Gemaakt om</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Geopend om</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Aangepast om</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archief</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Opmerking</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Controleer de bestandstoewijzing in de instellingen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Het archief is ondertussen aangepast. Open het opnieuw.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Map</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Programma</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Afbeelding</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archief</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Uitvoerbaar bestand</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Document</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Reservekopiebestand</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Onbekend</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Openen met</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Ander programma kiezen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Instellen als standaard</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Aanbevolen programma&apos;s</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Andere programma&apos;s</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Het bestand is versleuteld - voer het wachtwoord in.</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Huidig pad:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Terug naar ‘%1’</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>Er is/zijn %1 lopende taak/taken</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Taak</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Bezig met uitpakken</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Weet je zeker dat je het uitpakken wilt afbreken?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ja</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Bezig met berekenen…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Resterende tijd</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Bezig met inpakken</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Bezig met verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Naam wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Bezig met omzetten</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Bezig met bijwerken van opmerking…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Bezig met uitpakken</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Onderbreken</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Doorgaan</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Weet je zeker dat je het uitpakken wilt afbreken?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Weet je zeker dat je de verwijdering wilt afbreken?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Weet je zeker dat je het inpakken wilt afbreken?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Weet je zeker dat je het omzetten wilt afbreken?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Aangepast op</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Soort</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 is aangepast. Wil je de aanpassingen opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Uitpakken</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Automatisch een map aanmaken bij het uitpakken van meerdere bestanden</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Uitgepakte bestanden tonen in bestandsbeheerder</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Bestandsbeheer</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Bestanden na comprimeren verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Bestandstoewijzingen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Bestandstype</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Overslaan</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Samenvoegen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Er is al een bestand met deze naam. Wil je het vervangen?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Er is al een map met deze naam. Wil je deze vervangen?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Toepassen op alles</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Naam wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>Deze naam is al in gebruik</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Huidige map</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Alles wissen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Alles selecteren</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Aanbevolen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Archieven uitpakken naar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Andere map</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Bureaublad</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Archieven na uitpakken verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Nooit</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Vragen om bevestiging</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Altijd</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Inpakken voltooid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Bekijken</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Bestand openen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Bestandsinformatie</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Uitpakken in:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Uitpakken</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Het standaardpad bestaat niet. Probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Je bent niet bevoegd om hier bestanden op te slaan. Kies een andere locatie.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Map zoeken</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Je kunt het archief niet toevoegen aan hetzelfde archief</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Uitpakken</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Uitpakken in huidige map</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Naam wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Openen met</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Standaardprogramma kiezen</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Weet je zeker dat je de geselecteerde bestanden wilt verwijderen?</translation>
     </message>

--- a/translations/deepin-compressor_pl.ts
+++ b/translations/deepin-compressor_pl.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Dodaj pliki do bieżącego archiwum</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Użyj hasła</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Plik oryginalny %1 nie istnieje, sprawdź i spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 nie istnieje na dysku, sprawdź i spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nie posiadasz uprawnień, aby skompresować %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Błędne hasło</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Aktualizowanie komentarza...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Dalej</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Dodaj pliki</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Nowe archiwum</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Opcje zaawansowane</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Metoda kompresji</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Zaszyfruj archiwum</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Rdzeni CPU</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Zaszyfruj także listę plików</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Podziel na woluminy</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Komentarz</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Skompresuj</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Przechowanie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Szybsza</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Szybka</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normalna</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Dokładna</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Najdokładniejsza</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Pojedynczy rdzeń</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 rdzenie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 rdzenie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 rdzeni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Obsługuje tylko zip, 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Obsługuje tylko typ 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Wprowadź maksymalnie %1 znaków</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Zapisz do</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Nieprawidłowa nazwa pliku</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Wprowadź ścieżkę</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Ścieżka nie istnieje, spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nie posiadasz uprawnień do zapisywania plików tutaj, zmień ścieżkę i spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Za dużo woluminów, zmień i spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 nie istnieje na dysku, sprawdź i spróbuj ponownie </translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nie posiadasz uprawnień do kompresji %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Plik oryginalny %1 nie istnieje, sprawdź i spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Zastąp</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Całkowity rozmiar: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Użyta nazwa jest taka sama jak skompresowanego archiwum, użyj innej</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Hasło dla wolumenów ZIP nie może być w języku Chińskim</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Istnieje już inny plik o tej samej nazwie, czy chcesz go zastąpić?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Obsługiwane są tylko znaki chińskie i angielskie oraz niektóre symbole</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Zmień nazwę</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Otwórz za pomocą</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Wybierz program domyślny</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Spowoduje to permanentne usunięcie plik(ów). Czy na pewno chcesz kontynuować?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potwierdź</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Dodaj</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Czy chcesz dodać archiwum do listy lub otworzyć je w nowym oknie?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Otwórz w nowym oknie</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Zmiany w archiwach w tym typie plików nie są obsługiwane. Przekonwertuj format archiwum, aby zapisać zmiany.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Konwertuj format na:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Konwertuj</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>przedmiot(ów)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Wypakowanie nie powiodło się</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Uszkodzony plik, nie można wypakować</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Ponów</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Wstecz</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Przeciągnij tutaj plik lub katalog</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Wybierz plik</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Archiwum jest uszkodzone</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Otwórz jako tylko-do-odczytu</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Ładowanie, proszę czekać...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Zarządzanie archiwami</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Zarządzanie archiwami to szybka i lekka aplikacja do tworzenia i wypakowywania archiwów.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Otwórz plik</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Utwórz nowe archiwum</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Konwertuję</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Aktualizowanie komentarzy</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Błąd wtyczki</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Dodawanie zakończone pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Brak w nim danych</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Anulowano dodawanie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Nie udało się dodać</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Wypakowanie nie powiodło się: nazwa pliku jest za długa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Nie udało się utworzyć &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Otwieranie nieudane: nazwa pliku jest za długa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Skompresowano pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Nazwa pliku jest za długa, pierwsze 60 znaków zostało wykorzystanych do stworzenia nazwy.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Za mało miejsca na dysku</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Brakuje niektórych woluminów</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Błędne hasło, spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Nazwa pliku jest za długa, prosimy o zmieszczenie się w limicie 60 znaków.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Konwersja nie powiodła się</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Wybierz plik</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Wprowadź maksymalnie %1 znaków</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Informacje o pliku</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Czy chcesz usunąć to archiwum?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 został zmieniony na dysku, zaimportuj go ponownie.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Zarządzanie archiwami</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nie posiadasz uprawnień do zapisywania plików tutaj, zmień ścieżkę i spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Dodawanie plików do %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Kompresowanie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Wypakowywanie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Usuwanie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Ładowanie, proszę czekać...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Czy na pewno chcesz przerwać zadanie w toku?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Aktualizuję, proszę czekać...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Nazwa pliku jest za długa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Nie udało się utworzyć pliku</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Kompresja nie powiodła się</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Zastąp</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Znajdź katalog</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Nie udało się otworzyć</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Błędne hasło</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Format pliku nie jest obsługiwany przez Zarządzanie Archiwami</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Zmienianie nazwy</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Nie posiadasz uprawnień do załadowania %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potwierdź</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Nie ma takiego pliku lub katalogu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Wypakowano pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Wypakowanie anulowane</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Archiwum jest uszkodzone</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Wypakowano pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Konwersja zakończona pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Skompresowane woluminy już istnieją</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Wypakowanie nie powiodło się</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Wyświetl skróty</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Skróty</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Użyta nazwa jest taka sama jak skompresowanego archiwum, użyj innej</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Istnieje już inny plik o tej samej nazwie, czy chcesz go zastąpić?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Nie możesz dodać archiwum do siebie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Nie można dodawać plików do archiwów w tym typie plików</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aktualizowanie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Informacje podstawowe</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Położenie</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Data utworzenia</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Ostatni dostęp</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Data modyfikacji</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Archiwum</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Komentarz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Sprawdź typ skojarzenia plików w ustawieniach Zarządzania Archiwami</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Archiwum zostało zmienione na dysku, zaimportuj je ponownie.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Katalog</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Program</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Film</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Obraz</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Archiwum</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Plik wykonywalny</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Dokument</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Plik kopii zapasowej</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Nieznane</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Otwórz za pomocą</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Dodaj inne programy</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Ustaw jako domyślne</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potwierdź</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Zalecane aplikacje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Inne aplikacje</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Plik zaszyfrowany, wprowadź hasło</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Obecna ścieżka:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Wróć do: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 zadanie(a) w toku</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Zadanie</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Wypakowywanie</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Czy na pewno chcesz zatrzymać wypakowywanie?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potwierdź</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Obliczenie...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Pozostało</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Kompresowanie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Usuwanie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Zmienianie nazwy</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Konwertuję</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Aktualizuję komentarz...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Wypakowywanie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Wstrzymaj</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Kontynuuj</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Zatwierdź</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Czy na pewno chcesz zatrzymać dekompresję?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Czy na pewno chcesz zatrzymać usuwanie?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Czy na pewno chcesz zatrzymać kompresję?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Czy na pewno chcesz zatrzymać konwersję?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Data modyfikacji</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 został zmieniony. Czy chcesz zapisać zmiany w archiwum? </translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Ogólne</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Wypakowywanie</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Automatycznie utwórz katalog dla wielu wyodrębnionych plików</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Pokaż wypakowane pliki po zakończeniu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Zarządzanie plikami</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Usuń pliki po kompresji</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Skojarzenia plików</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Typy plików</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Pomiń</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Scal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Istnieje już inny plik o tej samej nazwie, czy chcesz go zastąpić?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Zastąp</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Istnieje już inny katalog o tej samej nazwie, czy chcesz go zastąpić?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Zastosuj do wszystkich</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Zmień nazwę</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>Taka nazwa już istnieje</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Obecny katalog</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Wyczyść wszystko</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Zalecane</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Wypakuj archiwa do</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Inny katalog</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Pulpit</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Usuń archiwa po wypakowaniu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Nigdy</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Poproś o potwierdzenie</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Zawsze</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Skompresowano pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Podgląd</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Wstecz</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Otwórz plik</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Wstecz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Informacje o pliku</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Wypakuj do:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Wypakuj</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Domyślna ścieżka wypakowania nie istnieje, spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nie posiadasz uprawnień do zapisywania plików tutaj, zmień ścieżkę i spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Znajdź katalog</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Nie możesz dodać archiwum do samego siebie</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Wypakuj</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Wypakuj do bieżącego katalogu</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Zmień nazwę</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Otwórz za pomocą</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Wybierz program domyślny</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Zatwierdź</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Czy chcesz usunąć wybrane plik(i)?</translation>
     </message>

--- a/translations/deepin-compressor_pt.ts
+++ b/translations/deepin-compressor_pt.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Adicionar ficheiros ao arquivo atual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Usar palavra-passe</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>O ficheiro original de %1 não existe. Verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 não existe no disco. Verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Não tem permissão para comprimir %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Palavra-passe incorreta</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>A atualizar o comentário...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Seguinte</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Adicione ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Novo arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Opções avançadas</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Método de compressão</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Encriptar o arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Threads da CPU</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Encriptar a lista de ficheiros também</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Dividir em volumes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Comentário</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Comprimir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Armazenar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Mais rápido</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Rápido</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Bom</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Melhor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Thread único</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 threads</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Apenas suporta o formato zip e 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Apenas suporta o formato 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Introduzir até %1 caracteres</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Guardar para</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Nome de ficheiro inválido</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Introduza o caminho</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>O caminho não existe, tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Não tem permissão para guardar ficheiros aqui, mude e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Demasiados volumes, mude e tente de novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 não existe no disco, verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Não tem permissão para comprimir %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>O ficheiro original de %1 não existe, verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Tamanho total: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>O nome é o mesmo que o do arquivo comprimido, use outro</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>A palavra-passe para volumes ZIP não pode ser em chinês</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Já existe outro ficheiro com o mesmo nome, substituir?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Apenas caracteres chineses e ingleses e alguns símbolos são suportados</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Abrir com</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Selecione o programa predefinido</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Eliminará permanentemente o(s) ficheiro(s). Tem a certeza que deseja continuar?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Deseja adicionar o arquivo à lista ou abri-lo numa nova janela?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Abrir em nova janela</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>As alterações a arquivos neste tipo de ficheiro não são suportadas. Converta o formato do arquivo para guardar as alterações.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Converter o formato para:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Converter</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>item(ns)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Extração falhou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Ficheiro danificado. Incapaz de extrair</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Tentar novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Voltar</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Arraste o ficheiro ou pasta para aqui</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Selecione o ficheiro</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>O arquivo está corrompido</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Abrir como apenas-leitura</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>A carregar, aguarde...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Gestor de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>O Gestor de Arquivos é uma aplicação rápida e leve para a criação e extração de arquivos.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Abrir ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Criar novo arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>A converter</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Atualização de comentários</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Erro de plugin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Adicionado com sucesso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Não contém dados</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Adição cancelada</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Adição falhou</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Falha ao extrair: o nome do ficheiro é muito comprido</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Falha ao criar &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Falha ao abrir: o nome do ficheiro é muito comprido</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Compressão concluída</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>O nome do ficheiro é demasiado comprido, pelo que os primeiros 60 caracteres foram interceptados como o nome do ficheiro.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Espaço insuficiente em disco</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Alguns volumes estão em falta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Palavra-passe incorreta, tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>O nome do ficheiro é demasiado comprido. Manter o nome dentro de 60 caracteres.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Falha ao converter</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Selecionar ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Introduzir até %1 caracteres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Informação do ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Deseja eliminar o arquivo?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 foi mudado no disco, importe-o novamente.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Gestor de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Não tem permissão para guardar ficheiros aqui, mude e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Adicionar ficheiros a %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>A comprimir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>A extrair</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>A eliminar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>A carregar, aguarde...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Tem a certeza que deseja parar a tarefa em curso?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>A atualizar, aguarde...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Nome do ficheiro demasiado comprido</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Falha ao criar ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>A compressão falhou</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Localizar diretório</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Falha ao abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Palavra-passe incorreta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>O formato do ficheiro não é suportado pelo Gestor de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>A renomear</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Não tem permissão para carregar %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Não existe tal ficheiro ou diretório</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Extração concluída</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Extração cancelada</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>O arquivo está danificado</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Extração concluída</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Conversão bem sucedida</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Os volumes comprimidos já existem</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Extração falhou</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atalhos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Atalhos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>O nome é o mesmo que o do arquivo comprimido, use outro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Já existe outro ficheiro com o mesmo nome, substituir?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Não pode adicionar o arquivo a ele mesmo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Não é possível adicionar ficheiros a arquivos neste tipo de ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Informação básica</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Localização</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Data de criação</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Data de acesso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Data de modificação</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Comentário</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Verifique o tipo de associação de ficheiro nas definições do Gestor de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>O arquivo foi mudado no disco, importe-o novamente.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Diretório</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Aplicação</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Áudio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Imagem</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Executável</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Documento</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Ficheiro de cópia de segurança</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Desconhecido</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Abrir com</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Adicionar outros programas</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Definir como predefinido</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Aplicações recomendadas</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Outras aplicações</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Ficheiro encriptado. Introduza a palavra-passe</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Caminho atual:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Voltar a: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 tarefa(s) em andamento</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Tarefa</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>A extrair</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Tem a certeza que deseja parar a extração?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>A calcular...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Tempo restante</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>A comprimir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>A eliminar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>A renomear</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>A converter</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>A atualizar o comentário...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>A extrair</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pausa</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Tem a certeza de que deseja parar a descompressão?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Tem a certeza que deseja parar a eliminação?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Tem a certeza que deseja parar a compressão?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Tem a certeza que deseja parar a conversão?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Data de modificação</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 alterado. Deseja guardar as alterações no arquivo?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Geral</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Extração</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Criação automática de uma pasta para vários ficheiros extraídos</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Mostrar ficheiros extraídos quando concluído</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Gestão de Ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Eliminar ficheiros após compressão</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Ficheiros associados</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Tipo de ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Ignorar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Unir</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Já existe outro ficheiro com o mesmo nome, substituir?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Já existe outra pasta com o mesmo nome, substituí-la?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Aplicar a tudo</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>O nome já existe</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Diretório atual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Apagar tudo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Recomendado</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Extrair arquivos para</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Outro diretório</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Ambiente de trabalho</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Eliminar arquivos após compressão</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Nunca</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Pedido de confirmação</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Sempre</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Compressão concluída</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Voltar</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Abrir ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Voltar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Informação do ficheiro</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Extrair para:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Extrair</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>O caminho de extração predefinido não existe, tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Não tem permissão para guardar ficheiros aqui, mude e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Localizar diretório</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Não se pode acrescentar o arquivo a ele mesmo</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Extrair</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Extrair para o directório atual</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Abrir com</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Selecione o programa predefinido</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Deseja eliminar o(s) ficheiro(s) selecionado(s)?</translation>
     </message>

--- a/translations/deepin-compressor_pt_BR.ts
+++ b/translations/deepin-compressor_pt_BR.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Adicionar arquivos ao arquivo atual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Usar senha</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>O arquivo original de %1 não existe; verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 não existe no disco; verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Você não tem permissão para comprimir %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Senha incorreta</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Atualizando o comentário...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Adicione os arquivos</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Novo Arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Opções Avançadas</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Método de compressão</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Criptografar o arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Núcleos do processador</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Criptografar também a lista de arquivos</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Dividir em volumes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Comentário</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Comprimir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Loja</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Mais rápido</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Rápido</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Bom</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Melhor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>1 Núcleo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 Núcleos</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 Núcleos</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 Núcleos</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Suporta apenas .zip e .7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Suporta apenas .7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Insira até %1 caracteres</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Salvar em</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Nome de arquivo inválido</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Insira o caminho</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>O caminho não existe; tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Você não tem permissão para salvar os arquivos aqui; altere e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Há muitos volumes; altere e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 não existe no disco; verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Você não tem permissão para comprimir %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>O arquivo original de %1 não existe; verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Tamanho total: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>O nome é o mesmo que o do arquivo comprimido; use outro</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>A senha para arquivos ZIP não pode estar em Chinês</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Já existe um outro arquivo com o mesmo nome. Substituí-lo?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Apenas caracteres chineses / ingleses e alguns símbolos são suportados</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Abrir com</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Selecionar o aplicativo padrão</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Isso excluirá permanentemente o(s) arquivo(s). Continuar?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Adicionar o arquivo à lista ou abri-lo em uma nova janela?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Abrir em nova janela</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>As alterações nos arquivos deste formato não são suportadas. Para salvar as alterações, converta o arquivo para outro formato.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Converter o formato para:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Converter</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>item(ns)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>A extração falhou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Arquivo danificado, impossível extrair</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Tentar novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Voltar</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Arraste o Arquivo ou Pasta até aqui</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Selecionar Arquivo</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>O arquivo está danificado</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Abrir como somente leitura</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Carregando, aguarde...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Gerenciador de Compressão</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>O Gerenciador de Compressão é um aplicativo rápido e leve para comprimir e extrair arquivos.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Abrir arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Criar Novo Arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Convertendo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Atualizando comentários</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Erro de plugin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Adição bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Não há dados</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Adição cancelada</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>A adição falhou</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Falha na extração: o nome do arquivo é muito longo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Falha ao criar &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Falha ao abrir: o nome do arquivo é muito longo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Compressão bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>O nome do arquivo é muito longo, então os primeiros 60 caracteres foram interceptados como o nome do arquivo.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Espaço insuficiente em disco</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Alguns volumes estão ausentes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Senha incorreta; tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>O nome do arquivo é muito longo. Mantenha o nome dentro de 60 caracteres, por favor.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Falha na conversão</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Selecionar arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Insira até %1 caracteres</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Informações do arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Excluir arquivo?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 foi alterado no disco; importe-o novamente.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Gerenciador de Compressão</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Você não tem permissão para salvar os arquivos aqui; altere e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Adicionando os arquivos a %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Comprimindo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Extraindo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Excluindo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Carregando, aguarde...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Interromper a tarefa em andamento?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Atualizando, aguarde...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>O nome do arquivo é muito longo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Falha ao criar arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>A compressão falhou</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Pesquisar diretório</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>A abertura falhou</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Senha incorreta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>O formato do arquivo não é compatível com o Gerenciador de Compressão</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Você não tem permissão para carregar %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Nenhum arquivo ou diretório</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>A extração foi bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>A extração foi cancelada</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>O arquivo está danificado</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>A extração foi bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Conversão bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>A extração falhou</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Exibir atalhos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Atalhos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>O nome é o mesmo que o do arquivo comprimido; use outro</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Já existe um outro arquivo com o mesmo nome. Substituí-lo?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Não é possível adicionar o arquivo a si mesmo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Você não pode adicionar os arquivos a este tipo de arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Informações básicas</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Localização</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Data da criação</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Último acesso</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Última modificação</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Comentário</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Verifique o tipo de associação do arquivo nas configurações do Gerenciador de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>O arquivo foi alterado no disco; importe-o novamente.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Diretório</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Aplicativo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Áudio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Imagem</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Executável</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Documento</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Arquivo de backup</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Desconhecido</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Abrir com</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Adicionar outro aplicativo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Definir como padrão</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Aplicativos Recomendados</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Outros Aplicativos</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Arquivo criptografado; insira a senha</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Caminho atual:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Voltar para: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 tarefa(s) em andamento</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Tarefa</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Extraindo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Interromper a extração?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Calculando...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Tempo restante</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Comprimindo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Excluindo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Convertendo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Atualizando o comentário...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Extraindo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pausar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Interromper a descompressão?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Interromper a exclusão?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Interromper a compressão?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Interromper a conversão?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Última modificação</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 alterou. Salvar as alterações no arquivo?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Geral</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Extração</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Criar automaticamente uma pasta para os múltiplos arquivos extraídos</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Exibir os arquivos extraídos ao concluir</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Gerenciamento de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Excluir os arquivos após compressão</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Arquivos Associados</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Tipo de Arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Pular</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Mesclar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Já existe um outro arquivo com o mesmo nome. Substituí-lo?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Já existe outra pasta com o mesmo nome; substituí-la?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Aplicar a todos</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Ok</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Diretório atual</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Limpar Tudo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Recomendado</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Extrair arquivos para</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Outro diretório</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Área de Trabalho</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Excluir os arquivos após a extração</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Nunca</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Solicitar confirmação</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Sempre</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Compressão bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Visualizar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Voltar</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abrir arquivo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Voltar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Informações do arquivo</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Extrair para:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Extrair</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>O caminho de extração padrão não existe; tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Não há permissão para salvar arquivos aqui; altere e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Encontrar diretório</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Não é possível adicionar o arquivo a si mesmo</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Extrair</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Extrair no diretório atual</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Abrir com</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Selecionar o aplicativo padrão</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Excluir o(s) arquivo(s) selecionado(s)?</translation>
     </message>

--- a/translations/deepin-compressor_ro.ts
+++ b/translations/deepin-compressor_ro.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ro">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ro">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Adaugă fișiere în această arhivă</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Utilizează parola</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Fișierul original %1 nu există, vă rugăm să verificați și incercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 nu există pe disc, vă rugăm să verificați și să încercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nu aveți permisiunea de a comprima  %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Parola eronată</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Actualizare comentariu</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Următorul</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Adăugați, vă rog, fișiere</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Arhiva nouă</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Opțiuni avansate</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Metodă comprimare</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Criptare arhivă</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Șiruri CPU</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Criptare listei de fișiere</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Divizare în volume</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Comentariu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Comprimare</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Stocare</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Cel mai rapid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Rapid</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Bun</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Cel mai bun</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Singur șir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 șiruri</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 șiruri</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 șiruri</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Se acceptă doar tipul zip, 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Se acceptă doar tipul 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Introduceți până la %1 caractere</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Salvează pe</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Nume fișier nevalabil</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Introduceți, vă rog cale</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Această cale nu există, vă rugăm să încercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nu aveți permisiunea de a salva fișiere aici, schimbați vă rog, destinație și încercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Prea multe volume, micșorați vă rog,  numărul și încercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 nu există pe disc, vă rugăm să verificați și să încercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nu aveți permisiunea de a comprima  %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Fișierul original %1 nu există, vă rugăm să verificați și incercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Înlocuire</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Mărimea totală: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Nume fișier coincide cu numele arhivei comprimate, vă rugăm să utilizați alt nume</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Parola volumelor ZIP nu poate fi în chineză</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Fișier cu același nume deja există, doriți să-l înlocuiți?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Doar caractere chineze și engleze și unele altele sunt suportate</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Deschide</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Șterge</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Deschide cu</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Selectați programul implicit</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Această operațiune va șterge pentru totdeauna fișier(ele) selectate. Doriți să procedați?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmare</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Adăugare</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Doriți să adăugați arhiva pe listă sau să-o deschideți în fereastra nouă?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Deschide în fereastra nouă</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Modificările în arhivă a fișierelor de acest tip nu sunt acceptabile. Vă rugăm să efectuați convertirea arhivelor în alt format ca shimbările să aibă loc.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Convertirea formatului în:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Convertire</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>element(e)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation> Extragere eșuată</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Fișier deteriorat, imposibil de extras</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Încercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Trageți fișierul sau dosarul aici</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Selectare fișier</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Arhivă deteriorată</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Deschide doar pentru citire</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Se încarcă, așteptați, vă rog</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Managerul de Arhive</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Managerul de Arhive - este o aplicație rapidă și ușoară pentru crearea și extragerea arhivelor.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Deschidere fișier</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Creare arhivă nouă</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Convertare</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Actualizare comentarii</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Plugin eroare</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Adăugare cu succes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Lipsesc datele</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Adăugare anulată</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Adăugare eșuată</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Eșuare extragerea fișierului: denumirea prea lungă</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Eșuarea crearea &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Eșuare deschiderii fișierului: denumirea prea lungă</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Comprimare cu succes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Nume fișier prea lung, doar primele 60 de caractere vor fi folosite ca denumire.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Insuficient spațiu de stocare</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Câteva volume lipsesc</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Parola eronată, încercați vă rog, din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Nume fișier prea lung, acesta trebiue să conțină până 60 de caractere.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Convertire eșuată</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Selectare fișier</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Introduceți până la %1 caractere</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Informație fișier</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Doriți să ștergeți arhiva?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1  a fost modificat pe disc, vă rog repetați procedura de import</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Managerul de Arhive</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nu aveți permisiunea de a salva fișiere aici, schimbați vă rog destinație și încercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Adăugarea fișierelor pe %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Comprimarea</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Extragerea</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Ștergere</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Se încarcă, așteptați, vă rog</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Doriți să stopați procesul în derulare?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Actualizare, așteptați, vă rog...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Nume fișier prea lung</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Eșuare creare fișierului</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Comprimare eșuată</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Înlocuire</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Găsește directoriul</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Deschidere eșuată</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Parola eronată</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Acest format de fișier nu este suportat de Manager de Arhivă</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Nu aveți permisiunea de a încărca %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmare</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Nu există astfel de fișier sau directoriu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Extragere cu succes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation> Extragere  anulată</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Arhivă este deteriorată</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Extragere cu succes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Convertare cu succes</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation> Extragere eșuată</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Închide</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Ajutor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Șterge</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Afișare  comenzi rapide</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Comenzi rapide</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Nume fișier coincide cu numele arhivei comprimate, vă rugăm să utilizați alt nume</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Fișier cu așa nume deja există, să-l înlocuiesc?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Nu puteți să adăugați arhiva în ea însuși </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Nu puteți adăuga fișiere de așa tip în arhivă</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Actualizare</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Informație generală</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Mărime</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Locație</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Timpul creării</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Timpul accesării</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Timpul modificării</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arhivă</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Comentariu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Verificați tipul de asociere a fișierelor în setările Managerului de Arhive</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Arhiva a fost modificată pe disc, procedați repetat la importarea ei.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Directoriul</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Aplicație</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Imagine</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arhivă</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Executabil</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Document</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Fișier de rezervă</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Necunoscut</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Deschide cu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Adăugare alte programe</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Setează ca implicit</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmare</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Aplicații recomandate</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Alte Aplicații</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Fișier criptat, introduceți vă rog, parola</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Cale curentă:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Înapoi la: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1  sarcină(e) în derulare</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Sarcină</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Extragerea</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Doriți să stopați procesul de extragere?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmare</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Calculare...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Viteză</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Timpul rămas</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Comprimarea</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Ștergere</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Convertare</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Actualizare comentariu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Extragerea</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pauză</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continuare</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmare</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Doriți să stopați procesul de decomprimare?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Doriți să stopați procesul de ștergere?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Doriți să stopați procesul de comprimare?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Doriți să stopați procesul de convertire?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Timpul modificării</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Mărime</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1  modificat. Doriți să salvați modificările la arhivă?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Comun</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Extragere</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Creare în mod automat a  directoriului pentru mai multe fișiere extrase</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Afișare fișiere extrase la terminarea procesului</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Managementul fișierelor</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Ștergerea fișierelor după comprimarea acestora</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Fișiere asociate</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Tip de fișier</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Ignoră</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Combinare</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Fișier cu așa nume deja există, doriți să-l înlocuiți?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Înlocuire</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Directoriul cu așa nume deja există, doriți să-l înlocuiți?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Aplică la tot</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Directoriul curent</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Golește tot</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Selectează tot</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Recomandat</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Extrage arhivele la</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Alt directoriu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Masa de lucru</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Șterge arhivele după extragere</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Niciodată</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Întreabă pentru confirmare</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Întotdeauna</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Comprimare cu succes</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Vizualizare</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Deschidere fișier</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Înapoi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Informație fișier</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Extrage la:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Extrage</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Cale implicită de extragere nu există, încercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nu aveți permisiunea de a salva fișiere aici, schimbați vă rog destinație și încercați din nou</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Găsiți directoriul</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Nu puteți să adăugați arhiva în ea însuși </translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Extrage</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Extragere în directoriul curent</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Deschide</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Șterge</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Deschide cu</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Selectați programul implicit</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Confirmare</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Doriți să ștergeți fișier(ele) selectate?</translation>
     </message>

--- a/translations/deepin-compressor_ru.ts
+++ b/translations/deepin-compressor_ru.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Добавить файлы в текущий архив</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Использовать пароль</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Исходный файл %1 отсутствует, пожалуйста, проверьте и попробуйте ещё раз.</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 отсутствует на диске, пожалуйста, проверьте и попробуйте ещё раз</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>У вас нет разрешения на сжатие %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Неверный пароль</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Обновление комментария...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Следующий</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Пожалуйста, добавьте файлы</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Новый архив</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Дополнительные параметры</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Метод сжатия</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Зашифровать архив</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Потоки ЦП</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Также зашифровать список файлов</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Разделить на тома</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Комментарий</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Сжатие</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Хранение</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Самый быстрый</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Быстрый</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Обычный</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Хороший</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Лучший</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Один поток</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 потока</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 потока</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 потоков</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Поддерживаются только zip, 7z форматы</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Поддерживается только 7z формат</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Введите до %1 символов</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Сохранить в</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Неверное имя файла</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Пожалуйста, укажите путь</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Путь не существует, пожалуйста, повторите попытку</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>У вас нет разрешения на сохранение файлов здесь, измените и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Слишком много томов, измените и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 отсутствует на диске, пожалуйста, проверьте еще раз и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>У вас нет разрешения на сжатие %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Отсутствует исходный файл %1 , пожалуйста, проверьте и повторите попытку</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Общий размер: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Имя совпадает с именем сжатого архива, пожалуйста, используйте другое имя</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Пароль для ZIP-архивов не может быть на китайском языке.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation> Файл с таким именем уже существует, заменить его?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Поддерживаются только китайские и английские символы и некоторые другие символы.</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Открыть с помощью</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Выбрать  приложение по умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Это безвозвратно удалит выбранный файл(ы), продолжить?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Подтвердить</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Хотите добавить архив в список или открыть его в новом окне?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Открыть в новом окне</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Изменения в архивах в этом типе файлов не поддерживаются.  Чтобы сохранить изменения, пожалуйста, преобразуйте формат архива.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Преобразовать формат в:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Преобразовать</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>элемент(ы)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Не удалось выполнить извлечение</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Файл поврежден, невозможно извлечь</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Повторить</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Перетащите сюда файл или папку</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Выберите файл</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Архив повреждён</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Открыть только для чтения</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Загрузка, пожалуйста подождите...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Менеджер Архивов</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Менеджер Архивов - это быстрое и легкое приложение для создания и извлечения архивов.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Создать Новый Архив</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Преобразование</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Обновление комментариев</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Ошибка плагина</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Добавление прошло успешно</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Не содержит данных</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Отмена добавления</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Ошибка  добавления</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Извлечение не удалось: слишком длинное имя файла</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Не удалось создать &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation> Не удалось открыть: слишком длинное имя файла</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Сжатие успешно завершено!</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Слишком длинное имя файла,  будут использованы только первые 60 символов в наименовании.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Недостаточно места на диске</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Некоторые тома отсутствуют</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Неверный пароль, пожалуйста, повторите попытку</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Имя файла слишком длинное. Пожалуйста, укажите имя длиной до 60 символов.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Ошибка преобразования</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Выбрать файл</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Введите до %1 символов</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Информация о файле</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Желаете удалить архив?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 был изменен на диске, пожалуйста, импортируйте его снова.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Менеджер Архивов</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>У вас нет разрешения на сохранение файлов, Пожалуйста измените путь и повторите  снова</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Копирование файлов в %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Сжатие</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Извлечение</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Стирание</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Загрузка, пожалуйста подождите...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Вы действительно хотите прервать процесс?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Обновление, пожалуйста подождите...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Слишком длинное имя файла</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Не удалось создать файл</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Не удалось выполнить сжатие</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Найти каталог</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Не удалось открыть</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Неверный пароль</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Формат данного файла не поддерживается в Archive Manager</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Переименование</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>У вас нет разрешения для загрузки %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Подтвердить</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Такого файла или каталога не существует</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Извлечение прошло успешно </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Извлечение отменено</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Архив повреждён</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Извлечение прошло успешно </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Преобразование прошло успешно</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Сжатые тома уже существуют</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Не удалось выполнить извлечение</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Помощь</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Показать комбинации клавиш</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Имя совпадает с именем сжатого архива, пожалуйста, используйте другое имя</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation> Файл с таким именем уже существует, заменить его?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Архив нельзя добавить сам в себя</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Нельзя добавить файлы данного типа в архив</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Основная информация</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Местоположение</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Время создания</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Время доступа</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Время изменения</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Архив</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Комментарий</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Пожалуйста, проверьте тип ассоциации файлов в настройках Менеджера Архивов</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Архив был изменен на диске, пожалуйста, импортируйте его снова.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Каталог</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Приложение</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Видео</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Изображение</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Архив</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Исполняемый файл</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Документ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Файл резервной копии</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Неизвестный</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Открыть с помощью</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Добавить другие программы</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Установить по умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Подтвердить</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Рекомендованные приложения</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Другие приложения</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Зашифрованный файл, пожалуйста, введите пароль</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Текущий путь:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Назад в: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 задач(и) выполняется</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Задача</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Извлечение</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Вы уверены, что хотите остановить извлечение?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Подтвердить</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Вычисление...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Осталось времени</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Сжатие</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Удаление</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Переименование</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Преобразование</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Обновление комментария</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Извлечение</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Приостановить</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Продолжить</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Подтвердить</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Вы действительно хотите прервать распаковку?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Вы уверены, что хотите остановить удаление?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Вы уверены, что хотите остановить сжатие?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Вы уверены что хотите прервать преобразование?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Время изменения</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 изменен. Вы хотите сохранить изменения в архиве?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Основное</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Извлечение</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Автоматическое создание папки для нескольких извлеченных файлов</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Показать извлеченные файлы по завершении</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Управление Файлами</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Удалить файлы после сжатия</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Связанные Файлы</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Тип Файла</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Пропустить</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Слияние</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation> Файл с таким именем уже существует, заменить его?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Замена</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Папка с таким именем уже существует, заменить ее?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Применить ко всем</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>Имя уже существует</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Текущий каталог</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Очистить Всё</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Выбрать Всё</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Рекомендуется</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Извлечь архивы в</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Другой каталог</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Рабочий стол</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Удалить архивы после извлечения</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Никогда</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Запросить подтверждение</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Всегда</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Сжатие успешно завершено!</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Просмотр</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Сведения о файле</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Извлечь в:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Извлечь</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Путь извлечения по умолчанию не существует, пожалуйста, повторите попытку</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>У вас нет разрешения на сохранение файлов здесь, пожалуйста, измените путь и повторите попытку.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Найти каталог</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Вы не можете добавить архив идентичного значения</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Извлечь</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Извлечь в текущий каталог</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Открыть с помощью</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Выберите  приложение по умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Подтвердить</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Удалить выбранный файл(ы)</translation>
     </message>

--- a/translations/deepin-compressor_sl.ts
+++ b/translations/deepin-compressor_sl.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Dodaj datoteke v trenutni arhiv</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Uporabi geslo</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Izvirna datoteka za %1 ne obstaja - preverite in poskusite znova</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 ne obstaja na disku - preverite in poskusite znova</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nimate pravic za stiskanje %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Napačno geslo</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Posodabljanje komentarja...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Naprej</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Dodajte datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>V redu</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Nov arhiv</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Napredne možnosti</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Način stiskanja</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Šifriraj arhiv</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Niti procesorja</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Šifriraj tudi seznam datotek</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Razdeli na nosilce</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Komentar</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Stisni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Shrani</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Najhitreje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Hitro</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Navadno</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Dobro</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Najboljše</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Posamična nit</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>4 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>8 threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>4 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>8 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Podpira zgolj zip in 7z datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Podpira zgolj 7z datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Vnesite do največ %1 znakov</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Shrani v</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Napačno ime datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Vnesite pot</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Pot ne obstaja. Poskusite znova.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nimate pravic za shranjevanje datotek na to mesto. Spremenite lokacijo in poskusite znova.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Preveč nosilcev. Spremenite število in poskusite znova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 ne obstaja na disku - preverite in poskusite znova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Nimate pravic za stiskanje %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Izvirna datoteka za %1 ne obstaja - preverite in poskusite znova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Skupna velikost: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Ime je enako imenu stisnjene datoteke. Uporabite drugo ime</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Gesla za ZIP nosilce ne morejo biti v kitajščini</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Obstaja druga datoteka s tem imenom. Ali naj jo zamenjam?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Podprti so le nagleški in kitajski znaki ter nekaj posebnih znakov</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Odpri</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Odpri z</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Določi privzeti program</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Datoteke bodo trajno izbrisane. Aii želite nadaljevati?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potrdi</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Dodaj</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Želite arhiv dodati v seznam ali ga želite odpreti v novem oknu?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Odpri v novem oknu</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Za to vrsto datotek spreminjanje arhivov ni podprto. Pretvorite vrsto arhiva, da bi shranili spremembe.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Pretvori format v:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Pretvori</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>Predmet(ov)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Razširanje ni uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Poškodovana datoteka, razširjanje ni možno</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Ponovi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Nazaj</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Sem povlecite datoteko ali imenik</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Izberite datoteko</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Arhiv je poškodovan</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Odpri samo za branje</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Nalagam, počakajte...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Upravitelj arhivov</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Upravitelj arhivov je hiter in lahek program za ustvarjanje in razširjanje arhivov.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Odpri datoteko</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Nastavitve</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Ustvari nov arhiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Pretvarjanje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Posodabljanje komentarjev</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Napaka vtičnika</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Dodajanje je uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Ne vsebuje podatkov</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Dodajanje je bilo prekinjeno</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Dodajanje ni uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Neuspelo ustvarjanje &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Stiskanje je uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Na disku ni dovolj prostora</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Nekateri pogoni manjkajo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Napačno geslo, poskusite znova</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Izberite datoteko</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Vnesite do %1 znakov</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Podatki o datoteki</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Ali želite izbrisati arhiv?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 na disku je bil spremenjen. Uvozite ga znova.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Upravitelj arhivov</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nimate pravic za shranjevanje na to mesto. Spremenite lokacijo in poskusite znova.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Dodajanje datotek v %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Stiskanje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Razširjanje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Brisanje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Nalaganje, počakajte...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Želite zaustaviti trenutno opravilo?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Posodabljanje. Počakajte...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Predolgo ime datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Neuspešno ustvarjanje datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Stiskanje ni uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Poišči mapo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Odpiranje ni uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Napačno geslo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Upravitelj arhivov ne podpira formata datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Nimate dovoljenja za nalaganje %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potrdi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Datoteka li mapa ne obstaja</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Razširjanje je uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Razširjanje je bilo prekinjeno</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Arhiv je poškodovan</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Razširjanje je uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Pretvorba je uspela</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Razširanje ni uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Zapri</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Pomoč</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Prikaži bljižnice</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Bljižnice</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Ime je enako imenu stisnjene datoteke. Uporabite drugo ime</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Obstaja druga datoteka s tem imenom. Ali naj jo zamenjam?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Arhiva ne morete dodajati samega vase</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Arhivom ne morete dodajati datotek te vrste</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Posodobi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Osnovni podatki</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Vrsta</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Lokacija</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Čas stvarjenja</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Čas dostopa</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Čas spremembe</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arhiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Komentar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Preverite povezano vrsto datotek v nastavitvah Upravitelja arhivov</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Arhiv na disku je bil spremenjen. Uvozite ga znova.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Mapa</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Program</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Zvok</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Posnetek</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arhiv</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Zagonska</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Dokument</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Varnostna datoteka</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>neznan</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Odpri z</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Dodaj druge programe</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Določi za privzeto</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potrdi</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Priporočeni programi</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Drugi programi</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Šifirirana datoteka, vnesite geslo</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Trenutna pot:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Nazaj na: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>Izvaja se %1 opravil</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Opravilo</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Razširjam</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Ali želite zaustaviti razširjanje?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potrdi</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Preračunavanje...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Preostali čas</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Stiskam</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Brisanje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Pretvarjanje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Posodabljanje komentarja...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Razširjanje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Premor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Nadaljuj</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potrdi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Želite res zaustaviti razširjanje?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Želite res zaustaviti brisanje?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Ali želite zaustaviti stiskanje?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Želite zaustaviti pretvorbo?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Čas spremembe</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Vrsta</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>Sprememba v %1. Želite shraniti spremembe v arhiv?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Splošno</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Razširjanje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Samodejno ustvari mapo za več razširjenih datotek</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Ko končaš, prikaži razširjene datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Upravljanje datotek</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Po stiskanju izbriši datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Povezane datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Vrsta datoteke</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Preskoči</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Združi</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Obstaja druga datoteka s tem imenom. Ali naj jo zamenjam?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Mapa s tem imenom že obstaja. Jo zamenjam?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Uveljavi na vseh</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">V redu</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Trenutni imenik</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Počisti vse</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Izberi vse</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Priporočeno</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Razširi arhive v</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Drug imenik</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Namizje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Po razširitvi izbriši arhiv</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Nikoli</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Vprašaj za potrditev</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Vedno</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Stiskanje je uspelo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Prikaz</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Nazaj</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Odpri datoteko</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Nazaj</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Podatki o datoteki</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Razširi v:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Razširi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Privzeta pot za razširitev ne obstaja. Poskusite znova</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Nimate pravic za shranjevanje na to mesto. Spremenite lokacijo in poskusite znova.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Iskanje mape</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Arhiva ne morete dodajati samega vase</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Razširi</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Razširi v trenutni imenik</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Odpri</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Odpri z</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Določi privzeti program</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Potrdi</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Želite izbrisati izbrane datoteke?</translation>
     </message>

--- a/translations/deepin-compressor_sq.ts
+++ b/translations/deepin-compressor_sq.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Shtoni kartela te arkivi i tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Përdor fjalëkalim</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Kartela origjinale e %1 s’ekziston, ju lutemi, kontrolloni dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 s’ekziston në disk, ju lutemi, kontrolloni dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>S’keni leje për të ngjeshur %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Fjalëkalim i gabuar</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Po përditësohet komenti…</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Pasuesja</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Ju lutemi, shtoni kartela</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Arkiv i Ri</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Mundësi të Mëtejshme</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Metodë ngjeshjeje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Fshehtëzoje arkivin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Fshehtëzo edhe listën e kartelave</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Ndaje në vëllime</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Koment</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Ngjeshe</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Depozitoje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Më e shpejta</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>E shpejtë</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>E mirë</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Më e mira</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>2 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>4 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>8 threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>2 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>4 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>8 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Mbulo zip, vetëm të llojit 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Mbulo vetëm llojin 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Jepni deri %1 shenja</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Ruaje te</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Emër i pavlefshëm kartele</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Ju lutemi, jepni shtegun</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Shtegu s’ekziston, ju lutemi, riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>S’keni leje të ruani kartela këtu, ju lutemi, ndryshoni lejet dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Shumë vëllime, ju lutemi, ndryshojini dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 s’ekziston te disku, ju lutemi, kontrolloni dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>S’keni leje të ngjishni %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Kartela origjinale %1 s’ekziston, ju lutemi, kontrolloni dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Madhësi gjithsej: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Emri është i njëjtë me atë të arkivit të ngjeshur, ju lutemi, përdorni një tjetër</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Fjalëkalimi për vëllimet ZIP s’mund të jetë në kinezçe</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ka tashmë një kartelë me po atë emër, të zëvendësohet?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Mbulohen vetëm shenja të gjuhës kineze dhe të anglishtes, si dhe disa simbole</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Përzgjidhni kartelën</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Riemërtojeni</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Hape me</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Përzgjidhni program parazgjedhje</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Do të fshijë përgjithnjë kartelën(at). Jeni i sigurt se doni të vazhdohet?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ripohojeni</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Shtoje</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Doni të shtohet arkivi te lista apo të hapet në një dritare të re?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Hape në dritare të re</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Nuk mbulohet ndryshime te arkiva me këtë lloj kartelash. Që të ruhen ndryshimet, ju lutemi, shndërroni formatin e arkivit.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Shndërroje formatin në:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Shndërroje</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>objekt(e)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Përftimi dështoi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Kartelë e dëmtuar, s’arrihet të përftohet</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Mbrapsht</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Tërhiqni këtu kartelë ose dosje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Përzgjidhni Kartelë</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Arkivi është i dëmtuar</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Hape si vetëm-për-lexim</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Po ngarkohet, ju lutemi, pritni…</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Përgjegjës Arkivash</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Përgjegjësi i Kartelave është një aplikacion i shpejtë dhe i peshës së lehtë për krijim dhe përftim arkivash.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Hap kartelë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Krijoni Arkiv të Ri</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Po shndërrohet</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Po përditësohen komentet</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Gabim shtojce</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Shtim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>S’ka të dhëna në të</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Shtimi u anulua</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Shtimi dështoi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Përftim dështoi: emri i kartelës është shumë i gjatë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>S’u arrit të krijohet &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Hapja dështoi: emri i kartelës është shumë i gjatë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Ngjeshje e suksesshme</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Emri i kartelës është shumë i gjatë, ndaj si emri i kartelës janë dhënë 60 shenjat e para.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Hapësirë e pamjaftueshme disku</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Mungojnë disa vëllime</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Fjalëkalim i gabuar, ju lutemi, riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Emri i kartelës është shumë i gjatë. Ju lutemi, mbajeni emrin brenda 60 shenjave.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Shndërrimi dështoi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Përzgjidhni kartelë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Jepni deri %1 shenja</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Të dhëna kartele</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Doni të fshihet arkivi?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 ndryshoi në disk, ju lutemi, riimportojeni.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Përgjegjës Arkivash</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>S’keni leje të ruani kartela këtu, ju lutemi, ndryshoni lejet dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Po shtohen kartela te %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Po ngjishen</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Po përftohet</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Po fshihet</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Po ngarkohet, ju lutemi, pritni…</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Jeni i sigurt se doni të ndalet akti në xhirim e sipër?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Po përditësohet, ju lutemi, pritni…</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Emër kartele shumë i gjatë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>S’u arrit të krijohet kartelë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Ngjeshja dështoi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Gjej drejtori</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Hapja dështoi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Fjalëkalim i gabuar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Formati i kartelës nuk mbulohet nga Përgjegjësi i Arkivave</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Riemërtim</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>S’keni leje të ngarkoni%1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ripohojeni</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>S’ka kartelë ose drejtori të tillë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Përftim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Përftimi u anulua</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Arkivi është i dëmtuar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Përftim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Shndërrim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Vëllimet e ngjeshura ekzistojnë tashmë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Përftimi dështoi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Mbylle</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Ndihmë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Shfaq shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Emri është i njëjti me atë të arkivit të ngjeshur, ju lutemi, përdorni një tjetër</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ka tashmë një kartelë me po atë emër, të zëvendësohet?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>S’mund t’i shtoni arkivit vetveten</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>S’mund të shtoni kartela të këtij lloji te arkiva</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Përditësoje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Të dhëna bazë</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Lloj</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Vendndodhje</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Kohë kur u krijua</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Kohë kur u përdor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Kohë ndryshimi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arkiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Koment</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Ju lutemi, kontrolloni llojin e përshoqërimit të kartelës te rregullimet e Përgjegjësit të Arkivave</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Arkivi ndryshoi në disk, ju lutemi, riimportojeni.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Drejtori</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Aplikacion</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Figurë</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arkiv</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>E ekzekutueshme</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Dokument</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Kartelë kopjeruajtje</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>E panjohur</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Hape me</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Shtoni programe të tjera</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Caktoje si parazgjedhje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ripohojeni</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Aplikacione të Rekomanduar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Aplikacione të Tjera</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Kartelë e fshehtëzuar, ju lutemi, jepni fjalëkalimin</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Shtegu i tanishëm:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Mbrapsht te: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 punë(ra) në ecuri e sipër</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Punë</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Po përftohet</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Jeni i sigurt se dëshironi të ndalet përftimi?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ripohojeni</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Po llogariten…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Kohë e mbetur</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Po ngjishen</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Po fshihet</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Riemërtim</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Po shndërrohet</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Po përditësohet komenti…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Po përftohet</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Pushim</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Vazhdo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ripohojeni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Jeni i sigurt se doni të ndalet çngjeshja?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Jeni i sigurt se doni të ndalet fshirja?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Jeni i sigurt se dëshironi të ndalet ngjeshja?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Jeni i sigurt se doni të ndalet shndërrimi?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Kohë ndryshimi</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Lloj</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 ndryshoi. Doni të ruhen ndryshimet te arkivi?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Të përgjithshme</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Përftim</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Vetëkrijo një dosje për kartela të shumta të përftuara</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Shfaqi kartelat e përftuara, kur të plotësohet</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Administrim Kartelash</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Fshiji kartelat pas ngjeshjes</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Kartela të Përshoqëruara</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Lloj Kartele</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Anashkaloje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Përzieji</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Ka tashmë një kartelë me po atë emër, të zëvendësohet?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Ka tashmë një dosje me të njëjtin emër, të zëvendësohet?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Zbatoje për të tëra</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Riemërtojeni</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>Emri ekziston tashmë</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Drejtoria e tanishme</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Spastroji Krejt</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Përzgjidhi Krejt</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>E këshilluar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Përftoji arkivat te</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Drejtori tjetër</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Fshiji arkivat pas përftimit</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Kurrë</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Kërko ripohim</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Përherë</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Ngjeshje e suksesshme</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Shihni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Mbrapsht</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Hape kartelën</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Mbrapsht</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Hollësi kartele</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Përftoji te:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Përftoji</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Shtegu parazgjedhje i përftimeve s’ekziston, ju lutemi, riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>S’keni leje të ruani kartela këtu, ju lutemi, ndryshoni lejet dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Gjej drejtori</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>S’mund ta shtoni arkivin te vetvetja</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Përftoji</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Përftoji te drejtoria e tanishme</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Përzgjidhni kartelën</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Riemërtojeni</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Hape me</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Përzgjidhni program parazgjedhje</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Ripohojeni</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Doni të fshihet kartelat(t) e përzgjedhur?</translation>
     </message>

--- a/translations/deepin-compressor_sr.ts
+++ b/translations/deepin-compressor_sr.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Додај датотеке у тренутну архиву</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Користи лозинку</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Првобитна датотека од %1 не постоји, проверите и поново покушајте</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 не постоји на диску, проверите и поново покушајте</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Немате дозволу да запакујете %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Погрешна лозинка</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Ажурирање коментара...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Следеће</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Додајте датотеке</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Нова архива</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Напредне опције</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Поступак запакивања</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Шифруј архиву</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Шифруј и списак датотека</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Раздвој на делове</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Коментар</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Запакуј</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Неуспешно отварање</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Најбрже</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Брзо</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Уобичајено</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Добро</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Најбоље</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>2 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>4 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>8 threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>2 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>4 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>8 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Подржава само zip, 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Подржава само 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Унесите до %1 карактера</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Име</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Сачувај у</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Неважеће име датотеке</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Молимо унесите путању</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Путања не постоји, покушајте поново</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Немате дозволу да овде сачувате датотеке, направите промену и покушајте поново</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Превише делова, направите промену и покушајте поново</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 не постоји на диску, проверите и поново покушајте</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Немате дозволу да запакујете %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Првобитна датотека од %1 не постоји, проверите и поново покушајте</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Замени</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Укупна величина: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Име је исто као од запаковане архиве, употребите друго име</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Лозинка за ZIP складишта не може бити на кинеском</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Датотека под истим називом већ постоји. Заменити?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Подржани су само енглески и кинески карактери и један број симбола</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Отвори</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Обриши</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Отвори са</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Изабери подразумевани програм</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Радња ће трајно обрисати датотеке. Заиста желите да наставите?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Потврди</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Додај</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Желите ли да додате архиву на спиисак или да је отворите у новом прозору?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Отвори у новом прозору</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Промене у архивама ове врсте датотека нису подржане. Промените формат архиве да сачувате измене.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Претвори формат у:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Претвори</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>ставки(е)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Неуспешно распакивање</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Оштећена датотека, немогуће распаковати</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Поново покушај</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Превуци датотеку или фасциклу овде</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Изабери датотеку</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Архива је оштећена</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Отвори као само-читање</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Учитавање, молимо сачекајте...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Архиватор</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Архиватор је лаган и брз програм за прављење и распакивање архива.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Отвори датотеку</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Подешавања</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Нова архива</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Претварање</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Ажурирање коментара</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Грешка додатка</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Успешно додато</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>Не садржи податке</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Додавање је отказано</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Неуспешно додавање</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Неуспешно прављење &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Успешно запаковано</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Недовољно простора на диску</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Неки делови недостау</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Погрешна лозинка, поново унесите</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Изабери датотеку</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Унесите до %1 карактера</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Својства датотеке</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Желите ли да обришете архиву?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 је измењено на диску, поново увезите.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Архиватор</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Немате дозволу да чувате датотеке овде, направите промену и покушајте поново</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Додавање датотека у %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Запакивање</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Распакивање</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Брисање</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Учитавање, молимо сачекајте...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Заиста желите да зауставите задатак који је у току?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Ажурирање, молимо сачекајте...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Предугачко име датотеке</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Неуспешно прављење датотеке</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Неуспешно запакивање</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Замени</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Нађи директоријум</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Неуспешно отварање</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Погрешна лозинка</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Архиватор не подржава овај формат датотеке</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>Немате дозволу да учитате %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Потврди</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Нема такве датотеке или директоријума</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Успешно распаковано</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Распакивање је отказано</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Архива је оштећена</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Успешно распаковано</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Успешно претворено</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Неуспешно распакивање</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Затвори</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Помоћ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Обриши</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Прикажи пречице</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Пречице</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Име је исто као од запаковане архиве, употребите друго име</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Датотека под истим називом већ постоји. Заменити?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Не можете додати архиву самој себи</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Не можете додавати архиве ове врсте датотека</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Ажурирај</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Основни подаци</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Величина</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Врста</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Локација</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Настало</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Приступљено</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Време измене</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Архива</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Коментар</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Подесите врсте датотека у подешавањима Архиватора</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Архива је измењена на диску, поново увезите.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Директоријум</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Програм</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Видео</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Аудио</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Слика</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Архива</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Извршно</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Документ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Датотека резерве</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Непознато</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Отвори са</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Додај друге програме</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Постави као подразумевано</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Потврди</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Препоручени програми</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Други програми</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Шифрована датотека, молимо унесите лознку</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Тренутна путања:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Назад на: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 задатак(а) у току</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Задатак</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Распакивање</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Заиста желите да зауставите распакивање?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Потврди</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Рачунање...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Брзина</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Преостало време</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Запакивање</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Брисање</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Претварање</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Ажурирање коментара...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Распакивање</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Пузирај</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Настави</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Потврди</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Заиста желите да зауставите распакивање?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Заиста желите да зауставите брисње?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Заиста желите да зауставите запакивање?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Заиста желите да зауставите претварање?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Име</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Време измене</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Врста</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Величина</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 је измењена. Желите ли да сачувате измене архиве?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Генерално</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Распакивање</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Самостално направи фасциклу за више распакованих датотека</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>На крају прикажи распаковане датотеке</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Управљање датотекама</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Обриши датотеке након запакивања</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Опције датотека</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Врсте датотека</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Прескочи</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Спој</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Датотека под истим називом већ постоји. Заменити?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Замени</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Датотека под истим називом већ постоји. Заменити?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Примени на све</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">У реду</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Тренутни директоријум</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Очисти све</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Изабери све</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Препоручено</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Распакуј архиву у</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Други директоријум</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Радна површина</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Обриши архиве након распакивања</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Никад</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Питај за потврду</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Увек</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Успешно запаковано</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Прикажи</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Отвори датотеку</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Назад</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Својства датотеке</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Распакуј у:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Распакуј</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Подразумевана путања распакивања не постоји, покушајте поново</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Немате дозволу да чувате датотеке овде, направите промену и покушајте поново</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Нађи директоријум</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Не можете додати архиву самој себи</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>У реду</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Распакуј</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Распакуј у тренутном директоријуму</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Отвори</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Обриши</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Отвори са</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Изабери подразумевани програм</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Потврди</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Желите ли да обришете изабрану(е) датотеку(е)?</translation>
     </message>

--- a/translations/deepin-compressor_tr.ts
+++ b/translations/deepin-compressor_tr.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Dosyaları mevcut arşive ekleyin.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Parola kullan</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>%1 özgün dosyası mevcut değil, lütfen denetleyin ve tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 diskte yok, lütfen kontrol edip ve tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>Sıkıştırma izniniz yok %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Yanlış parola</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Açıklama güncelleniyor....</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>İleri</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Lütfen dosya ekle</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>TAMAM</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Yeni Arşiv</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Gelişmiş Seçenekler</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Sıkıştırma yöntemi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Arşivi şifrele</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>CPU iş parçacıkları</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Dosya listesini de şifrele</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Birimlere böl</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Açıklama</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Sıkıştır</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Depo</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>En hızlı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Hızlı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>İyi</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>En iyi </translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Tek iş parçacığı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 iş parçacığı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 iş parçacığı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 iş parçacığı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Destek zip, sadece 7z türü</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Destek sadece 7z türü</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>%1 fazla karakter girin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Şuraya kaydet</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Bilinmeyen dosya adı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Lütfen yolu gir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Yol mevcut değil, lütfen tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Dosyaları buraya kaydetme izniniz yok, lütfen değiştirin ve tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Çok fazla cilt, lütfen değiştirin ve yeniden deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 diskte yok, lütfen kontrol edip ve tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>Sıkıştırma izniniz yok %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>%1 orijinal dosyası mevcut değil, lütfen kontrol edip ve tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>TAMAM</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Toplam boyut: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Ad, sıkıştırılmış arşivin adıyla aynı, lütfen başka bir ad kullanın</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>ZIP birimlerinin parolası Çince olamaz.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Aynı ada sahip başka bir dosya zaten var, değiştirilsin mi?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Yalnızca Çince ve İngilizce karakterler ve bazı sembolleri destekler</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Bununla aç</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Varsayılan programı seç</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>Dosya(lar) kalıcı olarak silinecektir. Devam etmek istediğine emin misin?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Onayla</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Ekle</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Arşivi listeye eklemek mi yoksa yeni pencerede mi açmak istiyorsunuz?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Yeni pencerede aç</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Bu dosya türündeki arşivlerde yapılan değişiklikler desteklenmez. Değişiklikleri kaydetmek için lütfen arşiv biçimini dönüştürün.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Biçimi şuna dönüştür:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Dönüştür</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>öge(ler)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Çıkarma başarısız</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Bozuk dosya, çıkarılamıyor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Yeniden dene</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Geri</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Dosya veya klasörü buraya sürükle</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Dosya Seç</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Arşiv zarar görmüş</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Salt okunur olarak aç</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Yükleniyor lütfen bekleyin...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Arşiv Yöneticisi</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>Arşiv Yöneticisi arşiv oluşturmak ve çıkarmak için hızlı ve hafif bir uygulamadır.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Dosya aç</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Yeni Arşiv Oluştur</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Dönüştürülüyor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Açıklamalar güncelleniyor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Eklenti hatası</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Ekleme başarılı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>İçinde veri yok</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Ekleme iptal edildi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Eklenemedi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Çıkarma başarısız oldu: dosya adı çok uzun</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>&quot;%1&quot; oluşturulamadı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Açılamadı: dosya adı çok uzun</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Sıkıştırma başarılı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Dosya adı çok uzun, bu nedenle ilk 60 karakter dosya adı olarak belirlendi.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>Yetersiz disk alanı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Bazı bölümler eksik</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Yanlış şifre, lütfen tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Dosya adı çok uzun. Adı 60 karakter içinde tutun lütfen. </translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Dönüştürülemedi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Dosya seç</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>%1 fazla karakter girin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Dosya bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Arşivi silmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 diskte değiştirildi, lütfen tekrar içe aktarın.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Arşiv Yöneticisi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Dosyaları buraya kaydetme izniniz yok, lütfen değiştirin ve tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>%1 klasörüne dosya ekleniyor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Sıkıştırılıyor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Çıkarılıyor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Siliniyor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Yükleniyor lütfen bekleyin...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Devam eden görevi durdurmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Güncelleniyor, lütfen bekleyin ...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Dosya adı çok uzun</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Dosya oluşturulamadı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Sıkıştırma başarısız</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Dizin bul</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Açma başarısız</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Yanlış parola</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>Dosya biçimi Arşiv Yöneticisi tarafından desteklenmiyor</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>TAMAM</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>%1 yükleme izniniz yok</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Onayla</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Böyle bir dosya ya da dizin yok</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Çıkarma başarılı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Çıkarma iptal edildi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Arşiv zarar görmüş</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Çıkarma başarılı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Dönüştürme başarılı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Çıkarma başarısız</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Yardım</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Kısayolları göster</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Kısayollar</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Ad, sıkıştırılmış arşivin adıyla aynı, lütfen başka bir ad kullanın</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Aynı ada sahip başka bir dosya zaten var, değiştirilsin mi?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Arşivi kendisine ekleyemezsiniz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Bu dosya türünde arşivlere dosya ekleyemezsiniz</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Güncelle</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Temel bilgi</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Tür</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Konum</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Oluşturulma zamanı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Erişim zamanı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Değiştirilme zamanı</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Arşiv</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Açıklama</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Arşiv Yöneticisi ayarlarında dosya ilişkilendirme türünü kontrol edin</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Arşiv diskte değiştirildi, lütfen tekrar içe aktarın.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Dizin</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Uygulama</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Ses</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Görüntü</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Arşiv</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Çalıştırılabilir</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Belge</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Yedekleme dosyası</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Bilinmiyor</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Bununla aç</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Başka programlar ekle</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Varsayılan olarak ayarla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Onayla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Önerilen Uygulamalar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Diğer Uygulamalar</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Şifrelenmiş dosya, lütfen parolayı gir</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Şuanki yol:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Geri dön: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>%1 görev(ler) devam ediyor</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Görev</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Çıkarılıyor</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Çıkarmayı durdurmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Onayla</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Hesaplanıyor...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Hız</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Kalan zaman</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Sıkıştırılıyor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Siliniyor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Dönüştürülüyor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Açıklama güncelleniyor....</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Çıkarılıyor</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Duraklat</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Devam</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Onayla</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Açmayı durdurmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Silme işlemini durdurmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Sıkıştırmayı durdurmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Dönüştürmeyi durdurmak istediğinizden emin misiniz?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Değiştirilme zamanı</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Tür</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 değişti. Arşivdeki değişiklikleri kaydetmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Genel</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Çıkar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Birden çok çıkarılan dosya için otomatik klasör oluştur</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Tamamlandığında çıkarılan dosyaları göster</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Dosya Yönetimi</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Sıkıştırmadan sonra dosyaları sil</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>İlişkili Dosyalar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Dosya Türü</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Atla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Aynı ada sahip başka bir dosya zaten var, değiştirilsin mi?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>TAMAM</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Aynı isimde başka bir klasör zaten var, değiştirilsin mi?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Tümünü onayla</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">TAMAM</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Mevcut dizin</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Tümünü Temizle</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Tümünü Seç</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Önerilen</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Arşivleri şuraya çıkar</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Diğer dizin</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Masaüstü</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Çıkarttıktan sonra arşivleri sil</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Asla</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Onay iste</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Sürekli</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Sıkıştırma başarılı</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>Görünüm</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Geri</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Dosya aç</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Geri</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Dosya bilgisi</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Şuraya çıkart:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Çıkart</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Varsayılan çıkarma yolu mevcut değil, lütfen tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>Dosyaları buraya kaydetme izniniz yok, lütfen değiştirin ve tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>TAMAM</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Dizin bul</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Arşivi kendisine ekleyemezsiniz</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>TAMAM</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Çıkart</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Mevcut dizine çıkart</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Bununla aç</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Varsayılan programı seç</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Onayla</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Seçili dosya(ları) silmek istiyor musunuz?</translation>
     </message>

--- a/translations/deepin-compressor_ug.ts
+++ b/translations/deepin-compressor_ug.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ug">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>ھۆججەتنى نۆۋەتتىكى بولاققا قوشۇڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>پارول ئىشلىتىش</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>«%1»غا يۆنۈلگەن مەنبە ھۆججەت مەۋجۇت ئەمەس، تەكشۈرگەندىن كېيىن سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>«%1» مەۋجۇت ئەمەس، تەكشۈرگەندىن كېيىن سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>% 1 نى پىرىسلاش ھوقۇقىڭىز يوق</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">مەخپىي نومۇر خاتا</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>ئىزاھات يېڭىلىنىۋاتىدۇ، سەل ساقلاڭ...</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>كېيىنكىسى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>ھۆججەت قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>تاماملاندى</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>يىڭى ئارخىپ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>ئالىي تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>پىرىسلاش ئۇسۇلى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>ئارخىپنى مەخپىلەشتۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>CPU لىنىيەسى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>ھۆججەت تىزىملىكىنىمۇ مەخپىيلەشتۈرۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>ھەجىمگە بۆلۈش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>ئىزاھات</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>پىرسلاش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>ئەڭ تېز</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>تېزرەك</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>ئۆلچەملىك</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>ياخشى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>ئەڭ ياخشى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>تاق لىنىيە</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>4 threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
-        <source>8 threads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>4 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <source>8 threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>قوللايدۇ zip ، پەقەت 7z تىپى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>پەقەت 7z تىپنىلا قوللايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>ئىزاھات مەزمۇنى %1 خەتتىن ئېشىپ كەتمىسۇن</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>ساقلاندى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>ھۆججەت ئىسمى ئىناۋەتسىز</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>مۇندەرىجىنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>بۇ مۇندەرىجە مەۋجۇت ئەمەس ، قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>بۇ يەردە ھۆججەتلەرنى ساقلاش ھوقۇقىڭىز يوق ، ئۆزگەرتىپ قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>توم بەك كۆپ ، ئۆزگەرتىپ قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>«%1» مەۋجۇت ئەمەس، تەكشۈرگەندىن كېيىن سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>% 1 نى پىرىسلاش ھوقۇقىڭىز يوق</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>«%1»غا يۆنۈلگەن مەنبە ھۆججەت مەۋجۇت ئەمەس، تەكشۈرگەندىن كېيىن سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>تاماملاندى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>ئالماشتۇرۇڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>جەمئىي چوڭلۇقى:1%</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>ھۆججەت نامى پىرىسلانغان ھۆججەتنىڭ نامى بىلەن ئوخشاش قالدى، ھۆججەت نامىنى ئۆزگەرتىڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>zip بولىقى خەنزۇچە خەتنى قوللىمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ئوخشاش ئىسىمدىكى باشقا بىر ھۆججەت بۇرۇنلا مەۋجۇت ، ئۇنى ئالماشتۇرامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>پەقەت خەنزۇچە ۋە ئىنگلىزچە ھەرپلەر ۋە بەزى بەلگىلەرنىلا قوللايدۇ</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>بىلەن ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>سۈكۈتتىكى پىروگراممىنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>ئۇ ھۆججەت (لەرنى) مەڭگۈلۈك ئۆچۈرۈۋېتىدۇ. راستىنلا داۋاملاشتۇرامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>ئارخىپنى تىزىملىككە قوشماقچىمۇ ياكى يېڭى كۆزنەكتە ئاچماقچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>يىڭى كۆزنەك ئېچىش</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>بۇ ھۆججەت تىپىدىكى ئارخىپلارنى ئۆزگەرتىشنى قوللىمايدۇ. ئۆزگەرتىشلەرنى ساقلاش ئۈچۈن ئارخىپ فورماتىنى ئۆزگەرتىڭ.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>فورماتىنى ئۆزگەرتىش:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>ئايلاندۇرۇش</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>تۈر(s)</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>ئېلىش مەغلۇب بولدى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>بۇزۇلغان ھۆججەت ، چىقىرىشقا ئامالسىز</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>قايتا سىناش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>ھۆججەت ياكى ھۆججەت قىسقۇچنى بۇ يەرگە سۆرۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>ھۆججەتنى تاللاڭ</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>بولاق بۇزۇلغان</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>ئوقۇش ھالىتىدە ئېچىش</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>يۈكلەۋاتىدۇ،كۈتۈپ تۇرۇڭ...</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>ئارخىپ باشقۇرغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>ئارخىپ باشقۇرغۇچى ئارخىپ قۇرۇش ۋە چىقىرىش ئۈچۈن تېز ھەم يېنىك قوللىنىشچان پروگرامما.</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>ھۆججەتنى ئېچىڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>يىڭى ئارخىپ قۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>ئايلاندۇرۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>ئىزاھات يېڭىلىنىۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>قىستۇرما بىنورمال</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>قوشۇلدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>بولاق قۇرۇق</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>قوشۇش بىكار قىلىندى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>قوشالمىدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>«%1”» ھۆججەت قۇرۇش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>مۇۋەپپەقىيەتلىك پىرىسلاندى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>دىسكا بوشلۇقى يەتمىدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>ھەجىمى كەمچىل</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>بولاق پارولى خاتا، قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>ھۆججەتنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>ئىزاھات مەزمۇنى %1 خەتتىن ئېشىپ كەتمىسۇن</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>ھۆججەت ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>تاللانغان ئارخىپىنى يۇيۇۋەتمەكچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>دىسكىدا% 1 ئۆزگەرتىلدى ، قايتا ئەكىرىڭ.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>ئارخىپ باشقۇرغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>بۇ يەردە ھۆججەتلەرنى ساقلاش ھوقۇقىڭىز يوق ، ئۆزگەرتىپ قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>%1 غا ھۆججەت قوشۇۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>پىرىسلاش</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>ئېلىش</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>ئۆچۈرلىۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>يۈكلەۋاتىدۇ،كۈتۈپ تۇرۇڭ...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>داۋاملىشىۋاتقان ۋەزىپىنى توختاتماقچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>يېڭىلىنىۋاتىدۇ، سەل ساقلاڭ...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>ھۆججەت نامى بەك ئۇزۇن</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>ھۆججەت قۇرۇش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>پىرىسلاش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>ئالماشتۇرۇڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>مۇندەرىجىنى تېپىڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>ئاچالمىدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>مەخپىي نومۇر خاتا</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>بۇ فورماتتىكى ھۆججەتنى ئاچالمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>تاماملاندى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>«%1”» ھۆججەتنى يۈكلەش ھوقۇقىڭىز يوق</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>نىشان ھۆججەت ياكى مۇندەرىجە يوق</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>ئېلىش مۇۋەپپەقىيەتلىك بولدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>ئېلىش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>بولاق بۇزۇلغان</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>ئېلىش مۇۋەپپەقىيەتلىك بولدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>ئۆزگەرتىش مۇۋەپپەقىيەتلىك</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>ئېلىش مەغلۇب بولدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>ياردەم</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>تېزلەتمە كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>تېزلەتمە</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>ھۆججەت نامى پىرىسلانغان ھۆججەتنىڭ نامى بىلەن ئوخشاش قالدى، ھۆججەت نامىنى ئۆزگەرتىڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ئوخشاش ئىسىمدىكى باشقا بىر ھۆججەت بۇرۇنلا مەۋجۇت ، ئۇنى ئالماشتۇرامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>ئارخىپنى ئۆزىگە قوشالمايسىز</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>بۇ پىرىسلانغان بوغچا فورماتى ھۆججەت قوشۇشنى قوللىمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>يىڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>ئاساسىي ئۇچۇر</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>تىپى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>ئورۇن</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>قۇرۇلغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>زىيارەت ۋاقتى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>ۋاقىت ئۆزگەرتىلدى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>ئارخىپ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>ئىزاھات</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>ئارخىپ باشقۇرغۇچىنىڭ تەڭشەكلىرىدىكى ھۆججەت بىرلەشمىسىنىڭ تۈرىنى تەكشۈرۈپ بېقىڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>ئارخىپ دىسكىدا ئۆزگەرتىلدى ، ئۇنى قايتا ئەكىرىڭ.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>مۇندەرىجە</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>ئىلتىماس</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>فىلىم</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>مۇزىكا</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>رەسىم</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>ئارخىپ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>ئىجرا قىلىشقا بولىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>پۈتۈك</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>زاپاس ھۆججەت</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>نامەلۇم</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>بىلەن ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>باشقا پىروگراممىلارنى قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>سۈكۈتتىكى قىلىپ تەڭشەش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>تەۋسىيەلىك ئەپلەر</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>باشقا ئەپلەر</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>شىفىرلانغان ھۆججەت ، مەخپىي نومۇرنى كىرگۈزۈڭ</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>ھازىرقى ئورنى:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>%1: گە قايتىش</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>% 1 ۋەزىپە (ۋەزىپە) داۋاملىشىۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>ۋەزىپە</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>ئېلىش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>ئېلىشنى توختاتماقچى بولغانلىقىڭىزغا جەزىم قىلامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈڭ</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>پىرېستىن يېشىش سۈرئىتى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>ھېسابلاۋاتىدۇ...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>پىرېستىن يېشىش سۈرئىتى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">پىرېستىن يېشىش سۈرئىتى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>پىرېستىن يېشىش سۈرئىتى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>پىرېستىن يېشىش سۈرئىتى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>قالغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>پىرىسلاش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>ئۆچۈرلىۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>ئايلاندۇرۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>ئىزاھات يېڭىلىنىۋاتىدۇ، سەل ساقلاڭ...</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>ئېلىش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>توختاش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>داۋاملىق</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>پىرىسلاشنى توختاتماقچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>ئۆچۈرۈشنى توختاتماقچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>پىرىسلاشنى توختاتماقچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>ئايلاندۇرۇشنى توختاتماقچىمۇ؟</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>ۋاقىت ئۆزگەرتىلدى</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>تىپى</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>% 1 ئۆزگەردى. ئارخىپقا ئۆزگەرتىش كىرگۈزمەكچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>ئېلىش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>كۆپ چىقىرىۋېتىلگەن ھۆججەتلەر ئۈچۈن ئاپتوماتىك ھۆججەت قىسقۇچ قۇرالايسىز</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>چىقىرىۋېتىلگەن ھۆججەتلەرنى تاماملاپ بولۇپ كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>ھۆججەت باشقۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>ھۆججەتلەرنى پىرىسلاپ بولۇپ يۇيۇۋىتىش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>مۇناسىۋەتلىك ھۆججەتلەر</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>ھۆججەت تىپى</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>ئاتلاش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>قوشۇۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>ئوخشاش ئىسىمدىكى باشقا بىر ھۆججەت بۇرۇنلا مەۋجۇت ، ئۇنى ئالماشتۇرامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>ئالماشتۇرۇڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>تاماملاندى</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>ئوخشاش نامدىكى ھۆججەت مەۋجۇت، ئالماشتۇرامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>ھەممەيلەنگە ئىلتىماس قىلىڭ</translation>
     </message>
@@ -1289,89 +1335,89 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation type="unfinished">تاماملاندى</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>نۆۋەتتىكى مۇندەرىجە</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>ھەممىنى تازىلاش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>ھەممىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>تەۋسىيەلىك تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>ئارخىپلارنى چىقىرىڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>باشقا مۇندەرىجە</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>ئۈستەل يۈزى</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>ھۆججەتلەرنى يېشىپ بولۇپ يۇيۇۋىتىش</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>ھەرگىز</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>جەزملەشتۈرۈشنى سوراڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>مەڭگۈ</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>مۇۋەپپەقىيەتلىك پىرىسلاندى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>كۆرۈش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
@@ -1397,55 +1443,55 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ھۆججەتنى ئېچىڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">قايتىش</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ھۆججەت ئۇچۇرى</translation>
     </message>
 </context>
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>ئېرىشكەنلىرى:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>ئېرىشىش</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>سۈكۈتتىكى ئېلىش يولى مەۋجۇت ئەمەس ، قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>بۇ يەردە ھۆججەتلەرنى ساقلاش ھوقۇقىڭىز يوق ، ئۆزگەرتىپ قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>تاماملاندى</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>مۇندەرىجىنى تېپىڭ</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>ئارخىپنى ئۆزىگە قوشالمايسىز</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>تاماملاندى</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>ئېرىشىش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>ئېرىشكەن نۆۋەتتىكى مۇندەرىجە</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>بىلەن ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>سۈكۈتتىكى پىروگراممىنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>جەزىملەشتۈرۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>تاللانغان ھۆججەتلەرنى يۇيۇۋەتمەكچىمۇ؟</translation>
     </message>

--- a/translations/deepin-compressor_uk.ts
+++ b/translations/deepin-compressor_uk.ts
@@ -1,13 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AppendDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="438"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="422"/>
         <source>Add files to the current archive</source>
         <translation>Додати файли до поточного архіву</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="443"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="427"/>
         <source>Use password</source>
         <translation>Використати пароль</translation>
     </message>
@@ -15,28 +17,41 @@
 <context>
     <name>CalculateSizeThread</name>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="68"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="136"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="53"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="121"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Початкового файла %1 не існує. Будь ласка, перевірте його наявність і повторіть спробу.</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="70"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="138"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="55"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="123"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 немає на диску. Будь ласка, перевірте наявність і повторіть спробу.</translation>
     </message>
     <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="79"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="147"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="64"/>
+        <location filename="../src/source/common/calculatesizethread.cpp" line="132"/>
         <source>You do not have permission to compress %1</source>
         <translation>У вас немає прав доступу для стискання %1</translation>
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Помилковий пароль</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="234"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
         <source>Updating the comment...</source>
         <translation>Оновлюємо коментар…</translation>
     </message>
@@ -44,17 +59,17 @@
 <context>
     <name>CompressPage</name>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="81"/>
+        <location filename="../src/source/page/compresspage.cpp" line="65"/>
         <source>Next</source>
         <translation>Далі</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>Please add files</source>
         <translation>Будь ласка, додайте файли</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresspage.cpp" line="122"/>
+        <location filename="../src/source/page/compresspage.cpp" line="106"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
@@ -63,209 +78,209 @@
 <context>
     <name>CompressSettingPage</name>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="146"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="229"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="137"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
         <source>New Archive</source>
         <translation>Новий архів</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="207"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="217"/>
         <source>Advanced Options</source>
         <translation>Додаткові параметри</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="211"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="221"/>
         <source>Compression method</source>
         <translation>Спосіб стискання</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="214"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
         <source>Encrypt the archive</source>
         <translation>Зашифрований файл</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="216"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="226"/>
         <source>CPU threads</source>
         <translation>Потоки процесора</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="218"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="228"/>
         <source>Encrypt the file list too</source>
         <translation>Зашифрований список файлів</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="220"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
         <source>Split to volumes</source>
         <translation>Поділити на томи</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="222"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="232"/>
         <source>Comment</source>
         <translation>Коментар</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="224"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
         <source>Compress</source>
         <comment>button</comment>
         <translation>Стиснути</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Store</source>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fastest</source>
         <translation>Найшвидше</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Fast</source>
         <translation>Швидко</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Normal</source>
         <translation>Звичайно</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Good</source>
         <translation>Добре</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="253"/>
         <source>Best</source>
         <translation>Найкраще</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>Single thread</source>
         <translation>Один потік</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>2 threads</source>
         <translation>2 потоки</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>4 threads</source>
         <translation>4 потоки</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="250"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
         <source>8 threads</source>
         <translation>8 потоків</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="260"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="270"/>
         <source>Support zip, 7z type only</source>
         <translation>Передбачено підтримку лише типів zip, 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="263"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
         <source>Support 7z type only</source>
         <translation>Передбачено підтримку лише типу 7z</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="275"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="285"/>
         <source>Enter up to %1 characters</source>
         <translation>Введіть до %1 символів</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="296"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="305"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="297"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="306"/>
         <source>Save to</source>
         <translation>Зберегти до</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="489"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="585"/>
         <source>Invalid file name</source>
         <translation>Некоректна назва файла</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="495"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="591"/>
         <source>Please enter the path</source>
         <translation>Будь ласка, вкажіть шлях</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="500"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="596"/>
         <source>The path does not exist, please retry</source>
         <translation>Шляху не існує. Будь ласка, повторіть спробу</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="505"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="601"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>У вас немає прав доступу для зберігання файлів тут. Будь ласка, змініть каталог і повторіть спробу.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="513"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="609"/>
         <source>Too many volumes, please change and retry</source>
         <translation>Забагато томів. Будь ласка, змініть кількість томів і повторіть спробу.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="522"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="550"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="618"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="646"/>
         <source>%1 does not exist on the disk, please check and try again</source>
         <translation>%1 немає на диску. Будь ласка, перевірте наявність і повторіть спробу.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="528"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="557"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="624"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="653"/>
         <source>You do not have permission to compress %1</source>
         <translation>У вас немає прав доступу для стискання %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="548"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="644"/>
         <source>The original file of %1 does not exist, please check and try again</source>
         <translation>Початкового файла %1 не існує. Будь ласка, перевірте його наявність і повторіть спробу.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="583"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="679"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="705"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="827"/>
         <source>Total size: %1</source>
         <translation>Загальний розмір: %1</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="725"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="847"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Назва збігається із назвою стисненого архіву. Будь ласка, скористайтеся іншою назвою.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="733"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="855"/>
         <source>The password for ZIP volumes cannot be in Chinese</source>
         <translation>Пароль до томів ZIP не можна вказувати українською</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="797"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="919"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Файл вже існує. Що робити?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="837"/>
+        <location filename="../src/source/page/compresssettingpage.cpp" line="959"/>
         <source>Only Chinese and English characters and some symbols are supported</source>
         <translation>Передбачено підтримку лише китайських ієрогліфів, символів англійської абетки та деяких інших символів</translation>
     </message>
@@ -273,62 +288,62 @@
 <context>
     <name>CompressView</name>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="296"/>
+        <location filename="../src/source/tree/compressview.cpp" line="280"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="309"/>
+        <location filename="../src/source/tree/compressview.cpp" line="293"/>
         <source>Rename</source>
         <translation>Перейменувати</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="314"/>
+        <location filename="../src/source/tree/compressview.cpp" line="298"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="317"/>
+        <location filename="../src/source/tree/compressview.cpp" line="301"/>
         <source>Open with</source>
         <translation>Відкрити за допомогою</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="321"/>
-        <location filename="../src/source/tree/compressview.cpp" line="500"/>
+        <location filename="../src/source/tree/compressview.cpp" line="305"/>
+        <location filename="../src/source/tree/compressview.cpp" line="490"/>
         <source>Select default program</source>
         <translation>Виберіть типову програму</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
         <translation>У результаті виконання цієї дії буде остаточно вилучено файли. Ви справді хочете її виконати?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
-        <location filename="../src/source/tree/compressview.cpp" line="474"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
+        <location filename="../src/source/tree/compressview.cpp" line="464"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="364"/>
+        <location filename="../src/source/tree/compressview.cpp" line="348"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Підтвердження</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="475"/>
+        <location filename="../src/source/tree/compressview.cpp" line="465"/>
         <source>Add</source>
         <comment>button</comment>
         <translation>Додати</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="473"/>
+        <location filename="../src/source/tree/compressview.cpp" line="463"/>
         <source>Do you want to add the archive to the list or open it in new window?</source>
         <translation>Хочете додати архів до списку чи відкрити його у новому вікні?</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/compressview.cpp" line="476"/>
+        <location filename="../src/source/tree/compressview.cpp" line="466"/>
         <source>Open in new window</source>
         <translation>Відкрити у новому вікні</translation>
     </message>
@@ -336,23 +351,23 @@
 <context>
     <name>ConvertDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="312"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="296"/>
         <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
         <translation>Підтримки внесення змін до цього типу архівів не передбачено. Будь ласка, змініть тип архіву, щоб зберегти зміни.</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="320"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="304"/>
         <source>Convert the format to:</source>
         <translation>Змінити формат на:</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="344"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="328"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="345"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="329"/>
         <source>Convert</source>
         <comment>button</comment>
         <translation>Перетворити</translation>
@@ -361,7 +376,7 @@
 <context>
     <name>DataModel</name>
     <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="70"/>
+        <location filename="../src/source/tree/datamodel.cpp" line="59"/>
         <source>item(s)</source>
         <translation>записів</translation>
     </message>
@@ -369,24 +384,24 @@
 <context>
     <name>FailurePage</name>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="87"/>
+        <location filename="../src/source/page/failurepage.cpp" line="71"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Помилка під час розпаковування.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
+        <location filename="../src/source/page/failurepage.cpp" line="84"/>
         <source>Damaged file, unable to extract</source>
         <translation>Пошкоджений файл, неможливо видобути</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="105"/>
+        <location filename="../src/source/page/failurepage.cpp" line="89"/>
         <source>Retry</source>
         <comment>button</comment>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../src/source/page/failurepage.cpp" line="108"/>
+        <location filename="../src/source/page/failurepage.cpp" line="92"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -394,12 +409,12 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="56"/>
+        <location filename="../src/source/page/homepage.cpp" line="40"/>
         <source>Drag file or folder here</source>
         <translation>Сюди можна перетягнути файл або теку</translation>
     </message>
     <message>
-        <location filename="../src/source/page/homepage.cpp" line="58"/>
+        <location filename="../src/source/page/homepage.cpp" line="42"/>
         <source>Select File</source>
         <translation>Вибрати файл</translation>
     </message>
@@ -407,17 +422,17 @@
 <context>
     <name>LoadCorruptQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="525"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="510"/>
         <source>The archive is damaged</source>
         <translation>Архів пошкоджено</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="528"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="513"/>
         <source>Open as read-only</source>
         <translation>Відкрити лише для читання</translation>
     </message>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="529"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="514"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
@@ -426,7 +441,7 @@
 <context>
     <name>LoadingPage</name>
     <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="65"/>
+        <location filename="../src/source/page/loadingpage.cpp" line="49"/>
         <source>Loading, please wait...</source>
         <translation>Завантаження, зачекайте…</translation>
     </message>
@@ -434,13 +449,13 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../src/main.cpp" line="60"/>
-        <location filename="../src/main.cpp" line="61"/>
+        <location filename="../src/main.cpp" line="137"/>
+        <location filename="../src/main.cpp" line="138"/>
         <source>Archive Manager</source>
         <translation>Засіб для керування архівами</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="62"/>
+        <location filename="../src/main.cpp" line="139"/>
         <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
         <translation>«Засіб для керування архівами» — програмний інструмент, який надає доступ до типових можливостей із видобування та стискання файлів</translation>
     </message>
@@ -448,427 +463,457 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="179"/>
+        <location filename="../src/source/mainwindow.cpp" line="209"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="180"/>
+        <location filename="../src/source/mainwindow.cpp" line="210"/>
         <source>Settings</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="276"/>
-        <location filename="../src/source/mainwindow.cpp" line="286"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>Створити архів</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="334"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>Перетворення</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="341"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>Оновлюємо коментарі</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="2071"/>
-        <location filename="../src/source/mainwindow.cpp" line="2097"/>
-        <location filename="../src/source/mainwindow.cpp" line="2122"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>Помилка додатка</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1284"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>Успішне додавання</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2146"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>У ньому немає даних</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1521"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>Додавання скасовано</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1623"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>Додавання зазнало невдачі</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1676"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>Не вдалося видобути. Назва файла є надто довгою.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1703"/>
-        <location filename="../src/source/mainwindow.cpp" line="2142"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>Не вдалося створити «%1»</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1825"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>Не вдалося відкрити. Назва файла є надто довгою.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2044"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>Успішне стискання</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2050"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>Назва файла є надто довгою. Для назви буде використано лише перші 60 символів.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2079"/>
-        <location filename="../src/source/mainwindow.cpp" line="2150"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>На диску недостатньо місця</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2109"/>
-        <location filename="../src/source/mainwindow.cpp" line="2130"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>Не вистачає деяких томів</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2134"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>Помилковий пароль, будь ласка, повторіть спробу</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2138"/>
-        <location filename="../src/source/mainwindow.cpp" line="2162"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>Назва файла є надто довгою. Будь ласка, обмежте назву 60 символами.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>Не вдалося перетворити</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>Вибір файла</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3167"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>Введіть до %1 символів</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3043"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>Відомості щодо файла</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>Хочете вилучити архів?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="533"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>%1 було змінено на диску. Будь ласка, імпортуйте його знову.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="75"/>
+        <location filename="../src/source/mainwindow.cpp" line="104"/>
         <source>Archive Manager</source>
         <translation>Керування архівами</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>У вас немає прав доступу для зберігання файлів тут. Будь ласка, змініть каталог і повторіть спробу.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="299"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>Додаємо файли до %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="306"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>Стискання</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="313"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>Видобування</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="320"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>Вилучення</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2867"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>Завантаження, зачекайте…</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>Ви справді хочете зупинити виконання завдання, яке виконується?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1290"/>
-        <location filename="../src/source/mainwindow.cpp" line="1417"/>
-        <location filename="../src/source/mainwindow.cpp" line="1433"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>Оновлення, будь ласка, зачекайте…</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1698"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>Назва файл є надто довгою</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2075"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>Не вдалося створити файл</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2068"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>Помилка під час стискання</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2471"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>Знайти каталог</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2094"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>Не вдалося відкрити</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1619"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
-        <location filename="../src/source/mainwindow.cpp" line="1823"/>
-        <location filename="../src/source/mainwindow.cpp" line="2105"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>Помилковий пароль</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="645"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>У «Менеджері архівів» не передбачено підтримки файлів у цьому форматі</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="136"/>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="503"/>
-        <location filename="../src/source/mainwindow.cpp" line="536"/>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
-        <location filename="../src/source/mainwindow.cpp" line="612"/>
-        <location filename="../src/source/mainwindow.cpp" line="652"/>
-        <location filename="../src/source/mainwindow.cpp" line="1316"/>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
-        <location filename="../src/source/mainwindow.cpp" line="2729"/>
+        <location filename="../src/source/mainwindow.cpp" line="165"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="327"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>Перейменовування</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="441"/>
-        <location filename="../src/source/mainwindow.cpp" line="603"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>У вас немає прав доступу для завантаження %1</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="569"/>
-        <location filename="../src/source/mainwindow.cpp" line="1393"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Підтвердити</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="597"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>Немає такого файла або каталогу</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1332"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>Успішне видобування</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1542"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>Видобування скасовано</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1688"/>
-        <location filename="../src/source/mainwindow.cpp" line="1763"/>
-        <location filename="../src/source/mainwindow.cpp" line="2101"/>
-        <location filename="../src/source/mainwindow.cpp" line="2126"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>Архів пошкоджено</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2048"/>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
+        <location filename="../src/source/mainwindow.cpp" line="2154"/>
+        <source>Failed to create temporary directory, please check and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
+        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>Успішне видобування</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2054"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>Успішне перетворення</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2083"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>Стиснені томи вже існують</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2119"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
+        <source>No compression support in current directory. Download the files to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
+        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>Помилка під час розпаковування.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
+        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2309"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>Показати клавіатурні скорочення</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2321"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>Клавіатурні скорочення</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2399"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>Назва збігається із назвою стисненого архіву. Будь ласка, скористайтеся іншою назвою.</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2407"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Файл вже існує. Що робити?</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2550"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>Ви не можете додавати архів до самого себе</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2565"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>Ви не можете додавати архіви до цього типу файлів</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2889"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3067"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>Основні відомості</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3083"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3084"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3085"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>Розташування</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3086"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>Час створення</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3087"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>Час доступу</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3088"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>Час зміни</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3098"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>Архівувати</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3129"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>Коментар</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>Будь ласка, перевірте прив&apos;язку до типу файлів у параметрах «Керування архівами»</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2278"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>Архів було змінено на диску. Будь ласка, імпортуйте його знову.</translation>
     </message>
@@ -876,52 +921,52 @@
 <context>
     <name>MimeTypeDisplayManager</name>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="46"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="29"/>
         <source>Directory</source>
         <translation>Каталог</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="47"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="30"/>
         <source>Application</source>
         <translation>Програма</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="48"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="31"/>
         <source>Video</source>
         <translation>Відео</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="49"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
         <source>Audio</source>
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="50"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
         <source>Image</source>
         <translation>Зображення</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="51"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
         <source>Archive</source>
         <translation>Архівувати</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="53"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
         <source>Executable</source>
         <translation>Виконуваний файл</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="52"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
         <source>Document</source>
         <translation>Документ</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="54"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
         <source>Backup file</source>
         <translation>Файл резервної копії</translation>
     </message>
     <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="55"/>
+        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
         <source>Unknown</source>
         <translation>Невідомий</translation>
     </message>
@@ -929,39 +974,39 @@
 <context>
     <name>OpenWithDialog</name>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="280"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="265"/>
         <source>Open with</source>
         <translation>Відкрити за допомогою</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="300"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="285"/>
         <source>Add other programs</source>
         <translation>Додати інші програми</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="301"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="286"/>
         <source>Set as default</source>
         <translation>Зробити типовим</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="303"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="288"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="304"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="289"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Підтвердити</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="308"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="293"/>
         <source>Recommended Applications</source>
         <translation>Рекомендовані програми</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="310"/>
+        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="295"/>
         <source>Other Applications</source>
         <translation>Інші програми</translation>
     </message>
@@ -969,7 +1014,7 @@
 <context>
     <name>PasswordNeededQuery</name>
     <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="394"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="379"/>
         <source>Encrypted file, please enter the password</source>
         <translation>Зашифрований файл. Будь ласка, введіть пароль</translation>
     </message>
@@ -977,12 +1022,12 @@
 <context>
     <name>PreviousLabel</name>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="52"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="37"/>
         <source>Current path:</source>
         <translation>Поточний шлях:</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="60"/>
+        <location filename="../src/source/tree/treeheaderview.cpp" line="45"/>
         <source>Back to: %1</source>
         <translation>Повернутися до: %1</translation>
     </message>
@@ -990,35 +1035,35 @@
 <context>
     <name>ProgressDialog</name>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="52"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="37"/>
         <source>%1 task(s) in progress</source>
         <translation>Виконуємо %1 завдання</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="59"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="102"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="44"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="87"/>
         <source>Task</source>
         <translation>Завдання</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="65"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="113"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="50"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="98"/>
         <source>Extracting</source>
         <translation>Видобування</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="177"/>
         <source>Are you sure you want to stop the extraction?</source>
         <translation>Зараз виконуємо завдання з видобування даних</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="194"/>
+        <location filename="../src/source/dialog/progressdialog.cpp" line="179"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Підтвердження</translation>
@@ -1027,141 +1072,142 @@
 <context>
     <name>ProgressPage</name>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="325"/>
-        <location filename="../src/source/page/progresspage.cpp" line="328"/>
-        <location filename="../src/source/page/progresspage.cpp" line="331"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="314"/>
+        <location filename="../src/source/page/progresspage.cpp" line="317"/>
+        <location filename="../src/source/page/progresspage.cpp" line="320"/>
         <source>Speed</source>
         <comment>compress</comment>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="160"/>
+        <location filename="../src/source/page/progresspage.cpp" line="43"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="144"/>
         <source>Calculating...</source>
         <translation>Обчислення…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="61"/>
-        <location filename="../src/source/page/progresspage.cpp" line="335"/>
-        <location filename="../src/source/page/progresspage.cpp" line="337"/>
+        <location filename="../src/source/page/progresspage.cpp" line="45"/>
+        <location filename="../src/source/page/progresspage.cpp" line="324"/>
+        <location filename="../src/source/page/progresspage.cpp" line="326"/>
         <source>Speed</source>
         <comment>delete</comment>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="63"/>
-        <location filename="../src/source/page/progresspage.cpp" line="341"/>
-        <location filename="../src/source/page/progresspage.cpp" line="343"/>
+        <location filename="../src/source/page/progresspage.cpp" line="47"/>
+        <location filename="../src/source/page/progresspage.cpp" line="330"/>
+        <location filename="../src/source/page/progresspage.cpp" line="332"/>
         <source>Speed</source>
         <comment>rename</comment>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="65"/>
-        <location filename="../src/source/page/progresspage.cpp" line="355"/>
-        <location filename="../src/source/page/progresspage.cpp" line="357"/>
-        <location filename="../src/source/page/progresspage.cpp" line="359"/>
+        <location filename="../src/source/page/progresspage.cpp" line="49"/>
+        <location filename="../src/source/page/progresspage.cpp" line="344"/>
+        <location filename="../src/source/page/progresspage.cpp" line="346"/>
+        <location filename="../src/source/page/progresspage.cpp" line="348"/>
         <source>Speed</source>
         <comment>convert</comment>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="69"/>
-        <location filename="../src/source/page/progresspage.cpp" line="347"/>
-        <location filename="../src/source/page/progresspage.cpp" line="349"/>
-        <location filename="../src/source/page/progresspage.cpp" line="351"/>
+        <location filename="../src/source/page/progresspage.cpp" line="53"/>
+        <location filename="../src/source/page/progresspage.cpp" line="336"/>
+        <location filename="../src/source/page/progresspage.cpp" line="338"/>
+        <location filename="../src/source/page/progresspage.cpp" line="340"/>
         <source>Speed</source>
         <comment>uncompress</comment>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="72"/>
-        <location filename="../src/source/page/progresspage.cpp" line="321"/>
+        <location filename="../src/source/page/progresspage.cpp" line="56"/>
+        <location filename="../src/source/page/progresspage.cpp" line="310"/>
         <source>Time left</source>
         <translation>Лишилося часу</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="131"/>
+        <location filename="../src/source/page/progresspage.cpp" line="115"/>
         <source>Compressing</source>
         <translation>Стискання</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="133"/>
+        <location filename="../src/source/page/progresspage.cpp" line="117"/>
         <source>Deleting</source>
         <translation>Вилучення</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="135"/>
+        <location filename="../src/source/page/progresspage.cpp" line="119"/>
         <source>Renaming</source>
         <translation>Перейменовування</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="137"/>
+        <location filename="../src/source/page/progresspage.cpp" line="121"/>
         <source>Converting</source>
         <translation>Перетворення</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="139"/>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
+        <location filename="../src/source/page/progresspage.cpp" line="123"/>
+        <location filename="../src/source/page/progresspage.cpp" line="142"/>
         <source>Updating the comment...</source>
         <translation>Оновлюємо коментар…</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="141"/>
+        <location filename="../src/source/page/progresspage.cpp" line="125"/>
         <source>Extracting</source>
         <translation>Видобування</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <location filename="../src/source/page/progresspage.cpp" line="189"/>
-        <location filename="../src/source/page/progresspage.cpp" line="375"/>
+        <location filename="../src/source/page/progresspage.cpp" line="136"/>
+        <location filename="../src/source/page/progresspage.cpp" line="178"/>
+        <location filename="../src/source/page/progresspage.cpp" line="364"/>
         <source>Pause</source>
         <comment>button</comment>
         <translation>Призупинити</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="188"/>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="177"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="371"/>
+        <location filename="../src/source/page/progresspage.cpp" line="165"/>
+        <location filename="../src/source/page/progresspage.cpp" line="360"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Продовжити</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="404"/>
+        <location filename="../src/source/page/progresspage.cpp" line="393"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Підтвердити</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="393"/>
+        <location filename="../src/source/page/progresspage.cpp" line="382"/>
         <source>Are you sure you want to stop the decompression?</source>
         <translation>Ви справді хочете зупинити розпаковування?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="395"/>
+        <location filename="../src/source/page/progresspage.cpp" line="384"/>
         <source>Are you sure you want to stop the deletion?</source>
         <translation>Ви справді хочете зупинити вилучення?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="391"/>
-        <location filename="../src/source/page/progresspage.cpp" line="397"/>
+        <location filename="../src/source/page/progresspage.cpp" line="380"/>
+        <location filename="../src/source/page/progresspage.cpp" line="386"/>
         <source>Are you sure you want to stop the compression?</source>
         <translation>Ви справді хочете зупинити стискання?</translation>
     </message>
     <message>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
+        <location filename="../src/source/page/progresspage.cpp" line="388"/>
         <source>Are you sure you want to stop the conversion?</source>
         <translation>Ви справді хочете зупинити перетворення?</translation>
     </message>
@@ -1169,119 +1215,119 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Time modified</source>
         <translation>Час зміни</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/datamodel.h" line="71"/>
+        <location filename="../src/source/tree/datamodel.h" line="56"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2886"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>%1 змінено. Хочете зберегти зміни до архіву?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="26"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="10"/>
         <source>General</source>
         <translation>Параметр</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="27"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="11"/>
         <source>Extraction</source>
         <translation>Видобування</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="28"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
         <source>Auto create a folder for multiple extracted files</source>
         <translation>Автоматично створювати теку для декількох видобутих файлів</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="29"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
         <source>Show extracted files when completed</source>
         <translation>Показати видобуті файли після видобування</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="30"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
         <source>File Management</source>
         <translation>Керування файлами</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="31"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
         <source>Delete files after compression</source>
         <translation>Вилучити файли після стискання</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="32"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
         <source>Files Associated</source>
         <translation>Пов&apos;язані файли</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="33"/>
+        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
         <source>File Type</source>
         <translation>Тип файлів</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="208"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="214"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="244"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="192"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="198"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="229"/>
         <source>Skip</source>
         <comment>button</comment>
         <translation>Пропустити</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="209"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="193"/>
         <source>Merge</source>
         <comment>button</comment>
         <translation>Об&apos;єднати</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="212"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="221"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="196"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="206"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>Файл вже існує. Що робити?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="215"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="245"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="199"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="230"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="483"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="405"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="467"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="390"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="484"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="406"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="468"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="391"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="206"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="190"/>
         <source>Another folder with the same name already exists, replace it?</source>
         <translation>Вже існує тека із такою самою назвою. Замінити її?</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="226"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="202"/>
+        <location filename="../3rdparty/interface/queries.cpp" line="211"/>
         <source>Apply to all</source>
         <translation>Застосувати до всіх</translation>
     </message>
@@ -1289,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="557"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>Перейменувати</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="608"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="609"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="619"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>Таку назву вже використано</translation>
     </message>
@@ -1314,64 +1360,64 @@
 <context>
     <name>SettingDialog</name>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="195"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="179"/>
         <source>Current directory</source>
         <translation>Поточний каталог</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="125"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="109"/>
         <source>Clear All</source>
         <translation>Спорожнити все</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="124"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="108"/>
         <source>Select All</source>
         <comment>button</comment>
         <translation>Позначити все</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="126"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="110"/>
         <source>Recommended</source>
         <translation>Рекомендовано</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="160"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="144"/>
         <source>Extract archives to</source>
         <translation>Місце видобування архівів</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="205"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="189"/>
         <source>Other directory</source>
         <translation>Інший каталог</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="166"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="200"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="150"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation>Стільниця</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="272"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="256"/>
         <source>Delete archives after extraction</source>
         <translation>Вилучити архіви після видобування</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="299"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="283"/>
         <source>Never</source>
         <translation>Ніколи</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="302"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="286"/>
         <source>Ask for confirmation</source>
         <translation>Просити підтвердити</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="278"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="305"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="262"/>
+        <location filename="../src/source/dialog/settingdialog.cpp" line="289"/>
         <source>Always</source>
         <translation>Завжди</translation>
     </message>
@@ -1379,17 +1425,17 @@
 <context>
     <name>SuccessPage</name>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="79"/>
+        <location filename="../src/source/page/successpage.cpp" line="63"/>
         <source>Compression successful</source>
         <translation>Успішне стискання</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="89"/>
+        <location filename="../src/source/page/successpage.cpp" line="73"/>
         <source>View</source>
         <translation>показати файли</translation>
     </message>
     <message>
-        <location filename="../src/source/page/successpage.cpp" line="92"/>
+        <location filename="../src/source/page/successpage.cpp" line="76"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -1397,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3324"/>
-        <location filename="../src/source/mainwindow.cpp" line="3381"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3327"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3386"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>Відомості щодо файла</translation>
     </message>
@@ -1416,36 +1462,36 @@
 <context>
     <name>UnCompressPage</name>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="75"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="87"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="64"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="76"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="105"/>
         <source>Extract to:</source>
         <translation>Видобути до:</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="106"/>
         <source>Extract</source>
         <comment>button</comment>
         <translation>Видобути</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="193"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="182"/>
         <source>The default extraction path does not exist, please retry</source>
         <translation>Типового шляху для видобування не існує. Будь ласка, повторіть спробу</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="195"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="184"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation>У вас немає прав доступу для зберігання файлів тут. Будь ласка, змініть каталог і повторіть спробу.</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="199"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="188"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="213"/>
+        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
         <source>Find directory</source>
         <translation>Знайти каталог</translation>
     </message>
@@ -1453,67 +1499,67 @@
 <context>
     <name>UnCompressView</name>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>You cannot add the archive to itself</source>
         <translation>Ви не можете додавати архів до самого себе</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="401"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="385"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="627"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="611"/>
         <source>Extract</source>
         <comment>提取</comment>
         <translation>Видобуто</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="629"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="613"/>
         <source>Extract to current directory</source>
         <translation>Видобути до поточного каталогу</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="631"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="615"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="633"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="617"/>
         <source>Rename</source>
         <translation>Перейменувати</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="625"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="645"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="634"/>
         <source>Open with</source>
         <translation>Відкрити за допомогою</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="649"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="790"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="638"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="784"/>
         <source>Select default program</source>
         <translation>Виберіть типову програму</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>Підтвердити</translation>
     </message>
     <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="700"/>
+        <location filename="../src/source/tree/uncompressview.cpp" line="694"/>
         <source>Do you want to delete the selected file(s)?</source>
         <translation>Хочете вилучити позначені файли?</translation>
     </message>

--- a/translations/deepin-compressor_zh_CN.ts
+++ b/translations/deepin-compressor_zh_CN.ts
@@ -36,6 +36,19 @@
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation>密码错误</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation>密码输入错误，请重新输入。</translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
         <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
@@ -460,137 +473,137 @@
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="307"/>
-        <location filename="../src/source/mainwindow.cpp" line="317"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>新建归档文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="375"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>正在转换</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="382"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>正在更新注释</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="547"/>
-        <location filename="../src/source/mainwindow.cpp" line="2255"/>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
-        <location filename="../src/source/mainwindow.cpp" line="2318"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>插件异常</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1365"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>追加成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1397"/>
-        <location filename="../src/source/mainwindow.cpp" line="2342"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>压缩包无数据</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1603"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>已取消追加</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1711"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>追加失败</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>提取失败，文件名超长</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1795"/>
-        <location filename="../src/source/mainwindow.cpp" line="2338"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>创建“%1”文件失败</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1921"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>打开失败，文件名超长</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2228"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>压缩成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2234"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>文件名超长，已为您自动截取前60个字符</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2263"/>
-        <location filename="../src/source/mainwindow.cpp" line="2346"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>磁盘空间不足</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2271"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
         <source>No compression support in current directory. Download the files to a local device.</source>
         <translation>当前目录不支持压缩操作，请下载文件到本地设备操作。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
-        <location filename="../src/source/mainwindow.cpp" line="2326"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>分卷缺失</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2305"/>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
         <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
         <translation>当前目录不支持打开压缩包，请下载压缩包到本地设备操作。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2330"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>解压密码错误，请重试</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2275"/>
-        <location filename="../src/source/mainwindow.cpp" line="2334"/>
-        <location filename="../src/source/mainwindow.cpp" line="2362"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>文件名超长，请修改为60个字符以内</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2359"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>转换失败</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2557"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>选择文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3459"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>注释内容不得超过%1 字符</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3335"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>文件信息</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>您是否要删除此压缩文件？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="577"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>“%1”已经发生变化，请重新导入文件。</translation>
     </message>
@@ -605,302 +618,302 @@
         <translation>您没有权限在此路径保存文件，请重试</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="340"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>正在向%1添加文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="347"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>正在压缩</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="354"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>正在解压</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="361"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>正在删除</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="537"/>
-        <location filename="../src/source/mainwindow.cpp" line="3151"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>正在加载，请稍候...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>您确定要停止正在进行的任务吗？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1371"/>
-        <location filename="../src/source/mainwindow.cpp" line="1498"/>
-        <location filename="../src/source/mainwindow.cpp" line="1514"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>正在更新，请稍候...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>文件名过长</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2259"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>创建文件失败</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2252"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>压缩失败</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>替 换</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2751"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>解压到目录</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2286"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>打开失败</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1707"/>
-        <location filename="../src/source/mainwindow.cpp" line="1785"/>
-        <location filename="../src/source/mainwindow.cpp" line="1864"/>
-        <location filename="../src/source/mainwindow.cpp" line="1919"/>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>密码错误</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="656"/>
-        <location filename="../src/source/mainwindow.cpp" line="689"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>不支持打开此格式的文件</translation>
     </message>
     <message>
         <location filename="../src/source/mainwindow.cpp" line="165"/>
-        <location filename="../src/source/mainwindow.cpp" line="482"/>
-        <location filename="../src/source/mainwindow.cpp" line="547"/>
-        <location filename="../src/source/mainwindow.cpp" line="580"/>
-        <location filename="../src/source/mainwindow.cpp" line="641"/>
-        <location filename="../src/source/mainwindow.cpp" line="647"/>
-        <location filename="../src/source/mainwindow.cpp" line="656"/>
-        <location filename="../src/source/mainwindow.cpp" line="696"/>
-        <location filename="../src/source/mainwindow.cpp" line="1397"/>
-        <location filename="../src/source/mainwindow.cpp" line="2517"/>
-        <location filename="../src/source/mainwindow.cpp" line="2537"/>
-        <location filename="../src/source/mainwindow.cpp" line="2845"/>
-        <location filename="../src/source/mainwindow.cpp" line="3010"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="368"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>更名中</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="482"/>
-        <location filename="../src/source/mainwindow.cpp" line="647"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>您没有权限加载“%1”文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
-        <location filename="../src/source/mainwindow.cpp" line="3181"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="641"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>没有那个文件或目录</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1413"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>提取成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1624"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>已取消提取</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1780"/>
-        <location filename="../src/source/mainwindow.cpp" line="1859"/>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
-        <location filename="../src/source/mainwindow.cpp" line="2322"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>当前压缩包文件已损坏</translation>
     </message>
     <message>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
         <location filename="../src/source/mainwindow.cpp" line="2154"/>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
         <source>Failed to create temporary directory, please check and try again.</source>
         <translation>创建临时目录失败，请检查后重试。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2170"/>
-        <location filename="../src/source/mainwindow.cpp" line="2180"/>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
         <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
         <translation>准备压缩重命名后的项目 “%1” 失败，请检查权限及可用空间。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2232"/>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>解压成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2238"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>转换成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2267"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>当前路径已存在压缩分卷</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2315"/>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>解压失败</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2350"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
         <source>No extraction support in current directory. Download the compressed package to a local device.</source>
         <translation>当前目录不支持解压操作，请下载压缩包到本地设备操作。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2549"/>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2553"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2561"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2569"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2581"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>快捷键</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2679"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>文件名与被压缩文件同名，请修改文件名称</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>文件已存在，是否替换？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2830"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>无法将压缩文件添加到自身</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2845"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>此压缩包格式不支持追加文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3181"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3359"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>基本信息</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3375"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3376"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3377"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3378"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>创建时间</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3379"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>访问时间</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3380"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>修改时间</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3390"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>压缩文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3421"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>注释</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="686"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>请在归档管理器的设置中勾选此文件类型</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2517"/>
-        <location filename="../src/source/mainwindow.cpp" line="2537"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>当前压缩文件已经发生变化，请重新导入文件。</translation>
     </message>
@@ -1222,7 +1235,7 @@
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3178"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>文件“%1”已修改，是否将此修改更新到压缩包？</translation>
     </message>
@@ -1322,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="555"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="606"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="607"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="617"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>该名称已存在</translation>
     </message>
@@ -1430,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3641"/>
-        <location filename="../src/source/mainwindow.cpp" line="3696"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3644"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3700"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>文件信息</translation>
     </message>

--- a/translations/deepin-compressor_zh_HK.ts
+++ b/translations/deepin-compressor_zh_HK.ts
@@ -36,6 +36,19 @@
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation>密碼錯誤</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation>密碼錯誤，請再試一次。</translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
         <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
@@ -460,137 +473,137 @@
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="307"/>
-        <location filename="../src/source/mainwindow.cpp" line="317"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>新建歸檔文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="375"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>正在轉換</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="382"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>正在更新注釋</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="547"/>
-        <location filename="../src/source/mainwindow.cpp" line="2255"/>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
-        <location filename="../src/source/mainwindow.cpp" line="2318"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>插件異常</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1365"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>追加成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1397"/>
-        <location filename="../src/source/mainwindow.cpp" line="2342"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>壓縮包無數據</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1603"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>已取消追加</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1711"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>追加失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>提取失敗，文件名超長</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1795"/>
-        <location filename="../src/source/mainwindow.cpp" line="2338"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>創建“%1”文件失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1921"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>打開失敗，文件名超長</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2228"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>壓縮成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2234"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>文件名超長，已為您自動截取前60個字符</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2263"/>
-        <location filename="../src/source/mainwindow.cpp" line="2346"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>磁盤空間不足</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2271"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
         <source>No compression support in current directory. Download the files to a local device.</source>
         <translation>當前目錄不支持壓縮操作，請下載文件到本地設備操作。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
-        <location filename="../src/source/mainwindow.cpp" line="2326"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>分卷缺失</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2305"/>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
         <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
         <translation>當前目錄不支持打開壓縮包，請下載壓縮包到本地設備操作。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2330"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>解壓密碼錯誤，請重試</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2275"/>
-        <location filename="../src/source/mainwindow.cpp" line="2334"/>
-        <location filename="../src/source/mainwindow.cpp" line="2362"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>文件名超長，請修改為60個字符以內</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2359"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>轉換失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2557"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3459"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>注釋內容不得超過%1字符</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3335"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>文件訊息</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>您是否要刪除此壓縮文件？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="577"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>“%1”已經發生變化，請重新導入文件。</translation>
     </message>
@@ -605,302 +618,302 @@
         <translation>您沒有權限在此路徑保存文件，請重試</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="340"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>正在向%1添加文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="347"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>正在壓縮</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="354"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>正在解壓</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="361"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>正在刪除</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="537"/>
-        <location filename="../src/source/mainwindow.cpp" line="3151"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>正在加載，請稍候...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>您確定要停止正在進行的任務嗎？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1371"/>
-        <location filename="../src/source/mainwindow.cpp" line="1498"/>
-        <location filename="../src/source/mainwindow.cpp" line="1514"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>正在更新，請稍候...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>文件名過長</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2259"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>創建文件失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2252"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>壓縮失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>替 換</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2751"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>解壓到目錄</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2286"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>打開失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1707"/>
-        <location filename="../src/source/mainwindow.cpp" line="1785"/>
-        <location filename="../src/source/mainwindow.cpp" line="1864"/>
-        <location filename="../src/source/mainwindow.cpp" line="1919"/>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>密碼錯誤</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="656"/>
-        <location filename="../src/source/mainwindow.cpp" line="689"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>不支持打開此格式的文件</translation>
     </message>
     <message>
         <location filename="../src/source/mainwindow.cpp" line="165"/>
-        <location filename="../src/source/mainwindow.cpp" line="482"/>
-        <location filename="../src/source/mainwindow.cpp" line="547"/>
-        <location filename="../src/source/mainwindow.cpp" line="580"/>
-        <location filename="../src/source/mainwindow.cpp" line="641"/>
-        <location filename="../src/source/mainwindow.cpp" line="647"/>
-        <location filename="../src/source/mainwindow.cpp" line="656"/>
-        <location filename="../src/source/mainwindow.cpp" line="696"/>
-        <location filename="../src/source/mainwindow.cpp" line="1397"/>
-        <location filename="../src/source/mainwindow.cpp" line="2517"/>
-        <location filename="../src/source/mainwindow.cpp" line="2537"/>
-        <location filename="../src/source/mainwindow.cpp" line="2845"/>
-        <location filename="../src/source/mainwindow.cpp" line="3010"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="368"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>更名中</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="482"/>
-        <location filename="../src/source/mainwindow.cpp" line="647"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>您沒有權限加載“%1”文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
-        <location filename="../src/source/mainwindow.cpp" line="3181"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="641"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>沒有那個文件或目錄</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1413"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>提取成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1624"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>已取消提取</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1780"/>
-        <location filename="../src/source/mainwindow.cpp" line="1859"/>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
-        <location filename="../src/source/mainwindow.cpp" line="2322"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>當前壓縮包文件已損壞</translation>
     </message>
     <message>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
         <location filename="../src/source/mainwindow.cpp" line="2154"/>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
         <source>Failed to create temporary directory, please check and try again.</source>
         <translation>建立臨時目錄失敗，請檢查後再試。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2170"/>
-        <location filename="../src/source/mainwindow.cpp" line="2180"/>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
         <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
         <translation>準備壓縮已改名項目 “%1” 失敗，請檢查權限及磁碟空間。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2232"/>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>解壓成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2238"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>轉換成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2267"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>當前路徑已存在壓縮分卷</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2315"/>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>解壓失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2350"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
         <source>No extraction support in current directory. Download the compressed package to a local device.</source>
         <translation>當前目錄不支持解壓操作，請下載壓縮包到本地設備操作。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2549"/>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2553"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2561"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2569"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2581"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2679"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>文件名與被壓縮文件同名，請修改文件名稱</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>文件已存在，是否替換？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2830"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>無法將壓縮文件添加到自身</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2845"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>此壓縮包格式不支持追加文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3181"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3359"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>基本訊息</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3375"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3376"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3377"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3378"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>創建時間</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3379"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>訪問時間</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3380"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>修改時間</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3390"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>壓縮文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3421"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>注釋</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="686"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>請在歸檔管理器的設置中勾選此文件類型</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2517"/>
-        <location filename="../src/source/mainwindow.cpp" line="2537"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>當前壓縮文件已經發生變化，請重新導入文件。</translation>
     </message>
@@ -1222,7 +1235,7 @@
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3178"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>文件“%1”已修改，是否將此修改更新到壓縮包？</translation>
     </message>
@@ -1322,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="555"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="606"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="607"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="617"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>該名稱已存在</translation>
     </message>
@@ -1430,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3641"/>
-        <location filename="../src/source/mainwindow.cpp" line="3696"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>打開文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3644"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3700"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>文件訊息</translation>
     </message>

--- a/translations/deepin-compressor_zh_TW.ts
+++ b/translations/deepin-compressor_zh_TW.ts
@@ -36,6 +36,19 @@
     </message>
 </context>
 <context>
+    <name>CliRarPlugin</name>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>Wrong password</source>
+        <translation>密碼錯誤</translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/clirarplugin/clirarplugin.cpp" line="294"/>
+        <source>The password entered is incorrect. Please try again.</source>
+        <translation>密碼輸入錯誤，請重新輸入。</translation>
+    </message>
+</context>
+<context>
     <name>CommentProgressDialog</name>
     <message>
         <location filename="../src/source/dialog/progressdialog.cpp" line="219"/>
@@ -460,137 +473,137 @@
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="307"/>
-        <location filename="../src/source/mainwindow.cpp" line="317"/>
+        <location filename="../src/source/mainwindow.cpp" line="308"/>
+        <location filename="../src/source/mainwindow.cpp" line="318"/>
         <source>Create New Archive</source>
         <translation>建立歸檔文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="375"/>
+        <location filename="../src/source/mainwindow.cpp" line="376"/>
         <source>Converting</source>
         <translation>正在轉換</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="382"/>
+        <location filename="../src/source/mainwindow.cpp" line="383"/>
         <source>Updating comments</source>
         <translation>正在更新注釋</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="547"/>
-        <location filename="../src/source/mainwindow.cpp" line="2255"/>
-        <location filename="../src/source/mainwindow.cpp" line="2289"/>
-        <location filename="../src/source/mainwindow.cpp" line="2318"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="2250"/>
+        <location filename="../src/source/mainwindow.cpp" line="2284"/>
+        <location filename="../src/source/mainwindow.cpp" line="2313"/>
         <source>Plugin error</source>
         <translation>插件異常</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1365"/>
+        <location filename="../src/source/mainwindow.cpp" line="1360"/>
         <source>Adding successful</source>
         <translation>追加成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1397"/>
-        <location filename="../src/source/mainwindow.cpp" line="2342"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2337"/>
         <source>No data in it</source>
         <translation>壓縮包無數據</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1603"/>
+        <location filename="../src/source/mainwindow.cpp" line="1598"/>
         <source>Adding canceled</source>
         <translation>已取消追加</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1711"/>
+        <location filename="../src/source/mainwindow.cpp" line="1706"/>
         <source>Adding failed</source>
         <translation>追加失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1768"/>
+        <location filename="../src/source/mainwindow.cpp" line="1763"/>
         <source>Extraction failed: the file name is too long</source>
         <translation>提取失敗，檔案名超長</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1795"/>
-        <location filename="../src/source/mainwindow.cpp" line="2338"/>
+        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="2333"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation>創建“%1”文件失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1921"/>
+        <location filename="../src/source/mainwindow.cpp" line="1916"/>
         <source>Open failed: the file name is too long</source>
         <translation>打開失敗，檔案名超長</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2228"/>
+        <location filename="../src/source/mainwindow.cpp" line="2223"/>
         <source>Compression successful</source>
         <translation>壓縮成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2234"/>
+        <location filename="../src/source/mainwindow.cpp" line="2229"/>
         <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
         <translation>檔案名超長，已為您自動截取前60個字元</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2263"/>
-        <location filename="../src/source/mainwindow.cpp" line="2346"/>
+        <location filename="../src/source/mainwindow.cpp" line="2258"/>
+        <location filename="../src/source/mainwindow.cpp" line="2341"/>
         <source>Insufficient disk space</source>
         <translation>磁盤空間不足</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2271"/>
+        <location filename="../src/source/mainwindow.cpp" line="2266"/>
         <source>No compression support in current directory. Download the files to a local device.</source>
         <translation>當前目錄不支援壓縮操作，請下載檔案到本地裝置操作。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2301"/>
-        <location filename="../src/source/mainwindow.cpp" line="2326"/>
+        <location filename="../src/source/mainwindow.cpp" line="2296"/>
+        <location filename="../src/source/mainwindow.cpp" line="2321"/>
         <source>Some volumes are missing</source>
         <translation>分卷缺失</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2305"/>
+        <location filename="../src/source/mainwindow.cpp" line="2300"/>
         <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
         <translation>當前目錄不支援開啟壓縮包，請下載壓縮包到本地裝置操作。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2330"/>
+        <location filename="../src/source/mainwindow.cpp" line="2325"/>
         <source>Wrong password, please retry</source>
         <translation>解壓密碼錯誤，請重試</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2275"/>
-        <location filename="../src/source/mainwindow.cpp" line="2334"/>
-        <location filename="../src/source/mainwindow.cpp" line="2362"/>
+        <location filename="../src/source/mainwindow.cpp" line="2270"/>
+        <location filename="../src/source/mainwindow.cpp" line="2329"/>
+        <location filename="../src/source/mainwindow.cpp" line="2357"/>
         <source>The file name is too long. Keep the name within 60 characters please.</source>
         <translation>檔案名超長，請修改為60個字元以內</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2359"/>
+        <location filename="../src/source/mainwindow.cpp" line="2354"/>
         <source>Conversion failed</source>
         <translation>轉換失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2557"/>
+        <location filename="../src/source/mainwindow.cpp" line="2552"/>
         <source>Select file</source>
         <translation>選擇文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3459"/>
+        <location filename="../src/source/mainwindow.cpp" line="3454"/>
         <source>Enter up to %1 characters</source>
         <translation>注釋內容不得超過%1字元</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3335"/>
+        <location filename="../src/source/mainwindow.cpp" line="3330"/>
         <source>File info</source>
         <translation>文件訊息</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Do you want to delete the archive?</source>
         <translation>您是否要刪除此壓縮文件？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="577"/>
+        <location filename="../src/source/mainwindow.cpp" line="578"/>
         <source>%1 was changed on the disk, please import it again.</source>
         <translation>“%1”已經發生變化，請重新匯入文件。</translation>
     </message>
@@ -605,302 +618,302 @@
         <translation>您沒有權限在此路徑儲存文件，請重試</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="340"/>
+        <location filename="../src/source/mainwindow.cpp" line="341"/>
         <source>Adding files to %1</source>
         <translation>正在向%1添加文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="347"/>
+        <location filename="../src/source/mainwindow.cpp" line="348"/>
         <source>Compressing</source>
         <translation>正在壓縮</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="354"/>
+        <location filename="../src/source/mainwindow.cpp" line="355"/>
         <source>Extracting</source>
         <translation>正在解壓</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="361"/>
+        <location filename="../src/source/mainwindow.cpp" line="362"/>
         <source>Deleting</source>
         <translation>正在刪除</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="537"/>
-        <location filename="../src/source/mainwindow.cpp" line="3151"/>
+        <location filename="../src/source/mainwindow.cpp" line="538"/>
+        <location filename="../src/source/mainwindow.cpp" line="3146"/>
         <source>Loading, please wait...</source>
         <translation>正在載入，請稍候...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
         <source>Are you sure you want to stop the ongoing task?</source>
         <translation>您確定要停止正在進行的任務嗎？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1371"/>
-        <location filename="../src/source/mainwindow.cpp" line="1498"/>
-        <location filename="../src/source/mainwindow.cpp" line="1514"/>
+        <location filename="../src/source/mainwindow.cpp" line="1366"/>
+        <location filename="../src/source/mainwindow.cpp" line="1493"/>
+        <location filename="../src/source/mainwindow.cpp" line="1509"/>
         <source>Updating, please wait...</source>
         <translation>正在更新，請稍候...</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1790"/>
+        <location filename="../src/source/mainwindow.cpp" line="1785"/>
         <source>File name too long</source>
         <translation>文件名過長</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2259"/>
+        <location filename="../src/source/mainwindow.cpp" line="2254"/>
         <source>Failed to create file</source>
         <translation>創建文件失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2252"/>
+        <location filename="../src/source/mainwindow.cpp" line="2247"/>
         <source>Compression failed</source>
         <translation>壓縮失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Replace</source>
         <comment>button</comment>
         <translation>替 換</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2751"/>
+        <location filename="../src/source/mainwindow.cpp" line="2746"/>
         <source>Find directory</source>
         <translation>解壓到目錄</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2286"/>
+        <location filename="../src/source/mainwindow.cpp" line="2281"/>
         <source>Open failed</source>
         <translation>打開失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1707"/>
-        <location filename="../src/source/mainwindow.cpp" line="1785"/>
-        <location filename="../src/source/mainwindow.cpp" line="1864"/>
-        <location filename="../src/source/mainwindow.cpp" line="1919"/>
-        <location filename="../src/source/mainwindow.cpp" line="2297"/>
+        <location filename="../src/source/mainwindow.cpp" line="1702"/>
+        <location filename="../src/source/mainwindow.cpp" line="1780"/>
+        <location filename="../src/source/mainwindow.cpp" line="1859"/>
+        <location filename="../src/source/mainwindow.cpp" line="1914"/>
+        <location filename="../src/source/mainwindow.cpp" line="2292"/>
         <source>Wrong password</source>
         <translation>密碼錯誤</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="656"/>
-        <location filename="../src/source/mainwindow.cpp" line="689"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="690"/>
         <source>The file format is not supported by Archive Manager</source>
         <translation>不支持打開此格式的文件</translation>
     </message>
     <message>
         <location filename="../src/source/mainwindow.cpp" line="165"/>
-        <location filename="../src/source/mainwindow.cpp" line="482"/>
-        <location filename="../src/source/mainwindow.cpp" line="547"/>
-        <location filename="../src/source/mainwindow.cpp" line="580"/>
-        <location filename="../src/source/mainwindow.cpp" line="641"/>
-        <location filename="../src/source/mainwindow.cpp" line="647"/>
-        <location filename="../src/source/mainwindow.cpp" line="656"/>
-        <location filename="../src/source/mainwindow.cpp" line="696"/>
-        <location filename="../src/source/mainwindow.cpp" line="1397"/>
-        <location filename="../src/source/mainwindow.cpp" line="2517"/>
-        <location filename="../src/source/mainwindow.cpp" line="2537"/>
-        <location filename="../src/source/mainwindow.cpp" line="2845"/>
-        <location filename="../src/source/mainwindow.cpp" line="3010"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="548"/>
+        <location filename="../src/source/mainwindow.cpp" line="581"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
+        <location filename="../src/source/mainwindow.cpp" line="657"/>
+        <location filename="../src/source/mainwindow.cpp" line="697"/>
+        <location filename="../src/source/mainwindow.cpp" line="1392"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
+        <location filename="../src/source/mainwindow.cpp" line="3005"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="368"/>
+        <location filename="../src/source/mainwindow.cpp" line="369"/>
         <source>Renaming</source>
         <translation>更名中</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="482"/>
-        <location filename="../src/source/mainwindow.cpp" line="647"/>
+        <location filename="../src/source/mainwindow.cpp" line="483"/>
+        <location filename="../src/source/mainwindow.cpp" line="648"/>
         <source>You do not have permission to load %1</source>
         <translation>您沒有權限載入“%1”文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
-        <location filename="../src/source/mainwindow.cpp" line="3181"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="613"/>
-        <location filename="../src/source/mainwindow.cpp" line="1474"/>
+        <location filename="../src/source/mainwindow.cpp" line="614"/>
+        <location filename="../src/source/mainwindow.cpp" line="1469"/>
         <source>Confirm</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="641"/>
+        <location filename="../src/source/mainwindow.cpp" line="642"/>
         <source>No such file or directory</source>
         <translation>沒有那個文件或目錄</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1413"/>
+        <location filename="../src/source/mainwindow.cpp" line="1408"/>
         <source>Extraction successful</source>
         <comment>提取成功</comment>
         <translation>提取成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1624"/>
+        <location filename="../src/source/mainwindow.cpp" line="1619"/>
         <source>Extraction canceled</source>
         <comment>取消提取</comment>
         <translation>已取消提取</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="1780"/>
-        <location filename="../src/source/mainwindow.cpp" line="1859"/>
-        <location filename="../src/source/mainwindow.cpp" line="2293"/>
-        <location filename="../src/source/mainwindow.cpp" line="2322"/>
+        <location filename="../src/source/mainwindow.cpp" line="1775"/>
+        <location filename="../src/source/mainwindow.cpp" line="1854"/>
+        <location filename="../src/source/mainwindow.cpp" line="2288"/>
+        <location filename="../src/source/mainwindow.cpp" line="2317"/>
         <source>The archive is damaged</source>
         <translation>當前壓縮包文件已損壞</translation>
     </message>
     <message>
+        <location filename="../src/source/mainwindow.cpp" line="2149"/>
         <location filename="../src/source/mainwindow.cpp" line="2154"/>
-        <location filename="../src/source/mainwindow.cpp" line="2159"/>
         <source>Failed to create temporary directory, please check and try again.</source>
         <translation>無法建立暫存目錄，請檢查後再試一次。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2170"/>
-        <location filename="../src/source/mainwindow.cpp" line="2180"/>
+        <location filename="../src/source/mainwindow.cpp" line="2165"/>
+        <location filename="../src/source/mainwindow.cpp" line="2175"/>
         <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
         <translation>準備壓縮重新命名項目 “%1” 時失敗，請檢查權限與可用空間。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2232"/>
+        <location filename="../src/source/mainwindow.cpp" line="2227"/>
         <source>Extraction successful</source>
         <comment>解压成功</comment>
         <translation>解壓成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2238"/>
+        <location filename="../src/source/mainwindow.cpp" line="2233"/>
         <source>Conversion successful</source>
         <translation>轉換成功</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2267"/>
+        <location filename="../src/source/mainwindow.cpp" line="2262"/>
         <source>The compressed volumes already exist</source>
         <translation>當前路徑已存在壓縮分卷</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2315"/>
+        <location filename="../src/source/mainwindow.cpp" line="2310"/>
         <source>Extraction failed</source>
         <comment>解压失败</comment>
         <translation>解壓失敗</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2350"/>
+        <location filename="../src/source/mainwindow.cpp" line="2345"/>
         <source>No extraction support in current directory. Download the compressed package to a local device.</source>
         <translation>當前目錄不支援解壓操作，請下載壓縮包到本地裝置操作。</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2549"/>
+        <location filename="../src/source/mainwindow.cpp" line="2544"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2553"/>
+        <location filename="../src/source/mainwindow.cpp" line="2548"/>
         <source>Help</source>
         <translation>說明</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2561"/>
+        <location filename="../src/source/mainwindow.cpp" line="2556"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2569"/>
+        <location filename="../src/source/mainwindow.cpp" line="2564"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2581"/>
+        <location filename="../src/source/mainwindow.cpp" line="2576"/>
         <source>Shortcuts</source>
         <translation>快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2679"/>
+        <location filename="../src/source/mainwindow.cpp" line="2674"/>
         <source>The name is the same as that of the compressed archive, please use another one</source>
         <translation>檔案名與被壓縮文件同名，請修改檔案名稱</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2687"/>
+        <location filename="../src/source/mainwindow.cpp" line="2682"/>
         <source>Another file with the same name already exists, replace it?</source>
         <translation>文件已存在，是否取代？</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2830"/>
+        <location filename="../src/source/mainwindow.cpp" line="2825"/>
         <source>You cannot add the archive to itself</source>
         <translation>無法將壓縮文件添加到自身</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2845"/>
+        <location filename="../src/source/mainwindow.cpp" line="2840"/>
         <source>You cannot add files to archives in this file type</source>
         <translation>此壓縮包格式不支援追加文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3181"/>
+        <location filename="../src/source/mainwindow.cpp" line="3176"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3359"/>
+        <location filename="../src/source/mainwindow.cpp" line="3354"/>
         <source>Basic info</source>
         <translation>基本訊息</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3375"/>
+        <location filename="../src/source/mainwindow.cpp" line="3370"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3376"/>
+        <location filename="../src/source/mainwindow.cpp" line="3371"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3377"/>
+        <location filename="../src/source/mainwindow.cpp" line="3372"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3378"/>
+        <location filename="../src/source/mainwindow.cpp" line="3373"/>
         <source>Time created</source>
         <translation>創建時間</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3379"/>
+        <location filename="../src/source/mainwindow.cpp" line="3374"/>
         <source>Time accessed</source>
         <translation>訪問時間</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3380"/>
+        <location filename="../src/source/mainwindow.cpp" line="3375"/>
         <source>Time modified</source>
         <translation>修改時間</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3390"/>
+        <location filename="../src/source/mainwindow.cpp" line="3385"/>
         <source>Archive</source>
         <translation>壓縮文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3421"/>
+        <location filename="../src/source/mainwindow.cpp" line="3416"/>
         <source>Comment</source>
         <translation>注釋</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="686"/>
+        <location filename="../src/source/mainwindow.cpp" line="687"/>
         <source>Please check the file association type in the settings of Archive Manager</source>
         <translation>請在歸檔管理器的設定中勾選此文件類型</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="2517"/>
-        <location filename="../src/source/mainwindow.cpp" line="2537"/>
+        <location filename="../src/source/mainwindow.cpp" line="2512"/>
+        <location filename="../src/source/mainwindow.cpp" line="2532"/>
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>目前壓縮文件已經發生變化，請重新匯入文件。</translation>
     </message>
@@ -1222,7 +1235,7 @@
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3178"/>
+        <location filename="../src/source/mainwindow.cpp" line="3173"/>
         <source>%1 changed. Do you want to save changes to the archive?</source>
         <translation>文件“%1”已修改，是否將此修改更新到壓縮包？</translation>
     </message>
@@ -1322,24 +1335,24 @@
 <context>
     <name>RenameDialog</name>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="555"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="569"/>
         <source>Rename</source>
         <translation>重新命名</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="606"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="620"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="607"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="621"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="617"/>
+        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
         <source>The name already exists</source>
         <translation>該名稱已存在</translation>
     </message>
@@ -1430,18 +1443,18 @@
 <context>
     <name>TitleWidget</name>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3641"/>
-        <location filename="../src/source/mainwindow.cpp" line="3696"/>
+        <location filename="../src/source/mainwindow.cpp" line="3636"/>
+        <location filename="../src/source/mainwindow.cpp" line="3691"/>
         <source>Open file</source>
         <translation>打開文件</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3644"/>
+        <location filename="../src/source/mainwindow.cpp" line="3639"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../src/source/mainwindow.cpp" line="3700"/>
+        <location filename="../src/source/mainwindow.cpp" line="3695"/>
         <source>File info</source>
         <translation>文件訊息</translation>
     </message>


### PR DESCRIPTION
RAR5 errors no longer interrupt extraction, user sees floating message instead.
    
Bug: https://pms.uniontech.com/bug-view-354871.html
