### PR TITLE
fix: prevent wrong-password from overriding missing-volume in 7z extraction

### DIFF
--- a/3rdparty/cli7zplugin/cli7zplugin.cpp
+++ b/3rdparty/cli7zplugin/cli7zplugin.cpp
@@ -340,6 +340,13 @@ bool Cli7zPlugin::handleLine(const QString &line, WorkType workStatus)
     }
 
     if (isWrongPasswordMsg(line)) {  // 提示密码错误
+        // 加密分卷包缺失分卷时，7z 先输出 "Unexpected end of archive"（已置
+        // ET_MissingVolume），随后输出 "CRC Failed in encrypted file. Wrong
+        // password?"。根因是分卷缺失而非密码错误，密码错误不得覆盖已判定的
+        // 分卷缺失（PMS BUG-371879）。
+        if (workStatus == WT_Extract && ET_MissingVolume == m_eErrorType) {
+            return true;  // 已判定分卷缺失，忽略密码错误行，继续解析
+        }
         m_eErrorType = ET_WrongPassword;
         if (workStatus != WT_Delete) { // 区分删除操作密码错误的处理
             m_finishType = PFT_Error;


### PR DESCRIPTION
## 根因分析

加密分卷压缩包缺失部分分卷后，以只读模式打开、输入正确密码解压时，错误提示为「解压密码错误，请重试」，而应为「分卷缺失」；非加密分卷同步骤则正确显示「分卷缺失」。

根因在 `3rdparty/cli7zplugin/cli7zplugin.cpp::handleLine`：加密 zip 分卷缺失中间分卷时，7z 先输出 `Unexpected end of archive`（插件据此置 `ET_MissingVolume`，但该分支 `return false` 早在 `66fb7ccd` 被注释、不终止），随后输出 `ERROR: CRC Failed in encrypted file. Wrong password?`，被 `isWrongPasswordMsg`（`contains("Wrong password")`）误命中并覆盖为 `ET_WrongPassword`。非加密包的 CRC 行不含 "Wrong password"，故保留分卷缺失。

关键证据：
- `3rdparty/cli7zplugin/cli7zplugin.cpp:342` `isWrongPasswordMsg` 分支先于分卷缺失判断执行，命中即覆盖并终止；
- `:362` 分卷缺失分支 `return false` 已被注释、不终止，故被后续 CRC 行覆盖；
- `git blame` 证明回归点为 `66fb7ccd`（2021-01-05 注释掉 `return false`），其前 `aafd78a1` 带 `return false` 时无此 bug；
- 本机 p7zip 16.02 复现：加密 zip 分卷删中间卷 → `Unexpected end of archive` + `CRC Failed... Wrong password?`；非加密对照 → `CRC Failed`（无 "Wrong password"）→ 正确显示分卷缺失。

## 修复方案

在 `isWrongPasswordMsg` 分支增加优先级守卫：解压（`WT_Extract`）中若已判定 `ET_MissingVolume`，则忽略 `Wrong password?` 行、不覆盖，保留分卷缺失结论。真正密码错误（无分卷缺失）路径不变。

## 改动安全评估

低风险：仅增加一个条件 early return，不改变函数签名、不影响外部调用者，真正密码错误路径保持原有行为。

Bug: https://pms.uniontech.com/bug-view-371879.html

## Summary by Sourcery

Bug Fixes:
- Ensure encrypted multi-volume archives with missing parts report a missing-volume error instead of being overridden by a wrong-password error message during extraction.