### PR TITLE
chore: Update version to 6.5.32

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+deepin-compressor (6.5.32) unstable; urgency=medium
+
+  * chore: Update version to 6.5.32
+  * fix: update cppcheck workflow to use checkout@v7
+  * fix(compressor): prevent extracting to archive file path
+  * fix: remove deepin prefix from Chinese translations in desktop file
+  * [skip CI] Translate deepin-compressor.ts in ru
+  * [skip CI] Translate deepin-compressor.ts in it
+  * [skip CI] Translate deepin-compressor.ts in cs
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:07:45 +0800
+
 deepin-compressor (6.5.31) unstable; urgency=medium
 
   * fix(compressor): fix MIME type detection failure for spanned ZIP files


### PR DESCRIPTION
- update version to 6.5.32

log: update version to 6.5.32

## Summary by Sourcery

Chores:
- Bump recorded project version to 6.5.32 in the Debian changelog.