### PR TITLE
fix(compressor): fix encrypted file name not shown in password dialog…

### DIFF
--- a/3rdparty/libzipplugin/libzipplugin.cpp
+++ b/3rdparty/libzipplugin/libzipplugin.cpp
@@ -206,8 +206,8 @@ PluginFinishType LibzipPlugin::extractFiles(const QList<FileEntry> &files, const
                         return PFT_Error;
                     }
 
-                    // 全部解压时显示压缩包名称
-                    PasswordNeededQuery query(m_strArchiveName);
+                    // 全部解压时显示当前需要密码的加密文件名
+                    PasswordNeededQuery query(strFileName);
                     emit signalQuery(&query);
                     query.waitForResponse();
 


### PR DESCRIPTION
… during extraction

- Show the encrypted file name in password dialog instead of archive name when extracting encrypted ZIP files with partial encryption
- This helps users identify which specific file requires a password

修复解压加密 ZIP 文件时密码对话框显示压缩包名而非加密文件名的问题，
部分文件加密时显示具体加密文件名，方便用户确认输入密码对应的文件。

PMS: BUG-365277

Influence: 解压部分加密的 ZIP 文件时，密码对话框显示当前需要密码的加密文件名而非压缩包名。

## Summary by Sourcery

Bug Fixes:
- Correct the password prompt during extraction of partially encrypted ZIP files to display the specific file that requires a password rather than the archive name.