### PR TITLE
fix: prevent crash when loadarchive

### DIFF
--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -2610,7 +2610,7 @@ bool MainWindow::handleArguments_Open(const QStringList &listParam)
     if (UiTools::isWayland() && firstLoad) {
         firstLoad = false;
         auto path = listParam[0];
-        QTimer::singleShot(200, [this, &path]() {
+        QTimer::singleShot(200, [this, path]() {
             loadArchive(path);
         });
     } else {


### PR DESCRIPTION
Log: as title

## Summary by Sourcery

Bug Fixes:
- Fix potential crash when scheduling archive loading with a delayed timer on Wayland by ensuring the file path remains valid for the callback.