### PR TITLE
chore:: Update CLA check workflow to inherit secrets

### DIFF
--- a/.github/workflows/call-clacheck.yml
+++ b/.github/workflows/call-clacheck.yml
@@ -12,5 +12,4 @@ concurrency:
 jobs:
   clacheck:
     uses: linuxdeepin/.github/.github/workflows/cla-check.yml@master
-    secrets:
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    secrets: inherit


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Change CLA check workflow configuration to use `secrets: inherit` when calling the shared cla-check workflow.