### PR TITLE
chore: Add libssl-dev to Build-Depends in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Build-Depends:
  libgsettings-qt-dev,
  libarchive-dev,
  libsecret-1-dev,
+ libssl-dev,
  libpoppler-cpp-dev,
  libzip-dev,
  libmount-dev,


### PR DESCRIPTION
- Included libssl-dev as a new build dependency to support SSL functionalities in the project.

## Summary by Sourcery

Build:
- Add libssl-dev to the Build-Depends in debian/control to ensure SSL-related code can be built.