### PR TITLE
feat(tx): migrate Transifex config from legacy files to YAML format

### DIFF
--- a/.tx/deepin.conf
+++ b/.tx/deepin.conf
@@ -1,2 +1,0 @@
-[transifex]
-branch = m20

--- a/.tx/transifex.yaml
+++ b/.tx/transifex.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: CC0-1.0
+filters:
+  - filter_type: file
+    source_file: translations/deepin-compressor.ts
+    file_format: QT
+    source_language: en_US
+    translation_files_expression: translations/deepin-compressor_<lang>.ts
+  - filter_type: file
+    source_file: translations/desktop/desktop.ts
+    file_format: QT
+    source_language: en_US
+    translation_files_expression: translations/desktop/desktop_<lang>.ts
+settings:
+  pr_branch_name: transifex_update_<br_unique_id>

--- a/.tx/ts2desktop
+++ b/.tx/ts2desktop
@@ -1,5 +1,0 @@
-DESKTOP_TEMP_FILE=deepin-compressor/deepin-compressor.desktop.tmp
-DESKTOP_SOURCE_FILE=deepin-compressor/deepin-compressor.desktop
-DESKTOP_DEST_FILE=deepin-compressor/deepin-compressor.desktop
-DESKTOP_TS_DIR=translations/desktop
-


### PR DESCRIPTION
Replace old deepin.conf and ts2desktop scripts with modern transifex.yaml configuration for better maintainability.

从旧版配置文件迁移到新的YAML格式，提高可维护性。

Log: 迁移Transifex配置到YAML格式

## Summary by Sourcery

Migrate Transifex integration to a YAML-based configuration under .tx/transifex.yaml and remove the legacy deepin.conf and ts2desktop setup.

Enhancements:
- Introduce a structured transifex.yaml configuration defining QT translation file filters and PR branch naming.
- Remove obsolete Transifex configuration files deepin.conf and ts2desktop from the repository.