### PR TITLE
fix: Enhance error handling for wrong password scenarios in archive p…

### DIFF
--- a/3rdparty/clirarplugin/clirarplugin.cpp
+++ b/3rdparty/clirarplugin/clirarplugin.cpp
@@ -295,15 +295,11 @@ bool CliRarPlugin::handleLine(const QString &line, WorkType workStatus)
     }
 
     if (isWrongPasswordMsg(line)) {  // 提示密码错误
-        // RAR4密码错误直接结束
-        if (line.startsWith(QLatin1String("Checksum error in the encrypted file"))) {
-            m_eErrorType = ET_WrongPassword;
-            m_finishType = PFT_Error;
-            return false;
-        } else { // RAR5密码错误反复输入新密码
-            m_eErrorType = ET_WrongPassword;
-            return true;
-        }
+        // Strategy: treat wrong password as fatal and let UI show failure page with retry,
+        // consistent with zip/7z behavior.
+        m_eErrorType = ET_WrongPassword;
+        m_finishType = PFT_Error;
+        return false;
     }
 
     if (workStatus == WT_List) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,11 +223,14 @@ int main(int argc, char *argv[])
         qDebug() << "Registering standard DBus service";
         if (dbus.registerService("com.deepin.Compressor")) {
             dbus.registerObject("/com/deepin/Compressor", &w);
-            qDebug() << "DBus service registered successfully, moving window to center";
-            Dtk::Widget::moveToCenter(&w);
+            qDebug() << "DBus service registered successfully";
         } else {
             qWarning() << "Failed to register standard DBus service:" << dbus.lastError().message();
         }
+        // Keep window placement independent from DBus registration result.
+        // Otherwise, in the "second launch" path (service already taken), the window may still
+        // be at a default geometry when password queries trigger, causing mis-centered dialogs.
+        Dtk::Widget::moveToCenter(&w);
     } else {
         qDebug() << "Registering WPS-specific DBus service";
         QString serviceName = "com.deepin.Compressor"+QString::number(QGuiApplication::applicationPid());

--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -1907,7 +1907,7 @@ void MainWindow::handleJobErrorFinished(ArchiveJob::JobType eJobType, ErrorType 
             switch (eErrorType) {
             // 密码错误
             case ET_WrongPassword: {
-                showErrorMessage(FI_Uncompress, EI_WrongPassword);
+                showErrorMessage(FI_Uncompress, EI_WrongPassword, true);
                 break;
             }
             // 文件名过长
@@ -1931,7 +1931,7 @@ void MainWindow::handleJobErrorFinished(ArchiveJob::JobType eJobType, ErrorType 
             break;
         // 密码错误
         case ET_WrongPassword:
-            showErrorMessage(FI_Load, EI_WrongPassword);
+            showErrorMessage(FI_Load, EI_WrongPassword, true);
             break;
         // ftp目录不支持seek操作
         case ET_FileSeekError:
@@ -3495,6 +3495,18 @@ void MainWindow::slotFailureRetry()
     switch (m_pFailurePage->getFailureInfo()) {
     case FI_Compress: {
         m_ePageID = PI_CompressSetting;  // 返回到列表设置界面
+    }
+    break;
+    case FI_Load: {
+        // Retry opening the same archive (e.g. wrong password).
+        const QString archivePath = m_stUnCompressParameter.strFullPath;
+        if (!archivePath.isEmpty()) {
+            loadArchive(archivePath);
+        } else {
+            m_ePageID = PI_Home;
+            refreshPage();
+        }
+        return;
     }
     break;
     case FI_Uncompress: {


### PR DESCRIPTION
…rocessing

- Updated the handling of wrong password messages to treat them as fatal errors, aligning behavior with zip/7z.
- Modified UI error message display to ensure consistent user feedback during password-related failures.
- Implemented retry logic for loading archives after a wrong password error, improving user experience.

These changes improve the robustness of error handling and user interaction during archive operations.

bug: https://pms.uniontech.com/bug-view-355885.html