### PR TITLE
chore: Change secret handling to inherit in call-chatOps.yml

### DIFF
--- a/.github/workflows/call-chatOps.yml
+++ b/.github/workflows/call-chatOps.yml
@@ -6,5 +6,4 @@ on:
 jobs:
   chatopt:
     uses: linuxdeepin/.github/.github/workflows/chatOps.yml@master
-    secrets:
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    secrets: inherit


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust GitHub Actions workflow configuration to inherit secrets when invoking the shared chatOps workflow.