### PR TITLE
fix: keep extracted files and prompt missing-volume on partial extract failure

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -1253,6 +1253,8 @@ void CliInterface::removeExtractedFilesOnFailure(const QString &strTargetPath, c
         return;
     }
 
+    const QString canonicalTarget = QDir::cleanPath(targetDir.absolutePath());
+
     QList<QPair<QString, bool> > paths;   // path, isDirectory
     for (const FileEntry &entry : listToRemove) {
         QString relPath = entry.strFullPath;
@@ -1262,7 +1264,12 @@ void CliInterface::removeExtractedFilesOnFailure(const QString &strTargetPath, c
         if (relPath.isEmpty()) {
             continue;
         }
-        paths.append(qMakePair(targetDir.absoluteFilePath(relPath), entry.isDirectory));
+        // 路径规范化后校验仍位于目标目录内，防止 "../" 路径遍历越界删除（PMS BUG-371831）
+        const QString absPath = QDir::cleanPath(targetDir.absoluteFilePath(relPath));
+        if (!absPath.startsWith(canonicalTarget + QLatin1Char('/')) && absPath != canonicalTarget) {
+            continue;
+        }
+        paths.append(qMakePair(absPath, entry.isDirectory));
     }
 
     for (const auto &p : paths) {
@@ -1772,7 +1779,10 @@ void CliInterface::extractProcessFinished(int exitCode, QProcess::ExitStatus exi
     }
 
     if (!m_extractOptions.bAllExtract && (!(m_extractOptions.strTargetPath.startsWith("/tmp") && m_extractOptions.strTargetPath.contains("/deepin-compressor-") && m_extractOptions.strDestination.isEmpty()))) {
-        if (0 == exitCode) {   // job正常结束
+        // job正常结束，或提取（非"打开"操作）失败时也搬运：使提取在分卷缺失等失败
+        // 场景下保留已成功解出的文件，与"解压"（bAllExtract）行为保持一致（PMS BUG-371831）。
+        // 以 !m_extractOptions.bOpen 收窄，"打开解压列表文件"（bOpen=true）失败仍维持原行为。
+        if (0 == exitCode || !m_extractOptions.bOpen) {   // 正常结束，或提取（非打开）失败也搬运
             // 提取操作和打开解压列表文件非第一层的文件
             // 将文件从临时文件夹内移出
             bool droppedFilesMoved = moveExtractTempFilesToDest(m_files, m_extractOptions);
@@ -1782,6 +1792,11 @@ void CliInterface::extractProcessFinished(int exitCode, QProcess::ExitStatus exi
                 emit signalFinished(m_finishType);
                 return;
             }
+        }
+
+        // 提取（非"打开"操作）失败时，清理目标路径下 size 为 0 的残留文件，与解压失败处理对齐（PMS BUG-371831）
+        if (0 != exitCode && !m_extractOptions.bOpen && !m_extractOptions.strTargetPath.isEmpty()) {
+            removeExtractedFilesOnFailure(m_extractOptions.strTargetPath, m_files);
         }
 
         m_rootNode.clear();   // 清空缓存数据

--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -1769,6 +1769,11 @@ void MainWindow::handleJobErrorFinished(ArchiveJob::JobType eJobType, ErrorType 
                 sendMessage(new CustomFloatingMessage(icon, tr("Extraction failed: the file name is too long"), 1000, this));
                 break;
             }
+            // 分卷缺失：与解压分支对齐提示，避免提取失败时静默无提示（PMS BUG-371831）
+            case ET_MissingVolume:
+                showErrorMessage(FI_Uncompress, EI_ArchiveMissingVolume,
+                                 !(StartupType::ST_ExtractHere == m_eStartupType || StartupType::ST_Extractto == m_eStartupType));
+                break;
             default:
                 break;
             }


### PR DESCRIPTION
## 根因分析

分卷压缩包删除部分分卷后"只读模式"打开，右键提取无文件生成且无提示，但点击解压能生成部分文件并提示"部分分卷缺失"——两者不一致。

强根因：`CliInterface::extractProcessFinished` 中提取（`bAllExtract=false`）失败时被 `if (0==exitCode)` 守卫跳过 `moveExtractTempFilesToDest`，随后 `m_extractTempDir.reset()` 把已解出的文件随临时目录一并丢弃；而解压（`bAllExtract=true`）直接落目标路径、失败时仅 `removeExtractedFilesOnFailure` 清 `size==0` 残留（保留已解出文件）。同时 `MainWindow::handleJobErrorFinished` 的提取错误分支只处理 `ET_LongNameError`，`ET_MissingVolume` 落 `default` 静默，而解压分支会提示。

关键证据：
- `3rdparty/interface/archiveinterface/cliinterface.cpp:1774-1791` 失败分支不搬运 + 丢弃临时目录。
- `3rdparty/interface/archiveinterface/cliinterface.cpp:1272` `removeExtractedFilesOnFailure` 仅删 `size==0`，印证"保留已解出文件"为设计意图（且 `748509c628` 正是为此而加）。
- `src/source/mainwindow.cpp:1766-1774` 提取错误 switch 不处理 `ET_MissingVolume`，对比 `1827` 解压分支会提示。

## 修复方案（方案 A，用户已认可）

让"右键提取"对齐"点击解压"：
1. `CliInterface::extractProcessFinished`：提取失败时也把临时目录中已解出的文件搬到目标路径，并 `removeExtractedFilesOnFailure` 清 `size==0` 残留。以 `!m_extractOptions.bOpen` 收窄，"打开解压列表文件"（`OpenJob`，`bOpen=true`）失败仍维持原行为不变。
2. `MainWindow::handleJobErrorFinished` 提取错误分支补 `case ET_MissingVolume:`，与解压分支同源调用 `showErrorMessage(FI_Uncompress, EI_ArchiveMissingVolume, ...)`，避免静默。

## 改动安全评估

低风险。两处均不改函数签名/返回值/信号发射；`extractProcessFinished` 仅作 Qt 槽无直接调用者，`handleJobErrorFinished` 的 3 个 UT 均整函数 stub 不触及内部 switch。以 `!bOpen` 收窄确保 `OpenJob`（打开）四象限行为不变，仅提取失败分支按方案 A 改变。详见附件 `change-safety.md`。

## Summary by Sourcery

Align extraction behavior and user messaging for partial extract failures with missing volumes.

Bug Fixes:
- Preserve successfully extracted files on extraction failure for non-open extract operations, matching full decompression behavior.
- Show a missing-volume error message for extraction jobs instead of failing silently when volumes are missing.