### PR TITLE
fix(compressor): fix MIME type detection failure for spanned ZIP files

### DIFF
--- a/src/source/common/mimetypes.cpp
+++ b/src/source/common/mimetypes.cpp
@@ -117,8 +117,13 @@ CustomMimeType determineMimeType(const QString &filename)
     *  谷歌插件crx：内容检测为"application/octet-stream"，后缀检测为"application/octet-stream"，file命令探测为"application/x-chrome-extension"
     *  zip分卷包：内容检测为"application/octet-stream"，后缀检测为"application/zip"，file命令探测为"application/octet-stream"
     *  iso：内容检测为"application/octet-stream"，后缀检测为"application/x-cd-image"，file命令探测为"application/x-iso9660-image"
+    *  WinZip分卷ZIP：扩展名检测为"application/zip"，内容检测可能不是zip（如误识别为pdf），file命令探测为"application/zip"
     */
-    if (mimeFromContent.isDefault()) {
+    const QString &extName = mimeFromExtension.name();
+    bool isZipExtension = (extName == QStringLiteral("application/zip"));
+    bool isContentZip = mimeFromContent.inherits(QStringLiteral("application/zip"));
+    bool needFileCommandFallback = mimeFromContent.isDefault() || (isZipExtension && !isContentZip);
+    if (needFileCommandFallback) {
         qDebug() << "Using file command to detect MIME type for:" << filename;
         QProcess process;
         QStringList args;


### PR DESCRIPTION
- Some spanned ZIP files start with PK\x07\x08 signature (non-standard PK\x03\x04), which Qt MIME detection cannot recognize
- When file extension is .zip but content detection returns non-ZIP type, fall back to file command for re-detection

Qt 无法识别以 PK\x07\x08 开头的分卷 ZIP 文件，当扩展名为 .zip
但内容检测结果非 ZIP 类型时，回退使用 file 命令二次检测以确保
正确识别。

PMS: ztgd2026060900011

Influence: spanned ZIP files can be correctly detected and extracted

## Summary by Sourcery

Bug Fixes:
- Ensure spanned ZIP files with non-standard signatures are correctly detected by falling back to the file command when Qt content detection is inconclusive or inconsistent with a .zip extension.