### PR TITLE
fix: propagate write errors in libarchive extraction to avoid false success

### DIFF
--- a/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
+++ b/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
@@ -397,6 +397,10 @@ PluginFinishType LibarchivePlugin::extractFiles(const QList<FileEntry> &files, c
             m_mapLongName[tempFilePathName]++;   // 保存文件路径，不同目录下的同名文件分开计数，解压成功，添加计数
 
             copyDataFromSource(m_archiveReader.data(), writer.data(), QFileInfo(m_strArchiveName).size());
+            // 数据写入失败（如磁盘空间不足）时立即终止解压，避免误报成功
+            if (m_eErrorType != ET_NoError) {
+                return PFT_Error;
+            }
 
             // qInfo() <<  destinationDirectory + QDir::separator() + entryName;
             // 文件权限设置
@@ -684,6 +688,12 @@ void LibarchivePlugin::copyDataFromSource(struct archive *source, struct archive
     char buff[10240]; //缓存大小
     auto readBytes = archive_read_data(source, buff, sizeof(buff)); //读压缩包数据到buff
 
+    // 读取压缩包数据失败（如压缩包损坏）时设置错误类型，避免解压仍误报成功
+    if (readBytes < 0) {
+        m_eErrorType = ET_FileReadError;
+        return;
+    }
+
     while (readBytes > 0 && !QThread::currentThread()->isInterruptionRequested()) {
         if (m_bPause) { //解压暂停
             sleep(1);
@@ -693,6 +703,12 @@ void LibarchivePlugin::copyDataFromSource(struct archive *source, struct archive
 
         archive_write_data(dest, buff, static_cast<size_t>(readBytes)); //写数据
         if (archive_errno(dest) != ARCHIVE_OK) {
+            //ENOSPC /* No space left on device */ EDQUOT /* Disk quota exceeded */
+            if (archive_errno(dest) == ENOSPC || archive_errno(dest) == EDQUOT) {
+                m_eErrorType = ET_InsufficientDiskSpace;
+            } else {
+                m_eErrorType = ET_FileWriteError;
+            }
             return;
         }
 
@@ -700,6 +716,11 @@ void LibarchivePlugin::copyDataFromSource(struct archive *source, struct archive
         emit signalprogress(double(archive_filter_bytes(source, -1)) / totalSize * 100);
 
         readBytes = archive_read_data(source, buff, sizeof(buff));
+        // 循环尾部读取失败同样需要检查，避免多分块文件中途读损坏时误报成功
+        if (readBytes < 0) {
+            m_eErrorType = ET_FileReadError;
+            return;
+        }
     }
 }
 

--- a/3rdparty/libarchive/readwritelibarchiveplugin/readwritelibarchiveplugin.cpp
+++ b/3rdparty/libarchive/readwritelibarchiveplugin/readwritelibarchiveplugin.cpp
@@ -69,6 +69,7 @@ ReadWriteLibarchivePlugin::~ReadWriteLibarchivePlugin()
 PluginFinishType ReadWriteLibarchivePlugin::addFiles(const QList<FileEntry> &files, const CompressOptions &options)
 {
     qInfo()<<"ReadWriteLibarchivePlugin addFiles";
+    m_eErrorType = ET_NoError;
     if( !m_tempDir.isValid()) {
         return PFT_Error;
     }
@@ -151,6 +152,7 @@ PluginFinishType ReadWriteLibarchivePlugin::addFiles(const QList<FileEntry> &fil
 
 PluginFinishType ReadWriteLibarchivePlugin::deleteFiles(const QList<FileEntry> &files)
 {
+    m_eErrorType = ET_NoError;
     if (files.count() == 0) {
         return PFT_Error;
     }
@@ -596,9 +598,21 @@ void ReadWriteLibarchivePlugin::copyDataFromSourceAdd(archive *source, archive *
     char buff[10240];
     auto readBytes = archive_read_data(source, buff, sizeof(buff));
 
+    // 读取压缩包数据失败时设置错误类型，避免误报成功
+    if (readBytes < 0) {
+        m_eErrorType = ET_FileReadError;
+        return;
+    }
+
     while (readBytes > 0 && !QThread::currentThread()->isInterruptionRequested()) {
         archive_write_data(dest, buff, static_cast<size_t>(readBytes));
         if (archive_errno(dest) != ARCHIVE_OK) {
+            //ENOSPC /* No space left on device */ EDQUOT /* Disk quota exceeded */
+            if (archive_errno(dest) == ENOSPC || archive_errno(dest) == EDQUOT) {
+                m_eErrorType = ET_InsufficientDiskSpace;
+            } else {
+                m_eErrorType = ET_FileWriteError;
+            }
             return;
         }
 
@@ -606,6 +620,11 @@ void ReadWriteLibarchivePlugin::copyDataFromSourceAdd(archive *source, archive *
         emit signalprogress((double(m_currentAddFilesSize)) / totalsize * 100);
 
         readBytes = archive_read_data(source, buff, sizeof(buff));
+        // 循环尾部读取失败同样需要检查，避免多分块文件中途读损坏时误报成功
+        if (readBytes < 0) {
+            m_eErrorType = ET_FileReadError;
+            return;
+        }
     }
 }
 
@@ -722,6 +741,9 @@ bool ReadWriteLibarchivePlugin::writeEntryDelete(struct archive_entry *entry, co
         // If the whole archive is extracted and the total filesize is
         // available, we use partial progress.
         copyDataFromSource(m_archiveReader.data(), m_archiveWriter.data(), totalSize);
+        if (m_eErrorType != ET_NoError) {
+            return false;
+        }
         break;
     case ARCHIVE_FAILED:
     case ARCHIVE_FATAL:
@@ -742,6 +764,9 @@ bool ReadWriteLibarchivePlugin::writeEntryAdd(archive_entry *entry, const qlongl
         // If the whole archive is extracted and the total filesize is
         // available, we use partial progress.
         copyDataFromSourceAdd(m_archiveReader.data(), m_archiveWriter.data(), totalSize);
+        if (m_eErrorType != ET_NoError) {
+            return false;
+        }
         break;
     case ARCHIVE_FAILED:
     case ARCHIVE_FATAL:


### PR DESCRIPTION
## 根因分析

tar.gz 等格式解压到空间不足的磁盘时，归档管理器误报"解压成功"。

**根因**：`LibarchivePlugin::copyDataFromSource()`（`libarchiveplugin.cpp:694-696`）检测到写入错误（含 ENOSPC）后直接 `return`，不设置 `m_eErrorType`；调用方 `extractFiles()`（行399）调用后不检查错误，最终返回 `PFT_Nomral`（成功）。

对比 zip 插件（`libminizipplugin.cpp:396-410`），每次写入后检查返回值并返回 `ET_InsufficientDiskSpace`，错误正确传播。

## 修复方案

1. `copyDataFromSource()` 检测到写入错误时设置 `m_eErrorType`（ENOSPC → `ET_InsufficientDiskSpace`，其他 → `ET_FileWriteError`）
2. `extractFiles()` 的 `ARCHIVE_OK` 分支在 `copyDataFromSource()` 返回后检查 `m_eErrorType`，非 `ET_NoError` 则返回 `PFT_Error`

## 改动安全评估

- 风险等级：低风险
- 无函数签名变更，仅新增错误状态设置 + early return 检查

## Summary by Sourcery

Bug Fixes:
- Propagate write errors detected during libarchive extraction, including insufficient disk space, so extraction finishes with an error instead of success.