### PR TITLE
feat: Synchronize the V20 security vulnerability fix to V25

### DIFF
--- a/3rdparty/interface/common.cpp
+++ b/3rdparty/interface/common.cpp
@@ -537,6 +537,74 @@ bool Common::findLnfsPath(const QString &target, Compare func)
 }
 
 
+bool extractPathIsWithinTarget(const QString &extractRoot, const QString &absoluteDestPath)
+{
+    const QFileInfo rootFi(extractRoot);
+    const QString rootCanon = rootFi.canonicalFilePath();
+    if (rootCanon.isEmpty()) {
+        return false;
+    }
+
+    const QString destAbs = QFileInfo(absoluteDestPath).absoluteFilePath();
+    QString path = destAbs;
+
+    while (true) {
+        QFileInfo fi(path);
+        if (fi.exists()) {
+            const QString canon = fi.canonicalFilePath();
+            if (canon.isEmpty()) {
+                return false;
+            }
+            if (!canon.startsWith(rootCanon + QDir::separator()) && canon != rootCanon) {
+                return false;
+            }
+            return true;
+        }
+        const QString parent = fi.path();
+        if (parent == path || parent.isEmpty()) {
+            break;
+        }
+        path = parent;
+    }
+    return rootFi.exists();
+}
+
+bool symlinkTargetIsWithinTarget(const QString &extractRoot, const QString &symlinkFilePath, const QString &symlinkTarget)
+{
+    const QFileInfo rootFi(extractRoot);
+    const QString rootCanon = rootFi.canonicalFilePath();
+    if (rootCanon.isEmpty()) {
+        return false;
+    }
+
+    if (symlinkTarget.isEmpty()) {
+        return false;
+    }
+
+    const QString linkParent = QFileInfo(symlinkFilePath).path();
+    const QString resolved = QDir::cleanPath(QDir(linkParent).absoluteFilePath(symlinkTarget));
+    QString path = resolved;
+
+    while (true) {
+        QFileInfo fi(path);
+        if (fi.exists()) {
+            const QString canon = fi.canonicalFilePath();
+            if (canon.isEmpty()) {
+                return false;
+            }
+            return canon.startsWith(rootCanon + QDir::separator()) || canon == rootCanon;
+        }
+
+        const QString parent = fi.path();
+        if (parent == path || parent.isEmpty()) {
+            break;
+        }
+        path = parent;
+    }
+
+    return resolved.startsWith(rootCanon + QDir::separator()) || resolved == rootCanon;
+}
+
 bool IsMtpFileOrDirectory(QString path) noexcept {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     const static QRegExp regexp("((/run/user/[0-9]+/gvfs/mtp:)|(/root/.gvfs/mtp:)).+");

--- a/3rdparty/interface/common.cpp
+++ b/3rdparty/interface/common.cpp
@@ -540,14 +540,19 @@ bool Common::findLnfsPath(const QString &target, Compare func)
 bool extractPathIsWithinTarget(const QString &extractRoot, const QString &absoluteDestPath)
 {
     const QFileInfo rootFi(extractRoot);
-    const QString rootCanon = rootFi.canonicalFilePath();
+    QString rootCanon = rootFi.canonicalFilePath();
+    // 如果 canonical 失败，使用绝对路径作为后备
     if (rootCanon.isEmpty()) {
-        return false;
+        rootCanon = QDir(extractRoot).absolutePath();
+        if (rootCanon.isEmpty()) {
+            return false;
+        }
     }
 
     const QString destAbs = QFileInfo(absoluteDestPath).absoluteFilePath();
     QString path = destAbs;
 
+    // 向上遍历路径，解析符号链接
     while (true) {
         QFileInfo fi(path);
         if (fi.exists()) {
@@ -555,54 +560,21 @@ bool extractPathIsWithinTarget(const QString &extractRoot, const QString &absolu
             if (canon.isEmpty()) {
                 return false;
             }
+            // 检查解析后的路径是否在解压目录内
             if (!canon.startsWith(rootCanon + QDir::separator()) && canon != rootCanon) {
                 return false;
             }
             return true;
         }
+
         const QString parent = fi.path();
         if (parent == path || parent.isEmpty()) {
             break;
         }
         path = parent;
     }
+
     return rootFi.exists();
-}
-
-bool symlinkTargetIsWithinTarget(const QString &extractRoot, const QString &symlinkFilePath, const QString &symlinkTarget)
-{
-    const QFileInfo rootFi(extractRoot);
-    const QString rootCanon = rootFi.canonicalFilePath();
-    if (rootCanon.isEmpty()) {
-        return false;
-    }
-
-    if (symlinkTarget.isEmpty()) {
-        return false;
-    }
-
-    const QString linkParent = QFileInfo(symlinkFilePath).path();
-    const QString resolved = QDir::cleanPath(QDir(linkParent).absoluteFilePath(symlinkTarget));
-    QString path = resolved;
-
-    while (true) {
-        QFileInfo fi(path);
-        if (fi.exists()) {
-            const QString canon = fi.canonicalFilePath();
-            if (canon.isEmpty()) {
-                return false;
-            }
-            return canon.startsWith(rootCanon + QDir::separator()) || canon == rootCanon;
-        }
-
-        const QString parent = fi.path();
-        if (parent == path || parent.isEmpty()) {
-            break;
-        }
-        path = parent;
-    }
-
-    return resolved.startsWith(rootCanon + QDir::separator()) || resolved == rootCanon;
 }
 
 bool IsMtpFileOrDirectory(QString path) noexcept {

--- a/3rdparty/interface/common.h
+++ b/3rdparty/interface/common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -58,5 +58,15 @@ private:
  * /root/.gvfs/mtp:xxxxxxxxx/xxx
 */
 bool IsMtpFileOrDirectory(QString path) noexcept;
+
+/**
+ * 解压安全：校验目标绝对路径在真实文件系统解析后仍位于解压根目录内（防止符号链接路径逃逸）。
+ */
+bool extractPathIsWithinTarget(const QString &extractRoot, const QString &absoluteDestPath);
+
+/**
+ * 解压安全：ZIP 内符号链接目标解析后须位于解压根目录内。
+ */
+bool symlinkTargetIsWithinTarget(const QString &extractRoot, const QString &symlinkFilePath, const QString &symlinkTarget);
 
 #endif

--- a/3rdparty/interface/common.h
+++ b/3rdparty/interface/common.h
@@ -64,9 +64,4 @@ bool IsMtpFileOrDirectory(QString path) noexcept;
  */
 bool extractPathIsWithinTarget(const QString &extractRoot, const QString &absoluteDestPath);
 
-/**
- * 解压安全：ZIP 内符号链接目标解析后须位于解压根目录内。
- */
-bool symlinkTargetIsWithinTarget(const QString &extractRoot, const QString &symlinkFilePath, const QString &symlinkTarget);
-
 #endif

--- a/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
+++ b/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
@@ -831,6 +831,8 @@ int LibarchivePlugin::extractionFlags() const
 {
     int result = ARCHIVE_EXTRACT_TIME;
     result |= ARCHIVE_EXTRACT_SECURE_NODOTDOT;
+    result |= ARCHIVE_EXTRACT_SECURE_SYMLINKS;
+    result |= ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS;
 
     // TODO: Don't use arksettings here
     /*if ( ArkSettings::preservePerms() )

--- a/3rdparty/libminizipplugin/libminizipplugin.cpp
+++ b/3rdparty/libminizipplugin/libminizipplugin.cpp
@@ -293,6 +293,14 @@ ErrorType LibminizipPlugin::extractEntry(unzFile zipfile, unz_file_info file_inf
         strFileName = strFileName.remove(0, options.strDestination.size());
     }
 
+    while (strFileName.contains(QStringLiteral("../"))) {
+        qInfo() << "skipped ../ path component(s) in " << strFileName;
+        strFileName = strFileName.replace(QStringLiteral("../"), QString());
+    }
+    if (strFileName.contains(QLatin1Char('\\'))) {
+        strFileName = strFileName.replace(QLatin1Char('\\'), QDir::separator());
+    }
+
     emit signalCurFileName(strFileName);        // 发送当前正在解压的文件名
 
     bool bIsDirectory = strFileName.endsWith(QDir::separator());    // 是否为文件夹
@@ -303,6 +311,19 @@ ErrorType LibminizipPlugin::extractEntry(unzFile zipfile, unz_file_info file_inf
 
     // 解压完整文件名（含路径）
     QString strDestFileName = options.strTargetPath + QDir::separator() + strFileName;
+
+    const QString cleanTargetPath = QDir::cleanPath(QDir(options.strTargetPath).absolutePath());
+    const QString cleanDestPath = QDir::cleanPath(QDir(strDestFileName).absolutePath());
+    if (!cleanDestPath.startsWith(cleanTargetPath + QDir::separator()) &&
+        cleanDestPath != cleanTargetPath) {
+        qInfo() << "Path traversal detected! Rejected path: " << strFileName;
+        return ET_FileWriteError;
+    }
+    if (!extractPathIsWithinTarget(options.strTargetPath, strDestFileName)) {
+        qInfo() << "Rejected path (symlink escape or out of root):" << strDestFileName;
+        return ET_FileWriteError;
+    }
+
     QFile file(strDestFileName);
 
     if (bIsDirectory) {     // 文件夹

--- a/3rdparty/libminizipplugin/libminizipplugin.cpp
+++ b/3rdparty/libminizipplugin/libminizipplugin.cpp
@@ -311,19 +311,6 @@ ErrorType LibminizipPlugin::extractEntry(unzFile zipfile, unz_file_info file_inf
 
     // 解压完整文件名（含路径）
     QString strDestFileName = options.strTargetPath + QDir::separator() + strFileName;
-
-    const QString cleanTargetPath = QDir::cleanPath(QDir(options.strTargetPath).absolutePath());
-    const QString cleanDestPath = QDir::cleanPath(QDir(strDestFileName).absolutePath());
-    if (!cleanDestPath.startsWith(cleanTargetPath + QDir::separator()) &&
-        cleanDestPath != cleanTargetPath) {
-        qInfo() << "Path traversal detected! Rejected path: " << strFileName;
-        return ET_FileWriteError;
-    }
-    if (!extractPathIsWithinTarget(options.strTargetPath, strDestFileName)) {
-        qInfo() << "Rejected path (symlink escape or out of root):" << strDestFileName;
-        return ET_FileWriteError;
-    }
-
     QFile file(strDestFileName);
 
     if (bIsDirectory) {     // 文件夹

--- a/3rdparty/libzipplugin/libzipplugin.cpp
+++ b/3rdparty/libzipplugin/libzipplugin.cpp
@@ -910,6 +910,11 @@ ErrorType LibzipPlugin::extractEntry(zip_t *archive, zip_int64_t index, const Ex
         return ET_FileWriteError;
     }
 
+    if (!extractPathIsWithinTarget(options.strTargetPath, strDestFileName)) {
+        qInfo() << "Rejected path (symlink escape or out of root):" << strDestFileName;
+        return ET_FileWriteError;
+    }
+
     QFile file(strDestFileName);
 
     // Store parent mtime.
@@ -966,6 +971,12 @@ ErrorType LibzipPlugin::extractEntry(zip_t *archive, zip_int64_t index, const Ex
         const auto readBytes = zip_fread(zipFile, buf, zip_uint64_t(READBYTES));
         if (readBytes > 0) {
             QString strBuf = QString(buf).toLocal8Bit();
+            if (!symlinkTargetIsWithinTarget(options.strTargetPath, strDestFileName, strBuf)) {
+                qInfo() << "Symlink target escapes extract root, rejected:" << strBuf;
+                zip_fclose(zipFile);
+                emit signalFileWriteErrorName(strBuf);
+                return ET_FileWriteError;
+            }
             if (QFile::link(strBuf, strDestFileName)) {
                 qInfo() << "Symlink's created:" << buf << strFileName;
             } else {

--- a/3rdparty/libzipplugin/libzipplugin.cpp
+++ b/3rdparty/libzipplugin/libzipplugin.cpp
@@ -910,8 +910,9 @@ ErrorType LibzipPlugin::extractEntry(zip_t *archive, zip_int64_t index, const Ex
         return ET_FileWriteError;
     }
 
+    // 写入文件前检查路径是否通过符号链接逃逸
     if (!extractPathIsWithinTarget(options.strTargetPath, strDestFileName)) {
-        qInfo() << "Rejected path (symlink escape or out of root):" << strDestFileName;
+        qInfo() << "Rejected path (symlink escape detected):" << strDestFileName;
         return ET_FileWriteError;
     }
 
@@ -971,12 +972,6 @@ ErrorType LibzipPlugin::extractEntry(zip_t *archive, zip_int64_t index, const Ex
         const auto readBytes = zip_fread(zipFile, buf, zip_uint64_t(READBYTES));
         if (readBytes > 0) {
             QString strBuf = QString(buf).toLocal8Bit();
-            if (!symlinkTargetIsWithinTarget(options.strTargetPath, strDestFileName, strBuf)) {
-                qInfo() << "Symlink target escapes extract root, rejected:" << strBuf;
-                zip_fclose(zipFile);
-                emit signalFileWriteErrorName(strBuf);
-                return ET_FileWriteError;
-            }
             if (QFile::link(strBuf, strDestFileName)) {
                 qInfo() << "Symlink's created:" << buf << strFileName;
             } else {


### PR DESCRIPTION
cherry-pick
0116e203a7200d0dc7a08a3dd113aa6f1d84e524 fix(security): allow symlink creation, check path escape only during file writes (#381)

e3f6b70c26939ad82d2b8df42038e515f395ed79 fix(security): harden symlink target validation during extraction

task: https://pms.uniontech.com/task-view-389585.html

## Summary by Sourcery

Harden archive extraction security to prevent path traversal and symlink-based escapes from the extraction root.

Bug Fixes:
- Normalize and sanitize archive entry paths by removing "../" components and normalizing path separators before extraction.
- Validate destination paths against the extraction root at file-write time to block symlink traversal outside the target directory.
- Enable additional libarchive security flags to disallow unsafe symlinks and absolute paths during extraction.

Enhancements:
- Add a shared utility to verify that a resolved filesystem path remains within a specified extraction root.
- Update copyright metadata in the common header to reflect the current year range.