### PR TITLE
fix: handle password prompt and missing list in long filename extraction 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,18 @@ debian/deepin-compressor
 debian/deepin-compressor.debhelper.log
 debian/deepin-compressor.substvars
 debian/files
+
+# vscode
+.vscode/
+
+# cursor
+.specstory/
+.cursor/
+.cursorindexingignore
+
+ # ai
+CLAUDE.md
+AGENTS.md
+.trellis
+.claude
+.agents

--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -111,7 +111,7 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
     m_extractOptions = options;
 
     if (!bLnfs) {
-        if (arcData.listRootEntry.isEmpty() && options.qSize < FILE_MAX_SIZE) {
+        if (arcData.listRootEntry.isEmpty()) {
             emit signalprogress(1);
             setProperty("list", "tmpList");
             list();
@@ -1323,7 +1323,51 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
             pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
                                  m_cliProps->extractArgs(absoluteDestinationPath, fileList, false, password));
             pProcess->start();
-            pProcess->waitForFinished(-1);
+
+            // 检测加密文件解压时的密码提示，避免进程卡死
+            if (password.isEmpty()) {
+                bool bPasswordEntered = false;
+                while (!pProcess->waitForFinished(200)) {
+                    if (pProcess->bytesAvailable() > 0) {
+                        QByteArray output = pProcess->readAllStandardOutput();
+                        QStringList lines = QString::fromLocal8Bit(output).split('\n');
+                        for (const QString &line : lines) {
+                            if (isPasswordPrompt(line)) {
+                                pProcess->kill();
+                                pProcess->waitForFinished(3000);
+
+                                PasswordNeededQuery query(m_strArchiveName);
+                                emit signalQuery(&query);
+                                query.waitForResponse();
+
+                                if (query.responseCancelled()) {
+                                    m_eErrorType = ET_NeedPassword;
+                                    return false;
+                                }
+
+                                password = query.password();
+                                DataManager::get_instance().archiveData().strPassword = password;
+
+                                // 带密码参数重新启动解压进程
+                                pProcess->setPtyChannels(KPtyProcess::StdinChannel);
+                                pProcess->setOutputChannelMode(KProcess::MergedChannels);
+                                pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
+                                pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
+                                                     m_cliProps->extractArgs(absoluteDestinationPath, fileList, false, password));
+                                pProcess->start();
+                                pProcess->waitForFinished(-1);
+
+                                bPasswordEntered = true;
+                                break;
+                            }
+                        }
+                        if (bPasswordEntered)
+                            break;
+                    }
+                }
+            } else {
+                pProcess->waitForFinished(-1);
+            }
         }
     }
     pProcess->deleteLater();

--- a/src/source/archivemanager/singlejob.cpp
+++ b/src/source/archivemanager/singlejob.cpp
@@ -116,7 +116,6 @@ void SingleJob::initConnections()
     connect(m_pInterface, &ReadOnlyArchiveInterface::signalCurFileName, this, &SingleJob::signalCurFileName, Qt::ConnectionType::UniqueConnection);
     connect(m_pInterface, &ReadOnlyArchiveInterface::signalFileWriteErrorName, this, &SingleJob::signalFileWriteErrorName, Qt::ConnectionType::UniqueConnection);
     connect(m_pInterface, &ReadOnlyArchiveInterface::signalQuery, this, &SingleJob::signalQuery, Qt::ConnectionType::AutoConnection);
-    connect(m_pInterface, &ReadOnlyArchiveInterface::error, this, &SingleJob::slotError, Qt::AutoConnection);
 }
 
 void SingleJob::slotFinished(PluginFinishType eType)


### PR DESCRIPTION
3 commit: 
1.[fix: handle password prompt and missing list in long filename extraction](https://github.com/linuxdeepin/deepin-compressor/commit/41deaa270559fb1a9b12c91512743f2e5b05e807)
2.[fix: incorrect passing and display of third-party library signals.](https://github.com/linuxdeepin/deepin-compressor/commit/469ec92f0599cc8552683049f4fb87754dcfc32b)
3.[chore: update gitignore](https://github.com/linuxdeepin/deepin-compressor/commit/d97a4a0a21ac0f289c6a848de6f34e4dba34f6b8)

bug:
https://pms.uniontech.com/bug-view-360229.html
https://pms.uniontech.com//bug-view-361845.html