### PR TITLE
fix: handle password prompt and missing list in long filename extraction 

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -117,7 +117,7 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
     m_extractOptions = options;
 
     if (!bLnfs) {
-        if (arcData.listRootEntry.isEmpty() && options.qSize < FILE_MAX_SIZE) {
+        if (arcData.listRootEntry.isEmpty()) {
             emit signalprogress(1);
             setProperty("list", "tmpList");
             list();
@@ -1287,7 +1287,51 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
             pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
                                  m_cliProps->extractArgs(absoluteDestinationPath, fileList, false, password));
             pProcess->start();
-            pProcess->waitForFinished(-1);
+
+            // 检测加密文件解压时的密码提示，避免进程卡死
+            if (password.isEmpty()) {
+                bool bPasswordEntered = false;
+                while (!pProcess->waitForFinished(200)) {
+                    if (pProcess->bytesAvailable() > 0) {
+                        QByteArray output = pProcess->readAllStandardOutput();
+                        QStringList lines = QString::fromLocal8Bit(output).split('\n');
+                        for (const QString &line : lines) {
+                            if (isPasswordPrompt(line)) {
+                                pProcess->kill();
+                                pProcess->waitForFinished(3000);
+
+                                PasswordNeededQuery query(m_strArchiveName);
+                                emit signalQuery(&query);
+                                query.waitForResponse();
+
+                                if (query.responseCancelled()) {
+                                    m_eErrorType = ET_NeedPassword;
+                                    return false;
+                                }
+
+                                password = query.password();
+                                DataManager::get_instance().archiveData().strPassword = password;
+
+                                // 带密码参数重新启动解压进程
+                                pProcess->setPtyChannels(KPtyProcess::StdinChannel);
+                                pProcess->setOutputChannelMode(KProcess::MergedChannels);
+                                pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
+                                pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
+                                                     m_cliProps->extractArgs(absoluteDestinationPath, fileList, false, password));
+                                pProcess->start();
+                                pProcess->waitForFinished(-1);
+
+                                bPasswordEntered = true;
+                                break;
+                            }
+                        }
+                        if (bPasswordEntered)
+                            break;
+                    }
+                }
+            } else {
+                pProcess->waitForFinished(-1);
+            }
         }
     }
     pProcess->deleteLater();

--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -227,7 +227,10 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
         }
         if (bHandleLongName) {
             if (!handleLongNameExtract(m_files)) {
-                m_eErrorType = ET_FileWriteError;
+                if (m_eErrorType == ET_NoError) {
+                    m_eErrorType = ET_FileWriteError;
+                }
+                emit signalFinished(PFT_Error);
                 return PFT_Error;
             }
         }
@@ -269,7 +272,10 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
 
         if (bHandleLongName) {
             if (!handleLongNameExtract(arcData.mapFileEntry.values())) {
-                m_eErrorType = ET_FileWriteError;
+                if (m_eErrorType == ET_NoError) {
+                    m_eErrorType = ET_FileWriteError;
+                }
+                emit signalFinished(PFT_Error);
                 return PFT_Error;
             }
         }
@@ -779,9 +785,14 @@ bool CliInterface::runProcess(const QString &programName, const QStringList &arg
                         if (exitCode != 0) {
                             emit signalprogress(100);
                             emit signalFinished(PFT_Error);
+                            return;
                         }
                         deleteProcess();
-                        extractFiles(m_files, m_extractOptions, property("lnfs").toBool());
+                        PluginFinishType ret = extractFiles(m_files, m_extractOptions, property("lnfs").toBool());
+                        if (ret == PFT_Error) {
+                            emit signalprogress(100);
+                            emit signalFinished(PFT_Error);
+                        }
                     }
                 });
     }
@@ -1320,6 +1331,14 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
                                                      m_cliProps->extractArgs(absoluteDestinationPath, fileList, false, password));
                                 pProcess->start();
                                 pProcess->waitForFinished(-1);
+
+                                if (pProcess->exitCode() != 0) {
+                                    QByteArray output = pProcess->readAllStandardOutput();
+                                    if (output.contains("Wrong password")) {
+                                        m_eErrorType = ET_WrongPassword;
+                                        return false;
+                                    }
+                                }
 
                                 bPasswordEntered = true;
                                 break;


### PR DESCRIPTION
- Add password detection in handleLongNameExtract() for content-encrypted
      archives to prevent UI freeze
    - Remove FILE_MAX_SIZE check so right-click extract always lists first,
      ensuring long filename prescan has archive data available
    
    Log: fix bug
    
    Bug：https://pms.uniontech.com//bug-view-361845.html