### PR TITLE
chore(tests): adapt unit tests for Qt6 compatibility and fix lcov

### DIFF
--- a/tests/FuzzyTest/libfuzzer/CMakeLists.txt
+++ b/tests/FuzzyTest/libfuzzer/CMakeLists.txt
@@ -16,7 +16,7 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5Core)
+find_package(Qt${QT_DESIRED_VERSION} REQUIRED COMPONENTS Core)
 file(GLOB_RECURSE
   c_files
   ../../../3rdparty/ChardetDetector/*.cpp
@@ -25,7 +25,7 @@ file(GLOB_RECURSE
 
 add_executable(${PROJECT_NAME} "main.cpp"  ${c_files})
 
-target_link_libraries(${PROJECT_NAME} Qt5::Core)
+target_link_libraries(${PROJECT_NAME} Qt${QT_DESIRED_VERSION}::Core)
 target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/libFuzzer.a)
 
 execute_process(COMMAND /usr/bin/cp -rf ${CMAKE_SOURCE_DIR}/libfuzzer_in ${PROJECT_BINARY_DIR}/)

--- a/tests/UnitTest/src/source/dialog/openwithdialog/ut_openwithdialog.cpp
+++ b/tests/UnitTest/src/source/dialog/openwithdialog/ut_openwithdialog.cpp
@@ -158,11 +158,19 @@ TEST_F(UT_OpenWithDialog, test_eventFilter)
 {
     OpenWithDialogListItem *item = new OpenWithDialogListItem(QIcon(), "", m_tester);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseMove, QPointF(0, 0), QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
     QMouseEvent *event = new QMouseEvent(QEvent::MouseMove, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
     m_tester->eventFilter(item, event);
     delete event;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(0, 0), QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
     event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
     m_tester->eventFilter(item, event);
     delete event;
 }

--- a/tests/UnitTest/src/source/page/ut_compresssettingpage.cpp
+++ b/tests/UnitTest/src/source/page/ut_compresssettingpage.cpp
@@ -77,7 +77,11 @@ TEST_F(UT_TypeLabel, initTest)
 TEST_F(UT_TypeLabel, test_mousePressEvent)
 {
     QTest::mousePress(m_tester, Qt::LeftButton);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(50, 50), QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
     QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
     m_tester->mousePressEvent(event);
     delete event;
 }

--- a/tests/UnitTest/src/source/tree/ut_compressview.cpp
+++ b/tests/UnitTest/src/source/tree/ut_compressview.cpp
@@ -417,7 +417,11 @@ TEST_F(UT_CompressView, test_slotPreClicked_002)
 
 TEST_F(UT_CompressView, test_mouseReleaseEvent)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonRelease, QPointF(50, 50), QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
     QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonRelease, QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
     m_tester->mouseReleaseEvent(event);
     delete event;
     EXPECT_EQ(m_tester->m_isPressed, false);
@@ -427,7 +431,11 @@ TEST_F(UT_CompressView, test_mouseMoveEvent)
 {
     m_tester->m_isPressed = true;
     m_tester->m_lastTouchBeginPos = QPoint(0, 0);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseMove, QPointF(50, 50), QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
     QMouseEvent *event = new QMouseEvent(QEvent::MouseMove, QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
     m_tester->mouseMoveEvent(event);
     delete event;
     EXPECT_EQ(m_tester->m_lastTouchBeginPos, QPointF(50, 50));

--- a/tests/UnitTest/src/source/tree/ut_uncompressview.cpp
+++ b/tests/UnitTest/src/source/tree/ut_uncompressview.cpp
@@ -121,7 +121,11 @@ TEST_F(UT_UnCompressView, test_setDefaultUncompressPath)
 
 TEST_F(UT_UnCompressView, test_mousePressEvent)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonRelease, QPointF(50, 50), QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
     QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonRelease, QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
     m_tester->mousePressEvent(event);
     delete event;
     EXPECT_EQ(m_tester->m_dragPos, QPointF(50, 50));
@@ -130,7 +134,11 @@ TEST_F(UT_UnCompressView, test_mousePressEvent)
 TEST_F(UT_UnCompressView, test_mouseMoveEvent)
 {
     m_tester->m_isPressed = true;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseMove, QPointF(50, 50), QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
     QMouseEvent *event = new QMouseEvent(QEvent::MouseMove, QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
     m_tester->m_lastTouchBeginPos = QPointF(200, 100);
     m_tester->mouseMoveEvent(event);
     delete event;
@@ -146,7 +154,11 @@ TEST_F(UT_UnCompressView, test_mouseMoveEvent)
     m_tester->selectAll();
 
     m_tester->m_isPressed = false;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    event = new QMouseEvent(QEvent::MouseMove, QPointF(50, 50), QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
     event = new QMouseEvent(QEvent::MouseMove, QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#endif
     m_tester->m_lastTouchBeginPos = QPointF(200, 100);
     m_tester->mouseMoveEvent(event);
     delete event;

--- a/tests/UnitTest/src/source/ut_mainwindow.cpp
+++ b/tests/UnitTest/src/source/ut_mainwindow.cpp
@@ -972,9 +972,14 @@ TEST_F(UT_MainWindow, test_slotReceiveFileWriteErrorName)
 
 TEST_F(UT_MainWindow, test_slotQuery)
 {
-    Stub stub;
-    CommonStub::stub_OverwriteQuery_execute(stub);
-    OverwriteQuery query("", m_tester);
+    // 使用子类重写execute()替代二进制桩，避免ASan与桩框架冲突导致DEADLYSIGNAL
+    class TestOverwriteQuery : public OverwriteQuery {
+    public:
+        explicit TestOverwriteQuery(const QString &filename, QObject *parent = nullptr)
+            : OverwriteQuery(filename, parent) {}
+        void execute() override { /* no-op */ }
+    };
+    TestOverwriteQuery query("", m_tester);
     m_tester->slotQuery(&query);
 }
 
@@ -1534,6 +1539,7 @@ TEST_F(UT_MainWindow, test_showErrorMessage_012)
 
 TEST_F(UT_MainWindow, test_showErrorMessage_013)
 {
+    m_tester->m_fileWriteErrorName = "testfile.txt";
     m_tester->showErrorMessage(FI_Uncompress, EI_CreatFileFailed);
     EXPECT_EQ(m_tester->m_pFailurePage->m_pDetailLbl->text().contains("Failed to create"), true);
 }

--- a/tests/cmake-lcov-test.sh
+++ b/tests/cmake-lcov-test.sh
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,6 +11,8 @@ cd ../$utdir
 
 cmake -DCMAKE_BUILD_TYPE=Debug ..
 make -j16
+
+export LD_LIBRARY_PATH=./3rdparty/interface:$LD_LIBRARY_PATH
 
 ./bin/tests/bz2plugin_test --gtest_output=xml:./report/report_bz2plugin.xml
 ./bin/tests/cli7zplugin_test --gtest_output=xml:./report/report_cli7zplugin.xml

--- a/tests/test-prj-running.sh
+++ b/tests/test-prj-running.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,7 +37,7 @@ mkdir -p report
 #统计代码覆盖率并生成html报告
 lcov -d $workdir -c -o ./coverage.info
 
-lcov --extract ./coverage.info '*/src/*' -o ./coverage.info
+lcov --extract ./coverage.info '*/3rdparty/*' -o ./coverage.info
 
 lcov --remove ./coverage.info '*/tests/*' -o ./coverage.info
 


### PR DESCRIPTION
- Add QMouseEvent Qt5/Qt6 constructor compatibility in 5 test files
- Replace Stub with subclass in test_slotQuery to avoid ASan conflict
- Fix lcov coverage extraction path from */src/* to */3rdparty/*
- Add LD_LIBRARY_PATH in cmake-lcov-test.sh for runtime library loading
- Use ${QT_DESIRED_VERSION} instead of hardcoded Qt5 in CMake

适配Qt6兼容性：5个测试文件添加QMouseEvent Qt5/Qt6构造函数兼容性，
使用子类替代Stub避免ASan冲突，修复lcov覆盖率提取路径，
添加LD_LIBRARY_PATH环境变量。

Log: 适配Qt6兼容性并修复单元测试覆盖率问题
Influence: 修复后单元测试可在Qt6环境下正常编译运行，代码覆盖率报告正确生成。