### PR TITLE
chore: Update version to 6.5.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-compressor (6.5.28) unstable; urgency=medium
+
+  * fix: Fix ZIP multi-volume compression not working after pzip plugin was introduced
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 14 May 2026 19:02:25 +0800
+
 deepin-compressor (6.5.27) unstable; urgency=medium
 
   * chore: Add libssl-dev to Build-Depends in debian/control


### PR DESCRIPTION
- update version to 6.5.28

log: update version to 6.5.28

## Summary by Sourcery

Chores:
- Bump Debian package changelog to version 6.5.28.