### PR TITLE
fix: show loading page before delayed archive loading on Wayland

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,6 +205,8 @@ int main(int argc, char *argv[])
     if(!orderObject){
         if (dbus.registerService("com.deepin.compressor")) {
             Dtk::Widget::moveToCenter(&w);
+        } else if (UiTools::isWayland()) { // Wayland下非首个实例，弹窗需延迟等窗管设置位置
+            w.setDelayQueryDialog(true);
         }
     } else {
         if (dbus.registerService("com.deepin.compressor"+QString::number(QGuiApplication::applicationPid()))) {
@@ -212,6 +214,8 @@ int main(int argc, char *argv[])
              adaptor.setCompressFile(newfilelist.first());
              Dtk::Widget::moveToCenter(&w);
              w.setProperty(ORDER_JSON, sJsonStr);
+        } else if (UiTools::isWayland()) { // Wayland下非首个实例，弹窗需延迟等窗管设置位置
+            w.setDelayQueryDialog(true);
         }
         QDBusConnection dbusConnection = QDBusConnection::sessionBus();
 

--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -2591,10 +2591,12 @@ bool MainWindow::handleArguments_Open(const QStringList &listParam)
     qInfo() << "打开文件";
     m_eStartupType = StartupType::ST_Normal;
     // 加载单个压缩包数据
-    static bool firstLoad = true;
-    if (UiTools::isWayland() && firstLoad) {
-        firstLoad = false;
+    if (m_bDelayQueryDialog) {
+        m_bDelayQueryDialog = false;
         auto path = listParam[0];
+        m_ePageID = PI_Loading;
+        m_pLoadingPage->setDes(tr("Loading, please wait..."));
+        m_pLoadingPage->startLoading();
         QTimer::singleShot(200, [this, path]() {
             loadArchive(path);
         });

--- a/src/source/mainwindow.h
+++ b/src/source/mainwindow.h
@@ -55,6 +55,8 @@ public :
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow() override;
 
+    void setDelayQueryDialog(bool delay) { m_bDelayQueryDialog = delay; }
+
     /**
      * @brief checkHerePath 检查目标路径是否可写/可执行
      * @param strPath       全路径
@@ -586,6 +588,7 @@ private:
     QString m_fileWriteErrorName;     // 创建失败的文件名
 
     StartupType m_eStartupType = StartupType::ST_Normal;      // 操作方式
+    bool m_bDelayQueryDialog = false;
     CalculateSizeThread *m_mywork = nullptr; // 计算文件(夹)大小线程
     // 适配arm平台
 #ifdef __aarch64__


### PR DESCRIPTION
On Wayland, loadArchive is deferred by 200ms via QTimer but the page ID was not set to PI_Loading beforehand, causing the home page to flash briefly before the loading animation appeared.

Bug: https://pms.uniontech.com/bug-view-359077.html

## Summary by Sourcery

Bug Fixes:
- Set the loading page state before the deferred archive load on Wayland so the home page does not appear briefly before the loading animation.