### PR TITLE
fix: Long filename extraction failure (split volume merge + async refactor + suffix truncation fix)

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -275,6 +275,11 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
         }
     }
     if (bHandleLongName) {
+        // 异步长文件名解压进行中时, 不在此处调用 list(),
+        // 由 onLongNameProcessFinished 在解压完成后负责刷新列表
+        if (m_longNamePhase != LNE_None) {
+            return PFT_Nomral;
+        }
         m_eErrorType = ET_LongNameError;
         return list();
     }
@@ -1322,20 +1327,23 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
     } else {
         password = options.password;
     }
-    QScopedPointer<QTemporaryDir> extractTempDir;
-    extractTempDir.reset(new QTemporaryDir());
+    m_longNamePassword = password;
+
+    m_longNameTempDir.reset(new QTemporaryDir());
     QString absoluteDestinationPath;
-    // 复制压缩包到临时目录, 分卷包需复制所有卷, 否则 7z 解压时后续卷缺失会报错或卡死
-    if (!copyArchiveVolumesToDir(m_strArchiveName, extractTempDir->path(), absoluteDestinationPath)) {
-        qWarning() << "handleLongNameExtract: Failed to copy archive volumes to temp dir" << extractTempDir->path();
+    // 复制压缩包到临时目录, 分卷包需合并所有卷, 否则 7z 解压时后续卷缺失会报错或卡死
+    if (!copyArchiveVolumesToDir(m_strArchiveName, m_longNameTempDir->path(), absoluteDestinationPath)) {
+        qWarning() << "handleLongNameExtract: Failed to copy archive volumes to temp dir" << m_longNameTempDir->path();
         m_eErrorType = ET_FileWriteError;
+        m_longNameTempDir.reset();
         return false;
     }
+    m_longNameTempArchivePath = absoluteDestinationPath;
 
     // 第一遍：遍历所有文件，分离需要重命名的文件和普通文件，同时创建目录结构
-    QList<FileEntry> renameEntries;
+    m_renameEntries.clear();
+    m_allFileList.clear();
     QStringList normalFileList;
-    QScopedPointer<KPtyProcess> pProcess(new KPtyProcess);
     qInfo() << "handleLongNameExtract: total files:" << files.count();
 
     for (const FileEntry &entry : files) {
@@ -1360,10 +1368,18 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
             if (m_mapLongName[tempFilePathName]++ >= LONGFILE_SAME_FILES) {
                 emit signalCurFileName(entry.strFullPath);
                 m_eErrorType = ET_LongNameError;
+                m_longNameTempDir.reset();
                 return false;
             }
             m_eErrorType = ET_LongNameError;
-            QString strTempFileName = strTemp + QString("(%1)").arg(m_mapLongName[tempFilePathName], LONGFILE_SUFFIX_FieldWidth, BINARY_NUM, QChar('0')) + "." + QFileInfo(entry.strFullPath).completeSuffix();
+            QString sSuffix = QFileInfo(entry.strFullPath).completeSuffix();
+            if (10 < sSuffix.length()) {
+                sSuffix = QFileInfo(entry.strFullPath).suffix();
+                if (10 < sSuffix.length()) {
+                    sSuffix = sSuffix.right(10);
+                }
+            }
+            QString strTempFileName = strTemp + QString("(%1)").arg(m_mapLongName[tempFilePathName], LONGFILE_SUFFIX_FieldWidth, BINARY_NUM, QChar('0')) + "." + sSuffix;
             strFileName = strTempFileName;
             if (strFilePath != ".") {
                 strFileName = strFilePath + QDir::separator() + strTempFileName;
@@ -1386,6 +1402,7 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
         if (entry.strFullPath.endsWith(QDir::separator())) {
             if (!QDir(strDestFileName).exists()) {
                 if (!QDir(strDestFileName).mkpath(strDestFileName)) {
+                    m_longNameTempDir.reset();
                     return false;
                 }
             }
@@ -1393,7 +1410,7 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
             FileEntry newEntry = entry;
             newEntry.strAlias = QFileInfo(strFileName).fileName();
             if (needRename) {
-                renameEntries.append(newEntry);
+                m_renameEntries.append(newEntry);
             } else {
                 if (info.path() != ".") {
                     normalFileList.append(info.path() + QDir::separator() + newEntry.strAlias);
@@ -1404,95 +1421,150 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
         }
     }
 
-    // 第二步：对需要重命名的文件逐个执行 7z rn
-    qInfo() << "handleLongNameExtract: rename entries:" << renameEntries.count() << ", normal files:" << normalFileList.count();
-    for (const FileEntry &entry : renameEntries) {
-        qInfo() << "handleLongNameExtract: rename" << entry.strFullPath << "->" << entry.strAlias;
-        QList<FileEntry> lstFile;
-        lstFile.append(entry);
-        pProcess->setPtyChannels(KPtyProcess::StdinChannel);
-        pProcess->setOutputChannelMode(KProcess::MergedChannels);
-        pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
-        pProcess->setProgram(m_cliProps->property("moveProgram").toString(), m_cliProps->moveArgs(absoluteDestinationPath, lstFile, DataManager::get_instance().archiveData(), password));
-        pProcess->start();
-        pProcess->waitForFinished(-1);
-    }
-
-    // 第三步：一次性批量解压所有文件（包括重命名后的和普通的）
-    QStringList allFileList;
-    for (const FileEntry &entry : renameEntries) {
+    // 构建完整解压文件列表 (重命名后的文件 + 普通文件)
+    for (const FileEntry &entry : m_renameEntries) {
         QFileInfo info(entry.strFullPath);
         if (info.path() != ".") {
-            allFileList.append(info.path() + QDir::separator() + entry.strAlias);
+            m_allFileList.append(info.path() + QDir::separator() + entry.strAlias);
         } else {
-            allFileList.append(entry.strAlias);
+            m_allFileList.append(entry.strAlias);
         }
     }
-    allFileList.append(normalFileList);
-    qInfo() << "handleLongNameExtract: batch extract files:" << allFileList.count();
+    m_allFileList.append(normalFileList);
 
-    if (!allFileList.isEmpty()) {
-        pProcess->setWorkingDirectory(options.strTargetPath);
-        pProcess->setPtyChannels(KPtyProcess::StdinChannel);
-        pProcess->setOutputChannelMode(KProcess::MergedChannels);
-        pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
-        pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
-                             m_cliProps->extractArgs(absoluteDestinationPath, allFileList, false, password));
-        pProcess->start();
+    qInfo() << "handleLongNameExtract: rename entries:" << m_renameEntries.count()
+            << ", normal files:" << normalFileList.count()
+            << ", all files:" << m_allFileList.count();
 
-        if (password.isEmpty()) {
-            bool bPasswordEntered = false;
-            while (!pProcess->waitForFinished(200)) {
-                if (pProcess->bytesAvailable() > 0) {
-                    QByteArray output = pProcess->readAllStandardOutput();
-                    QStringList lines = QString::fromLocal8Bit(output).split('\n');
-                    for (const QString &line : lines) {
-                        if (isPasswordPrompt(line)) {
-                            pProcess->kill();
-                            pProcess->waitForFinished(3000);
-
-                            PasswordNeededQuery query(m_strArchiveName);
-                            emit signalQuery(&query);
-                            query.waitForResponse();
-
-                            if (query.responseCancelled()) {
-                                m_eErrorType = ET_NeedPassword;
-                                return false;
-                            }
-
-                            password = query.password();
-                            DataManager::get_instance().archiveData().strPassword = password;
-
-                            pProcess->setPtyChannels(KPtyProcess::StdinChannel);
-                            pProcess->setOutputChannelMode(KProcess::MergedChannels);
-                            pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
-                            pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
-                                                 m_cliProps->extractArgs(absoluteDestinationPath, allFileList, false, password));
-                            pProcess->start();
-                            pProcess->waitForFinished(-1);
-
-                            if (pProcess->exitCode() != 0) {
-                                QByteArray output = pProcess->readAllStandardOutput();
-                                if (output.contains("Wrong password")) {
-                                    m_eErrorType = ET_WrongPassword;
-                                    return false;
-                                }
-                            }
-
-                            bPasswordEntered = true;
-                            break;
-                        }
-                    }
-                    if (bPasswordEntered)
-                        break;
-                }
-            }
-        } else {
-            pProcess->waitForFinished(-1);
+    // 第二步：异步执行 7z rn (如有需要重命名的文件)
+    if (!m_renameEntries.isEmpty()) {
+        m_longNamePhase = LNE_Rename;
+        QString program = m_cliProps->property("moveProgram").toString();
+        QStringList args = m_cliProps->moveArgs(m_longNameTempArchivePath, m_renameEntries,
+                                                 DataManager::get_instance().archiveData(), m_longNamePassword);
+        qInfo() << "handleLongNameExtract: starting async rename" << m_renameEntries.count() << "files";
+        if (!startLongNameProcess(program, args)) {
+            m_longNamePhase = LNE_None;
+            m_longNameTempDir.reset();
+            m_renameEntries.clear();
+            m_allFileList.clear();
+            return false;
         }
+        return true;  // 异步进行中, onLongNameProcessFinished 会继续后续步骤
     }
+
+    // 第三步：异步执行 7z e (如有待解压文件)
+    if (!m_allFileList.isEmpty()) {
+        m_longNamePhase = LNE_Extract;
+        QString program = m_cliProps->property("extractProgram").toString();
+        QStringList args = m_cliProps->extractArgs(m_longNameTempArchivePath, m_allFileList, true, m_longNamePassword);
+        qInfo() << "handleLongNameExtract: starting async extract" << m_allFileList.count() << "files";
+        if (!startLongNameProcess(program, args, options.strTargetPath)) {
+            m_longNamePhase = LNE_None;
+            m_longNameTempDir.reset();
+            m_renameEntries.clear();
+            m_allFileList.clear();
+            return false;
+        }
+        return true;  // 异步进行中, onLongNameProcessFinished 会继续后续步骤
+    }
+
+    // 无需重命名也无需解压 (全为目录)
+    return true;
+}
+
+bool CliInterface::startLongNameProcess(const QString &program, const QStringList &args, const QString &workDir)
+{
+    Q_ASSERT(!m_process);
+
+    QString programPath = QStandardPaths::findExecutable(program);
+    if (programPath.isEmpty()) {
+        return false;
+    }
+
+    m_process = new KPtyProcess;
+    m_process->setPtyChannels(KPtyProcess::StdinChannel);
+    m_process->setOutputChannelMode(KProcess::MergedChannels);
+    m_process->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
+    if (!workDir.isEmpty()) {
+        m_process->setWorkingDirectory(workDir);
+    }
+    m_process->setProgram(programPath, args);
+
+    // 复用 readStdout 信号链: 自动处理密码提示、进度、错误等
+    connect(m_process, &QProcess::readyReadStandardOutput, this, [this]() {
+        readStdout();
+    });
+    // 自定义完成处理: 链式启动后续阶段或刷新列表
+    connect(m_process, SIGNAL(finished(int, QProcess::ExitStatus)),
+            this, SLOT(onLongNameProcessFinished(int, QProcess::ExitStatus)));
+
+    m_stdOutData.clear();
+    m_isProcessKilled = false;
+    m_finishType = PFT_Nomral;
+
+    m_process->start();
+    m_process->waitForStarted();
+    m_childProcessId.clear();
+    m_processId = m_process->processId();
 
     return true;
+}
+
+void CliInterface::onLongNameProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    qInfo() << "LongName process finished, exitcode:" << exitCode
+             << "exitstatus:" << exitStatus << "phase:" << m_longNamePhase;
+
+    deleteProcess();
+
+    if (m_isProcessKilled || exitCode != 0) {
+        // 错误或取消 (handleLine 返回 false 导致 killProcess, 或进程异常退出)
+        qWarning() << "LongName extraction failed in phase" << m_longNamePhase
+                   << "killed:" << m_isProcessKilled << "exitCode:" << exitCode;
+        // handleLine 可能已设置 m_finishType (如 PFT_Error/PFT_Cancel);
+        // 若进程异常退出但未产生输出 (handleLine 未被调用), m_finishType 仍为
+        // startLongNameProcess 中设置的 PFT_Nomral, 此处需修正为 PFT_Error
+        if (m_finishType == PFT_Nomral) {
+            m_finishType = PFT_Error;
+        }
+        m_longNamePhase = LNE_None;
+        m_longNameTempDir.reset();
+        m_renameEntries.clear();
+        m_allFileList.clear();
+        emit signalprogress(100);
+        emit signalFinished(m_finishType);
+        return;
+    }
+
+    // 进程正常完成
+    m_finishType = PFT_Nomral;
+
+    if (m_longNamePhase == LNE_Rename) {
+        // 重命名完成, 启动解压阶段
+        m_longNamePhase = LNE_Extract;
+        QString program = m_cliProps->property("extractProgram").toString();
+        QStringList args = m_cliProps->extractArgs(m_longNameTempArchivePath, m_allFileList,
+                                                    true, m_longNamePassword);
+        qInfo() << "LongName: rename done, starting async extract" << m_allFileList.count() << "files";
+        if (!startLongNameProcess(program, args, m_extractOptions.strTargetPath)) {
+            m_longNamePhase = LNE_None;
+            m_longNameTempDir.reset();
+            m_renameEntries.clear();
+            m_allFileList.clear();
+            emit signalprogress(100);
+            emit signalFinished(PFT_Error);
+        }
+    } else if (m_longNamePhase == LNE_Extract) {
+        // 解压完成, 刷新文件列表
+        m_longNamePhase = LNE_None;
+        m_longNameTempDir.reset();
+        m_renameEntries.clear();
+        m_allFileList.clear();
+        m_eErrorType = ET_LongNameError;
+        qInfo() << "LongName: extract done, refreshing file list";
+        list();
+    }
 }
 
 void CliInterface::readStdout(bool handleAll)

--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -1238,6 +1238,80 @@ void CliInterface::removeExtractedFilesOnFailure(const QString &strTargetPath, c
     } while (removed);
 }
 
+bool CliInterface::copyArchiveVolumesToDir(const QString &srcArchive, const QString &destDir, QString &outFirstVolumePath)
+{
+    QFileInfo srcInfo(srcArchive);
+    QString srcDir = srcInfo.absolutePath();
+    QString srcName = srcInfo.fileName();
+
+    // 7z/zip 分卷: xxx.7z.001, xxx.7z.002 ... / xxx.zip.001, xxx.zip.002 ...
+    // 合并为单个文件, 使 7z rn (重命名) 能正常工作 (7z rn 不支持分卷包)
+    static const QRegularExpression reDotNNN(QStringLiteral("^(.+)\\.[0-9]{3}$"));
+    QRegularExpressionMatch m = reDotNNN.match(srcName);
+    if (m.hasMatch()) {
+        QString base = m.captured(1);   // 例如 "收件箱.7z" / "收件箱.zip"
+        QStringList volumePaths;
+        for (int i = 1;; ++i) {
+            QString volName = QString("%1.%2").arg(base).arg(i, 3, 10, QChar('0'));
+            QString volPath = srcDir + QDir::separator() + volName;
+            if (!QFile::exists(volPath)) {
+                break;
+            }
+            volumePaths << volPath;
+        }
+
+        if (volumePaths.count() >= 2) {
+            // 分卷包: 拼接所有卷为单个文件
+            QString mergedPath = destDir + QDir::separator() + base;
+            if (QFile::exists(mergedPath)) {
+                QFile::remove(mergedPath);
+            }
+
+            QFile mergedFile(mergedPath);
+            if (!mergedFile.open(QIODevice::WriteOnly)) {
+                qWarning() << "copyArchiveVolumesToDir: FAILED to open merged file" << mergedPath;
+                return false;
+            }
+
+            for (const QString &volPath : volumePaths) {
+                QFile volFile(volPath);
+                if (!volFile.open(QIODevice::ReadOnly)) {
+                    qWarning() << "copyArchiveVolumesToDir: FAILED to open volume" << volPath;
+                    mergedFile.close();
+                    return false;
+                }
+                const qint64 chunkSize = 4 * 1024 * 1024;  // 4MB
+                while (!volFile.atEnd()) {
+                    QByteArray chunk = volFile.read(chunkSize);
+                    if (chunk.isEmpty()) {
+                        break;
+                    }
+                    mergedFile.write(chunk);
+                }
+                volFile.close();
+            }
+            mergedFile.close();
+
+            outFirstVolumePath = mergedPath;
+            qInfo() << "copyArchiveVolumesToDir: merged" << volumePaths.count()
+                     << "volumes into" << mergedPath;
+            return true;
+        }
+    }
+
+    // rar 分卷 / 非分卷: 复制单个文件
+    QString destPath = destDir + QDir::separator() + srcName;
+    if (QFile::exists(destPath)) {
+        QFile::remove(destPath);
+    }
+    if (!QFile::copy(srcArchive, destPath)) {
+        qWarning() << "copyArchiveVolumesToDir: FAILED to copy" << srcArchive << "->" << destPath;
+        return false;
+    }
+    outFirstVolumePath = destPath;
+    return true;
+}
+
 bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
 {
     ExtractionOptions &options = m_extractOptions;
@@ -1250,10 +1324,13 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
     }
     QScopedPointer<QTemporaryDir> extractTempDir;
     extractTempDir.reset(new QTemporaryDir());
-    QString absoluteDestinationPath = extractTempDir->path() + QDir::separator() + QFileInfo(m_strArchiveName).fileName();
-    QFile tmpFile(absoluteDestinationPath);
-    if (tmpFile.exists()) tmpFile.remove();
-    QFile::copy(m_strArchiveName, absoluteDestinationPath);
+    QString absoluteDestinationPath;
+    // 复制压缩包到临时目录, 分卷包需复制所有卷, 否则 7z 解压时后续卷缺失会报错或卡死
+    if (!copyArchiveVolumesToDir(m_strArchiveName, extractTempDir->path(), absoluteDestinationPath)) {
+        qWarning() << "handleLongNameExtract: Failed to copy archive volumes to temp dir" << extractTempDir->path();
+        m_eErrorType = ET_FileWriteError;
+        return false;
+    }
 
     // 第一遍：遍历所有文件，分离需要重命名的文件和普通文件，同时创建目录结构
     QList<FileEntry> renameEntries;
@@ -1355,12 +1432,12 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
     qInfo() << "handleLongNameExtract: batch extract files:" << allFileList.count();
 
     if (!allFileList.isEmpty()) {
-        QDir::setCurrent(options.strTargetPath);
+        pProcess->setWorkingDirectory(options.strTargetPath);
         pProcess->setPtyChannels(KPtyProcess::StdinChannel);
         pProcess->setOutputChannelMode(KProcess::MergedChannels);
         pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
         pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
-                             m_cliProps->extractArgs(absoluteDestinationPath, allFileList, true, password));
+                             m_cliProps->extractArgs(absoluteDestinationPath, allFileList, false, password));
         pProcess->start();
 
         if (password.isEmpty()) {
@@ -1390,7 +1467,7 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
                             pProcess->setOutputChannelMode(KProcess::MergedChannels);
                             pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
                             pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
-                                                 m_cliProps->extractArgs(absoluteDestinationPath, allFileList, true, password));
+                                                 m_cliProps->extractArgs(absoluteDestinationPath, allFileList, false, password));
                             pProcess->start();
                             pProcess->waitForFinished(-1);
 

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -56,6 +56,12 @@ enum ParseState {
     ParseStateEntryInformation
 };
 
+enum LongNamePhase {
+    LNE_None,
+    LNE_Rename,
+    LNE_Extract
+};
+
 class PasswordNeededQuery;
 
 class CliInterface : public ReadWriteArchiveInterface
@@ -202,6 +208,18 @@ private:
 
     bool handleLongNameExtract(const QList<FileEntry> &files);
 
+    /**
+     * @brief startLongNameProcess 启动长文件名处理的异步子进程 (7z rn 或 7z e)
+     * @param program  程序名 (如 "7z")
+     * @param args     命令参数
+     * @param workDir  工作目录 (为空则不设置)
+     * @return true 进程已成功启动; false 启动失败
+     *
+     * 供 handleLongNameExtract 及 onLongNameProcessFinished 内部使用,
+     * 复用 m_process 成员和 readStdout 信号链。
+     */
+    bool startLongNameProcess(const QString &program, const QStringList &args, const QString &workDir = QString());
+
     bool checkMoveCapability();
 
     /**
@@ -237,6 +255,14 @@ private slots:
      * @param exitStatus  结束状态
      */
     void extractProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+
+    /**
+     * @brief onLongNameProcessFinished 长文件名异步处理子进程结束
+     *
+     * 负责在 7z rn (重命名) 完成后启动 7z e (解压),
+     * 在 7z e 完成后调用 list() 刷新文件列表。
+     */
+    void onLongNameProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
     /**
      * @brief getChildProcessIdNormal7z  对于调用7z出现多个子进程的处理
@@ -277,6 +303,14 @@ private:
     QMap<QString, int> m_mapLongDirName;    // 长文件夹统计
     QMap<QString, int> m_mapRealDirValue;    // 真实文件统计
     QString m_scriptPath; // 脚本路径
+
+    // 长文件名异步解压状态
+    LongNamePhase m_longNamePhase = LNE_None;              // 当前阶段
+    QList<FileEntry> m_renameEntries;                       // 需要重命名的条目
+    QStringList m_allFileList;                              // 所有待解压文件列表
+    QString m_longNameTempArchivePath;                      // 临时目录中合并后的压缩包路径
+    QString m_longNamePassword;                             // 解压密码
+    QScopedPointer<QTemporaryDir> m_longNameTempDir;        // 临时目录 (合并分卷/解压用)
 };
 
 #endif // CLIINTERFACE_H

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -204,6 +204,19 @@ private:
 
     bool checkMoveCapability();
 
+    /**
+     * @brief copyArchiveVolumesToDir 将压缩包(含分卷)完整复制到目标目录
+     * @param srcArchive 原始压缩包路径(分卷时为第一卷, 如 xxx.7z.001 / xxx.zip.001 / xxx.part01.rar)
+     * @param destDir    目标目录
+     * @param outFirstVolumePath 输出: 目标目录中第一卷的完整路径
+     * @return true 全部卷复制成功; false 复制失败
+     *
+     * 用于 handleLongNameExtract 中将压缩包复制到临时目录后再做重命名/解压。
+     * 原实现仅复制单个文件, 对于分卷压缩包(如 .7z.001/.002, .zip.001-.010)
+     * 会导致后续卷缺失, 7z 解压时会报错或卡死。
+     */
+    bool copyArchiveVolumesToDir(const QString &srcArchive, const QString &destDir, QString &outFirstVolumePath);
+
 private slots:
     /**
      * @brief readStdout  读取命令行输出

--- a/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
+++ b/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
@@ -293,7 +293,15 @@ PluginFinishType LibarchivePlugin::extractFiles(const QList<FileEntry> &files, c
                 bLongName = true;
 
                 // bug 117553 tar格式含有多个长名称文件的压缩包，解压第一个同名文件编号是（000）
-                strTempFileName = strTemp + QString("(%1)").arg(m_mapLongName[tempFilePathName] + 1, LONGFILE_SUFFIX_FieldWidth, BINARY_NUM, QChar('0')) + "." + QFileInfo(entryName).completeSuffix();
+                // completeSuffix() 取第一个'.'之后所有内容, 文件名含 v1.4 等小数点时后缀过长导致截断后仍超 NAME_MAX
+                QString sSuffix = QFileInfo(entryName).completeSuffix();
+                if (10 < sSuffix.length()) {
+                    sSuffix = QFileInfo(entryName).suffix();
+                    if (10 < sSuffix.length()) {
+                        sSuffix = sSuffix.right(10);
+                    }
+                }
+                strTempFileName = strTemp + QString("(%1)").arg(m_mapLongName[tempFilePathName] + 1, LONGFILE_SUFFIX_FieldWidth, BINARY_NUM, QChar('0')) + "." + sSuffix;
                 entryName = strTempFileName;
                 if (iIndex >= 0) {
                     entryName = strFilePath + QDir::separator() + strTempFileName;


### PR DESCRIPTION
Extraction fails for archives containing large numbers of files with names
exceeding NAME_MAX (255 bytes). Multiple issues were identified:
1.Split archives (e.g. xxx.zip.001~010) only copied the first volume to the
   temp directory, causing 7z rn (rename) to fail with E_NOTIMPL since 7z rn
   does not support split archives.
2. QFileInfo::completeSuffix() returns everything after the first '.' in the
   filename. For filenames like "xxxv1.4xxx.eml", the first '.' is in "v1.4",
   producing an extremely long suffix (e.g. "4xxx.eml"). After truncation the
   renamed file was still longer than NAME_MAX, or even longer than the
   original.

- Convert handleLongNameExtract from synchronous (waitForFinished(-1)) to
  async pattern using startLongNameProcess / onLongNameProcessFinished,
  reusing the existing readStdout signal chain for password prompts,
  progress reporting, and error handling.

Bug: https://pms.uniontech.com/bug-view-370449.html