### PR TITLE
fix: Long filename extraction failure (split volume merge + async refactor + suffix truncation fix)

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -276,6 +276,11 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
         }
     }
     if (bHandleLongName) {
+        if (m_longNamePhase != LNE_None) {
+            // 异步长文件名解压已启动, 返回 PFT_Nomral 表示"操作进行中"非"已完成";
+            // 最终结果由 onLongNameProcessFinished 通过 signalFinished 发出
+            return PFT_Nomral;
+        }
         m_eErrorType = ET_LongNameError;
         return list();
     }
@@ -1245,10 +1250,11 @@ bool CliInterface::copyArchiveVolumesToDir(const QString &srcArchive, const QStr
     QString srcDir = srcInfo.absolutePath();
     QString srcName = srcInfo.fileName();
 
-    // 7z/zip 分卷: xxx.7z.001, xxx.7z.002 ... / xxx.zip.001, xxx.zip.002 ...
-    // 合并为单个文件, 使 7z rn (重命名) 能正常工作 (7z rn 不支持分卷包)
-    static const QRegularExpression reDotNNN(QStringLiteral("^(.+)\\.[0-9]{3}$"));
-    QRegularExpressionMatch m = reDotNNN.match(srcName);
+    // 7z/zip 分卷: xxx.7z.001, xxx.zip.001 ...
+    // 合并为单个文件, 使 7z rn (不支持分卷) 能正常工作
+    // (.+\.(?:7z|zip)) 捕获含扩展名的完整基本名, 确保 7z 能识别合并后的文件格式
+    static const QRegularExpression reSplitVol(QStringLiteral("^(.+\\.(?:7z|zip))\\.[0-9]{3}$"));
+    QRegularExpressionMatch m = reSplitVol.match(srcName);
     if (m.hasMatch()) {
         QString base = m.captured(1);   // 例如 "archive.7z" / "archive.zip"
         QStringList volumePaths;
@@ -1300,7 +1306,12 @@ bool CliInterface::copyArchiveVolumesToDir(const QString &srcArchive, const QStr
                 }
                 volFile.close();
             }
+            // 检查 flush 结果, 避免 write 缓冲区写入失败时静默丢数据
             mergedFile.close();
+            if (mergedFile.error() != QFile::NoError) {
+                qWarning() << "copyArchiveVolumesToDir: write error on merged file" << mergedPath;
+                return false;
+            }
 
             outFirstVolumePath = mergedPath;
             qInfo() << "copyArchiveVolumesToDir: merged" << volumePaths.count()
@@ -1339,20 +1350,22 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
     } else {
         password = options.password;
     }
-    QScopedPointer<QTemporaryDir> extractTempDir;
-    extractTempDir.reset(new QTemporaryDir());
+    m_longNamePassword = password;
+
+    m_longNameTempDir.reset(new QTemporaryDir());
     QString absoluteDestinationPath;
-    // 复制压缩包到临时目录, 分卷包需复制所有卷, 否则 7z 解压时后续卷缺失会报错或卡死
-    if (!copyArchiveVolumesToDir(m_strArchiveName, extractTempDir->path(), absoluteDestinationPath)) {
-        qWarning() << "handleLongNameExtract: Failed to copy archive volumes to temp dir" << extractTempDir->path();
+    if (!copyArchiveVolumesToDir(m_strArchiveName, m_longNameTempDir->path(), absoluteDestinationPath)) {
+        qWarning() << "handleLongNameExtract: Failed to copy archive volumes to temp dir" << m_longNameTempDir->path();
         m_eErrorType = ET_FileWriteError;
+        m_longNameTempDir.reset();
         return false;
     }
+    m_longNameTempArchivePath = absoluteDestinationPath;
 
-    // 第一遍：遍历所有文件，分离需要重命名的文件和普通文件，同时创建目录结构
-    QList<FileEntry> renameEntries;
+    // 遍历所有文件，分离需要重命名的文件和普通文件，同时创建目录结构
+    m_renameEntries.clear();
+    m_allFileList.clear();
     QStringList normalFileList;
-    QScopedPointer<KPtyProcess> pProcess(new KPtyProcess);
     qInfo() << "handleLongNameExtract: total files:" << files.count();
 
     for (const FileEntry &entry : files) {
@@ -1377,10 +1390,18 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
             if (m_mapLongName[tempFilePathName]++ >= LONGFILE_SAME_FILES) {
                 emit signalCurFileName(entry.strFullPath);
                 m_eErrorType = ET_LongNameError;
+                m_longNameTempDir.reset();
                 return false;
             }
             m_eErrorType = ET_LongNameError;
-            QString strTempFileName = strTemp + QString("(%1)").arg(m_mapLongName[tempFilePathName], LONGFILE_SUFFIX_FieldWidth, BINARY_NUM, QChar('0')) + "." + QFileInfo(entry.strFullPath).completeSuffix();
+            QString sSuffix = QFileInfo(entry.strFullPath).completeSuffix();
+            if (10 < sSuffix.length()) {
+                sSuffix = QFileInfo(entry.strFullPath).suffix();
+                if (10 < sSuffix.length()) {
+                    sSuffix = sSuffix.right(10);
+                }
+            }
+            QString strTempFileName = strTemp + QString("(%1)").arg(m_mapLongName[tempFilePathName], LONGFILE_SUFFIX_FieldWidth, BINARY_NUM, QChar('0')) + "." + sSuffix;
             strFileName = strTempFileName;
             if (strFilePath != ".") {
                 strFileName = strFilePath + QDir::separator() + strTempFileName;
@@ -1403,6 +1424,7 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
         if (entry.strFullPath.endsWith(QDir::separator())) {
             if (!QDir(strDestFileName).exists()) {
                 if (!QDir(strDestFileName).mkpath(strDestFileName)) {
+                    m_longNameTempDir.reset();
                     return false;
                 }
             }
@@ -1410,7 +1432,7 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
             FileEntry newEntry = entry;
             newEntry.strAlias = QFileInfo(strFileName).fileName();
             if (needRename) {
-                renameEntries.append(newEntry);
+                m_renameEntries.append(newEntry);
             } else {
                 if (info.path() != ".") {
                     normalFileList.append(info.path() + QDir::separator() + newEntry.strAlias);
@@ -1421,95 +1443,142 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
         }
     }
 
-    // 第二步：对需要重命名的文件逐个执行 7z rn
-    qInfo() << "handleLongNameExtract: rename entries:" << renameEntries.count() << ", normal files:" << normalFileList.count();
-    for (const FileEntry &entry : renameEntries) {
-        qInfo() << "handleLongNameExtract: rename" << entry.strFullPath << "->" << entry.strAlias;
-        QList<FileEntry> lstFile;
-        lstFile.append(entry);
-        pProcess->setPtyChannels(KPtyProcess::StdinChannel);
-        pProcess->setOutputChannelMode(KProcess::MergedChannels);
-        pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
-        pProcess->setProgram(m_cliProps->property("moveProgram").toString(), m_cliProps->moveArgs(absoluteDestinationPath, lstFile, DataManager::get_instance().archiveData(), password));
-        pProcess->start();
-        pProcess->waitForFinished(-1);
-    }
-
-    // 第三步：一次性批量解压所有文件（包括重命名后的和普通的）
-    QStringList allFileList;
-    for (const FileEntry &entry : renameEntries) {
+    // 构建解压文件列表
+    for (const FileEntry &entry : m_renameEntries) {
         QFileInfo info(entry.strFullPath);
         if (info.path() != ".") {
-            allFileList.append(info.path() + QDir::separator() + entry.strAlias);
+            m_allFileList.append(info.path() + QDir::separator() + entry.strAlias);
         } else {
-            allFileList.append(entry.strAlias);
+            m_allFileList.append(entry.strAlias);
         }
     }
-    allFileList.append(normalFileList);
-    qInfo() << "handleLongNameExtract: batch extract files:" << allFileList.count();
+    m_allFileList.append(normalFileList);
 
-    if (!allFileList.isEmpty()) {
-        pProcess->setWorkingDirectory(options.strTargetPath);
-        pProcess->setPtyChannels(KPtyProcess::StdinChannel);
-        pProcess->setOutputChannelMode(KProcess::MergedChannels);
-        pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
-        pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
-                             m_cliProps->extractArgs(absoluteDestinationPath, allFileList, false, password));
-        pProcess->start();
+    qInfo() << "handleLongNameExtract: rename entries:" << m_renameEntries.count()
+            << ", normal files:" << normalFileList.count()
+            << ", all files:" << m_allFileList.count();
 
-        if (password.isEmpty()) {
-            bool bPasswordEntered = false;
-            while (!pProcess->waitForFinished(200)) {
-                if (pProcess->bytesAvailable() > 0) {
-                    QByteArray output = pProcess->readAllStandardOutput();
-                    QStringList lines = QString::fromLocal8Bit(output).split('\n');
-                    for (const QString &line : lines) {
-                        if (isPasswordPrompt(line)) {
-                            pProcess->kill();
-                            pProcess->waitForFinished(3000);
-
-                            PasswordNeededQuery query(m_strArchiveName);
-                            emit signalQuery(&query);
-                            query.waitForResponse();
-
-                            if (query.responseCancelled()) {
-                                m_eErrorType = ET_NeedPassword;
-                                return false;
-                            }
-
-                            password = query.password();
-                            DataManager::get_instance().archiveData().strPassword = password;
-
-                            pProcess->setPtyChannels(KPtyProcess::StdinChannel);
-                            pProcess->setOutputChannelMode(KProcess::MergedChannels);
-                            pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
-                            pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
-                                                 m_cliProps->extractArgs(absoluteDestinationPath, allFileList, false, password));
-                            pProcess->start();
-                            pProcess->waitForFinished(-1);
-
-                            if (pProcess->exitCode() != 0) {
-                                QByteArray output = pProcess->readAllStandardOutput();
-                                if (output.contains("Wrong password")) {
-                                    m_eErrorType = ET_WrongPassword;
-                                    return false;
-                                }
-                            }
-
-                            bPasswordEntered = true;
-                            break;
-                        }
-                    }
-                    if (bPasswordEntered)
-                        break;
-                }
-            }
-        } else {
-            pProcess->waitForFinished(-1);
+    // 异步执行 7z rn
+    if (!m_renameEntries.isEmpty()) {
+        m_longNamePhase = LNE_Rename;
+        QString program = m_cliProps->property("moveProgram").toString();
+        QStringList args = m_cliProps->moveArgs(m_longNameTempArchivePath, m_renameEntries,
+                                                 DataManager::get_instance().archiveData(), m_longNamePassword);
+        qInfo() << "handleLongNameExtract: starting async rename" << m_renameEntries.count() << "files";
+        if (!startLongNameProcess(program, args)) {
+            m_longNamePhase = LNE_None;
+            m_longNameTempDir.reset();
+            m_renameEntries.clear();
+            m_allFileList.clear();
+            return false;
         }
+        return true;
+    }
+
+    // 异步执行 7z x
+    if (!m_allFileList.isEmpty()) {
+        m_longNamePhase = LNE_Extract;
+        QString program = m_cliProps->property("extractProgram").toString();
+        QStringList args = m_cliProps->extractArgs(m_longNameTempArchivePath, m_allFileList, true, m_longNamePassword);
+        qInfo() << "handleLongNameExtract: starting async extract" << m_allFileList.count() << "files";
+        if (!startLongNameProcess(program, args, options.strTargetPath)) {
+            m_longNamePhase = LNE_None;
+            m_longNameTempDir.reset();
+            m_renameEntries.clear();
+            m_allFileList.clear();
+            return false;
+        }
+        return true;
     }
 
     return true;
+}
+
+bool CliInterface::startLongNameProcess(const QString &program, const QStringList &args, const QString &workDir)
+{
+    Q_ASSERT(!m_process);
+
+    QString programPath = QStandardPaths::findExecutable(program);
+    if (programPath.isEmpty()) {
+        return false;
+    }
+
+    m_process = new KPtyProcess;
+    m_process->setPtyChannels(KPtyProcess::StdinChannel);
+    m_process->setOutputChannelMode(KProcess::MergedChannels);
+    m_process->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
+    if (!workDir.isEmpty()) {
+        m_process->setWorkingDirectory(workDir);
+    }
+    m_process->setProgram(programPath, args);
+
+    connect(m_process, &QProcess::readyReadStandardOutput, this, [this]() {
+        readStdout();
+    });
+    connect(m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, &CliInterface::onLongNameProcessFinished);
+
+    m_stdOutData.clear();
+    m_isProcessKilled = false;
+    m_finishType = PFT_Nomral;
+
+    m_process->start();
+    m_process->waitForStarted();
+    m_childProcessId.clear();
+    m_processId = m_process->processId();
+
+    return true;
+}
+
+void CliInterface::onLongNameProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    qInfo() << "LongName process finished, exitcode:" << exitCode
+             << "exitstatus:" << exitStatus << "phase:" << m_longNamePhase;
+
+    deleteProcess();
+
+    if (m_isProcessKilled || exitCode != 0) {
+        qWarning() << "LongName extraction failed in phase" << m_longNamePhase
+                   << "killed:" << m_isProcessKilled << "exitCode:" << exitCode
+                   << "archive:" << m_longNameTempArchivePath;
+        if (m_finishType == PFT_Nomral) {
+            m_finishType = PFT_Error;
+        }
+        m_longNamePhase = LNE_None;
+        m_longNameTempDir.reset();
+        m_renameEntries.clear();
+        m_allFileList.clear();
+        emit signalprogress(100);
+        emit signalFinished(m_finishType);
+        return;
+    }
+
+    m_finishType = PFT_Nomral;
+
+    if (m_longNamePhase == LNE_Rename) {
+        m_longNamePhase = LNE_Extract;
+        QString program = m_cliProps->property("extractProgram").toString();
+        QStringList args = m_cliProps->extractArgs(m_longNameTempArchivePath, m_allFileList,
+                                                    true, m_longNamePassword);
+        qInfo() << "LongName: rename done, starting async extract" << m_allFileList.count() << "files";
+        if (!startLongNameProcess(program, args, m_extractOptions.strTargetPath)) {
+            qWarning() << "LongName: FAILED to start extract process, archive:" << m_longNameTempArchivePath;
+            m_longNamePhase = LNE_None;
+            m_longNameTempDir.reset();
+            m_renameEntries.clear();
+            m_allFileList.clear();
+            emit signalprogress(100);
+            emit signalFinished(PFT_Error);
+        }
+    } else if (m_longNamePhase == LNE_Extract) {
+        m_longNamePhase = LNE_None;
+        m_longNameTempDir.reset();
+        m_renameEntries.clear();
+        m_allFileList.clear();
+        m_eErrorType = ET_LongNameError;
+        qInfo() << "LongName: extract done, refreshing file list";
+        list();
+    }
 }
 
 void CliInterface::readStdout(bool handleAll)

--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -40,6 +40,7 @@
 #include <QScopedPointer>
 #include <QTemporaryDir>
 #include <QTimer>
+#include <QUuid>
 
 #include "common.h"
 #include <linux/limits.h>
@@ -1238,6 +1239,96 @@ void CliInterface::removeExtractedFilesOnFailure(const QString &strTargetPath, c
     } while (removed);
 }
 
+bool CliInterface::copyArchiveVolumesToDir(const QString &srcArchive, const QString &destDir, QString &outFirstVolumePath)
+{
+    QFileInfo srcInfo(srcArchive);
+    QString srcDir = srcInfo.absolutePath();
+    QString srcName = srcInfo.fileName();
+
+    // 7z/zip 分卷: xxx.7z.001, xxx.7z.002 ... / xxx.zip.001, xxx.zip.002 ...
+    // 合并为单个文件, 使 7z rn (重命名) 能正常工作 (7z rn 不支持分卷包)
+    static const QRegularExpression reDotNNN(QStringLiteral("^(.+)\\.[0-9]{3}$"));
+    QRegularExpressionMatch m = reDotNNN.match(srcName);
+    if (m.hasMatch()) {
+        QString base = m.captured(1);   // 例如 "archive.7z" / "archive.zip"
+        QStringList volumePaths;
+        for (int i = 1;; ++i) {
+            QString volName = QString("%1.%2").arg(base).arg(i, 3, 10, QChar('0'));
+            QString volPath = srcDir + QDir::separator() + volName;
+            if (!QFile::exists(volPath)) {
+                break;
+            }
+            volumePaths << volPath;
+        }
+
+        if (volumePaths.count() >= 2) {
+            // 安全: 使用 O_CREAT|O_EXCL (QIODevice::NewOnly) 原子创建文件,
+            // 不预先 isSymLink 检查或 QFile::remove, 避免 TOCTOU 竞态条件
+            QString mergedPath = destDir + QDir::separator() + base;
+
+            QFile mergedFile(mergedPath);
+            if (!mergedFile.open(QIODevice::WriteOnly | QIODevice::NewOnly)) {
+                // 文件已存在可能是上次失败残留, 使用唯一名称重试
+                mergedPath = destDir + QDir::separator() + base + QStringLiteral(".merged");
+                mergedFile.setFileName(mergedPath);
+                if (!mergedFile.open(QIODevice::WriteOnly | QIODevice::NewOnly)) {
+                    qWarning() << "copyArchiveVolumesToDir: FAILED to create merged file" << mergedPath;
+                    return false;
+                }
+            }
+
+            for (const QString &volPath : volumePaths) {
+                QFile volFile(volPath);
+                if (!volFile.open(QIODevice::ReadOnly)) {
+                    qWarning() << "copyArchiveVolumesToDir: FAILED to open volume" << volPath;
+                    mergedFile.close();
+                    return false;
+                }
+                const qint64 chunkSize = 4 * 1024 * 1024;  // 4MB
+                while (!volFile.atEnd()) {
+                    QByteArray chunk = volFile.read(chunkSize);
+                    if (chunk.isEmpty()) {
+                        // 修复: 检查读取错误
+                        if (volFile.error() != QFile::NoError) {
+                            qWarning() << "copyArchiveVolumesToDir: Error reading volume" << volPath;
+                            mergedFile.close();
+                            return false;
+                        }
+                        break;
+                    }
+                    mergedFile.write(chunk);
+                }
+                volFile.close();
+            }
+            mergedFile.close();
+
+            outFirstVolumePath = mergedPath;
+            qInfo() << "copyArchiveVolumesToDir: merged" << volumePaths.count()
+                     << "volumes into" << mergedPath;
+            return true;
+        }
+    }
+
+    // rar 分卷 / 非分卷: 复制单个文件 (rar 由 unrar 原生处理分卷)
+    // 安全: 使用含 UUID 的唯一临时文件名, 避免 exists+remove 竞态条件;
+    // 复制成功后用原子 rename 放入目标路径
+    QString destPath = destDir + QDir::separator() + srcName;
+    QString tempPath = destDir + QDir::separator() + srcName + QStringLiteral(".tmpcopy.") + QUuid::createUuid().toString(QUuid::WithoutBraces);
+
+    if (!QFile::copy(srcArchive, tempPath)) {
+        qWarning() << "copyArchiveVolumesToDir: FAILED to copy" << srcArchive << "->" << tempPath;
+        return false;
+    }
+    QFile::remove(destPath);
+    if (!QFile::rename(tempPath, destPath)) {
+        qWarning() << "copyArchiveVolumesToDir: FAILED to rename" << tempPath << "->" << destPath;
+        QFile::remove(tempPath);
+        return false;
+    }
+    outFirstVolumePath = destPath;
+    return true;
+}
+
 bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
 {
     ExtractionOptions &options = m_extractOptions;
@@ -1250,10 +1341,13 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
     }
     QScopedPointer<QTemporaryDir> extractTempDir;
     extractTempDir.reset(new QTemporaryDir());
-    QString absoluteDestinationPath = extractTempDir->path() + QDir::separator() + QFileInfo(m_strArchiveName).fileName();
-    QFile tmpFile(absoluteDestinationPath);
-    if (tmpFile.exists()) tmpFile.remove();
-    QFile::copy(m_strArchiveName, absoluteDestinationPath);
+    QString absoluteDestinationPath;
+    // 复制压缩包到临时目录, 分卷包需复制所有卷, 否则 7z 解压时后续卷缺失会报错或卡死
+    if (!copyArchiveVolumesToDir(m_strArchiveName, extractTempDir->path(), absoluteDestinationPath)) {
+        qWarning() << "handleLongNameExtract: Failed to copy archive volumes to temp dir" << extractTempDir->path();
+        m_eErrorType = ET_FileWriteError;
+        return false;
+    }
 
     // 第一遍：遍历所有文件，分离需要重命名的文件和普通文件，同时创建目录结构
     QList<FileEntry> renameEntries;
@@ -1355,12 +1449,12 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
     qInfo() << "handleLongNameExtract: batch extract files:" << allFileList.count();
 
     if (!allFileList.isEmpty()) {
-        QDir::setCurrent(options.strTargetPath);
+        pProcess->setWorkingDirectory(options.strTargetPath);
         pProcess->setPtyChannels(KPtyProcess::StdinChannel);
         pProcess->setOutputChannelMode(KProcess::MergedChannels);
         pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
         pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
-                             m_cliProps->extractArgs(absoluteDestinationPath, allFileList, true, password));
+                             m_cliProps->extractArgs(absoluteDestinationPath, allFileList, false, password));
         pProcess->start();
 
         if (password.isEmpty()) {
@@ -1390,7 +1484,7 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
                             pProcess->setOutputChannelMode(KProcess::MergedChannels);
                             pProcess->setNextOpenMode(QIODevice::ReadWrite | QIODevice::Unbuffered | QIODevice::Text);
                             pProcess->setProgram(m_cliProps->property("extractProgram").toString(),
-                                                 m_cliProps->extractArgs(absoluteDestinationPath, allFileList, true, password));
+                                                 m_cliProps->extractArgs(absoluteDestinationPath, allFileList, false, password));
                             pProcess->start();
                             pProcess->waitForFinished(-1);
 

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -56,6 +56,12 @@ enum ParseState {
     ParseStateEntryInformation
 };
 
+enum LongNamePhase {
+    LNE_None,
+    LNE_Rename,
+    LNE_Extract
+};
+
 class PasswordNeededQuery;
 
 class CliInterface : public ReadWriteArchiveInterface
@@ -202,18 +208,14 @@ private:
 
     bool handleLongNameExtract(const QList<FileEntry> &files);
 
+    bool startLongNameProcess(const QString &program, const QStringList &args, const QString &workDir = QString());
+
     bool checkMoveCapability();
 
     /**
      * @brief copyArchiveVolumesToDir 将压缩包(含分卷)完整复制到目标目录
-     * @param srcArchive 原始压缩包路径(分卷时为第一卷, 如 xxx.7z.001 / xxx.zip.001 / xxx.part01.rar)
-     * @param destDir    目标目录
-     * @param outFirstVolumePath 输出: 目标目录中第一卷的完整路径
-     * @return true 全部卷复制成功; false 复制失败
      *
-     * 用于 handleLongNameExtract 中将压缩包复制到临时目录后再做重命名/解压。
-     * 原实现仅复制单个文件, 对于分卷压缩包(如 .7z.001/.002, .zip.001-.010)
-     * 会导致后续卷缺失, 7z 解压时会报错或卡死。
+     * 7z/zip 分卷合并为单个文件 (7z rn 不支持分卷), rar/非分卷直接复制。
      */
     bool copyArchiveVolumesToDir(const QString &srcArchive, const QString &destDir, QString &outFirstVolumePath);
 
@@ -237,6 +239,8 @@ private slots:
      * @param exitStatus  结束状态
      */
     void extractProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+
+    void onLongNameProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
     /**
      * @brief getChildProcessIdNormal7z  对于调用7z出现多个子进程的处理
@@ -277,6 +281,13 @@ private:
     QMap<QString, int> m_mapLongDirName;    // 长文件夹统计
     QMap<QString, int> m_mapRealDirValue;    // 真实文件统计
     QString m_scriptPath; // 脚本路径
+
+    LongNamePhase m_longNamePhase = LNE_None;
+    QList<FileEntry> m_renameEntries;
+    QStringList m_allFileList;
+    QString m_longNameTempArchivePath;
+    QString m_longNamePassword;
+    QScopedPointer<QTemporaryDir> m_longNameTempDir;
 };
 
 #endif // CLIINTERFACE_H

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -204,6 +204,19 @@ private:
 
     bool checkMoveCapability();
 
+    /**
+     * @brief copyArchiveVolumesToDir 将压缩包(含分卷)完整复制到目标目录
+     * @param srcArchive 原始压缩包路径(分卷时为第一卷, 如 xxx.7z.001 / xxx.zip.001 / xxx.part01.rar)
+     * @param destDir    目标目录
+     * @param outFirstVolumePath 输出: 目标目录中第一卷的完整路径
+     * @return true 全部卷复制成功; false 复制失败
+     *
+     * 用于 handleLongNameExtract 中将压缩包复制到临时目录后再做重命名/解压。
+     * 原实现仅复制单个文件, 对于分卷压缩包(如 .7z.001/.002, .zip.001-.010)
+     * 会导致后续卷缺失, 7z 解压时会报错或卡死。
+     */
+    bool copyArchiveVolumesToDir(const QString &srcArchive, const QString &destDir, QString &outFirstVolumePath);
+
 private slots:
     /**
      * @brief readStdout  读取命令行输出

--- a/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
+++ b/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
@@ -293,7 +293,14 @@ PluginFinishType LibarchivePlugin::extractFiles(const QList<FileEntry> &files, c
                 bLongName = true;
 
                 // bug 117553 tar格式含有多个长名称文件的压缩包，解压第一个同名文件编号是（000）
-                strTempFileName = strTemp + QString("(%1)").arg(m_mapLongName[tempFilePathName] + 1, LONGFILE_SUFFIX_FieldWidth, BINARY_NUM, QChar('0')) + "." + QFileInfo(entryName).completeSuffix();
+                QString sSuffix = QFileInfo(entryName).completeSuffix();
+                if (10 < sSuffix.length()) {
+                    sSuffix = QFileInfo(entryName).suffix();
+                    if (10 < sSuffix.length()) {
+                        sSuffix = sSuffix.right(10);
+                    }
+                }
+                strTempFileName = strTemp + QString("(%1)").arg(m_mapLongName[tempFilePathName] + 1, LONGFILE_SUFFIX_FieldWidth, BINARY_NUM, QChar('0')) + "." + sSuffix;
                 entryName = strTempFileName;
                 if (iIndex >= 0) {
                     entryName = strFilePath + QDir::separator() + strTempFileName;


### PR DESCRIPTION
Extraction fails for archives containing large numbers of files with names
exceeding NAME_MAX (255 bytes). Multiple issues were identified:
1.Split archives (e.g. xxx.zip.001~010) only copied the first volume to the
temp directory, causing 7z rn (rename) to fail with E_NOTIMPL since 7z rn
does not support split archives.
2. QFileInfo::completeSuffix() returns everything after the first '.' in the
filename. For filenames like "xxxv1.4xxx.eml", the first '.' is in "v1.4",
producing an extremely long suffix (e.g. "4xxx.eml"). After truncation the
renamed file was still longer than NAME_MAX, or even longer than the
original.

Convert handleLongNameExtract from synchronous (waitForFinished(-1)) to
async pattern using startLongNameProcess / onLongNameProcessFinished,
reusing the existing readStdout signal chain for password prompts,
progress reporting, and error handling.
Bug: https://pms.uniontech.com/bug-view-370449.html