### PR TITLE
chore: Update version to 6.5.30

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-compressor (6.5.30) unstable; urgency=medium
+
+  * fix(compressor): fix ZIP append failure when adding same-name folder
+  * fix(compressor): fix cursor jumping to end when editing in rename dialog
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 04 Jun 2026 20:48:00 +0800
+
 deepin-compressor (6.5.29) unstable; urgency=medium
 
   * chore: Update version to 6.5.29


### PR DESCRIPTION
- update version to 6.5.30

log: update version to 6.5.30

## Summary by Sourcery

Chores:
- Update Debian changelog entries to reflect version 6.5.30.