### PR TITLE
fix: disable file drag-and-drop on comment edit boxes

### DIFF
--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -3446,6 +3446,7 @@ void MainWindow::slotTitleCommentButtonPressed()
         // 显示注释内容的控件
         DTextEdit *commentTextedit = new DTextEdit(commentDrawer);
         commentTextedit->setTabChangesFocus(true); //使用tab按键切换焦点功能
+        commentTextedit->setAcceptDrops(false); // 禁止拖拽文件到注释框
         bool isReadOnly = false;
         if (m_stUnCompressParameter.bCommentModifiable) { // 只有zip格式支持修改注释(注:zip分卷也不支持修改注释)
             if (m_stUnCompressParameter.strFullPath.endsWith(".zip")) {

--- a/src/source/page/compresssettingpage.cpp
+++ b/src/source/page/compresssettingpage.cpp
@@ -284,6 +284,7 @@ void CompressSettingPage::initUI()
 
     m_pCommentEdt->setPlaceholderText(tr("Enter up to %1 characters").arg(MAXCOMMENTLEN));
     m_pCommentEdt->setTabChangesFocus(true); // DTextEdit中Tab键切换焦点
+    m_pCommentEdt->setAcceptDrops(false); // 禁止拖拽文件到注释框
 
     m_pCompressBtn->setMinimumWidth(340);    // 设置压缩按钮最小尺寸
 


### PR DESCRIPTION
## 根因分析

压缩设置界面和注释抽屉中的注释框（DTextEdit）未禁用拖拽接受（acceptDrops 默认为 true），QTextEdit 默认 dropEvent 通过 insertFromMimeData() 接受文件 URL 并插入为文本，导致文件可拖入注释框。

## 修复方案

在两处注释框初始化处添加 setAcceptDrops(false)，禁止注释框接受文件拖拽。

## 关联

PMS: https://pms.uniontech.com/bug-view-371747.html

## Summary by Sourcery

Disable file drag-and-drop into comment text fields to prevent files being inserted as text when editing comments.

Bug Fixes:
- Prevent files from being dragged and dropped into the main window comment drawer text box.
- Prevent files from being dragged and dropped into the compress settings comment text box.