### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/src/desktop/deepin-compressor.desktop
+++ b/src/desktop/deepin-compressor.desktop
@@ -166,7 +166,7 @@ Name[tr]=Deepin Arşiv Yöneticisi
 Name[ug]=Deepin ئارخىپ باشقۇرغۇچى
 Name[uk]=Керування архівами Deepin
 Name[lo]=Deepin ຕົວຈັດການໄຟລ໌ບີບອັດ
-Name[zh_CN]=深度归档管理器
-Name[zh_HK]=Deepin 歸檔管理器
-Name[zh_TW]=Deepin 歸檔管理器
+Name[zh_CN]=归档管理器
+Name[zh_HK]=歸檔管理器
+Name[zh_TW]=歸檔管理器
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese desktop entry translations by removing unnecessary "深度"/"deepin"/"Deepin" prefixes from Name and Comment fields.