### PR TITLE
fix(compressor): fix ZIP append failure when adding same-name folder

### DIFF
--- a/src/source/archivemanager/archivemanager.cpp
+++ b/src/source/archivemanager/archivemanager.cpp
@@ -134,12 +134,11 @@ bool ArchiveManager::loadArchive(const QString &strArchiveFullPath, UiTools::Ass
 bool ArchiveManager::addFiles(const QString &strArchiveFullPath, const QList<FileEntry> &listAddEntry, const CompressOptions &stOptions)
 {
     qDebug() << "Starting addFiles operation for archive:" << strArchiveFullPath;
-    // workaround:
-    // pzip 仅支持新建压缩，目前先将zip 追加时显式指定使用 libzip 插件
+    // pzip 仅支持新建压缩，ZIP 追加时排除 pzip 后保持自动选择
     UiTools::AssignPluginType eType = UiTools::APT_Auto;
     CustomMimeType mimeType = determineMimeType(strArchiveFullPath);
     if (mimeType.name() == QLatin1String("application/zip")) {
-        eType = UiTools::APT_Libzip;
+        eType = UiTools::APT_AutoWithoutPzip;
     }
 
     qDebug() << "Creating interface for adding files, plugin type:" << eType;

--- a/src/source/common/uitools.cpp
+++ b/src/source/common/uitools.cpp
@@ -285,10 +285,11 @@ ReadOnlyArchiveInterface *UiTools::createInterface(const QString &fileName, bool
         }
     }
 
-    // pzip 插件只用于压缩，不用于读取/解压
-    bool removePzipFlag = (!bWrite) && (mimeType.name() == QString("application/zip"));
+    // pzip 插件只用于压缩，不用于读取/解压；ZIP 追加时也需要排除 pzip，回到旧版自动选择链路
+    bool removePzipFlag = (mimeType.name() == QString("application/zip"))
+                          && ((!bWrite) || eType == APT_AutoWithoutPzip);
     if (removePzipFlag) {
-        qDebug() << "Setting flag to remove pzip plugin for reading zip (pzip is write-only)";
+        qDebug() << "Setting flag to remove pzip plugin for zip";
     }
 
     // 创建插件
@@ -310,6 +311,7 @@ ReadOnlyArchiveInterface *UiTools::createInterface(const QString &fileName, bool
         switch (eType) {
         // 自动识别
         case APT_Auto:
+        case APT_AutoWithoutPzip:
             qDebug() << "Using auto-detect plugin type";
             pIface = createInterface(fileName, mimeType, plugin);
             break;

--- a/src/source/common/uitools.h
+++ b/src/source/common/uitools.h
@@ -50,6 +50,7 @@ public:
 
     enum AssignPluginType {
         APT_Auto,           // 自动识别
+        APT_AutoWithoutPzip,// 自动识别，但排除 pzip 插件
         APT_Cli7z,          // cli7zplugin
         APT_Libarchive,     // libarchive
         APT_Libzip,         // libzipplugin


### PR DESCRIPTION
    - Restore automatic plugin selection for ZIP append operations while excluding the pzip plugin, which only supports creating new archives
    - Avoid forcing ZIP append to libzip so the operation can follow the previous plugin priority chain after pzip is filtered out
    - Keep pzip available for new ZIP compression and still exclude it from ZIP read/extract paths

    ZIP 追加时不再强制指定 libzip 插件，
    改为在自动选择插件时排除仅支持新建压缩的 pzip 插件，
    恢复旧版本的插件优先级选择链路，解决向 ZIP 中追加同名文件夹时失败的问题。

    PMS: BUG-364471

    Influence: ZIP 追加同名文件夹时可正常完成，ZIP 新建压缩仍可使用 pzip