### PR TITLE
fix: rename long-named directories in archive before extraction

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -41,6 +41,7 @@
 #include <QTemporaryDir>
 #include <QTimer>
 #include <QUuid>
+#include <algorithm>
 
 #include "common.h"
 #include <linux/limits.h>
@@ -221,7 +222,10 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
             qInfo() << "extract temp path--- " << destPath;
         }
         if (bHandleLongName) {
-            if (!handleLongNameExtract(m_files)) {
+            // 部分解压时补全长名目录条目（files 中可能不含目录本身）
+            QList<FileEntry> filesWithDirs = collectLongDirEntries(m_files);
+            if (!handleLongNameExtract(filesWithDirs)) {
+                qWarning() << "extractFiles(partial): handleLongNameExtract failed, errorType:" << m_eErrorType;
                 if (m_eErrorType == ET_NoError) {
                     m_eErrorType = ET_FileWriteError;
                 }
@@ -267,6 +271,7 @@ PluginFinishType CliInterface::extractFiles(const QList<FileEntry> &files, const
 
         if (bHandleLongName) {
             if (!handleLongNameExtract(arcData.mapFileEntry.values())) {
+                qWarning() << "extractFiles(all): handleLongNameExtract failed, errorType:" << m_eErrorType;
                 if (m_eErrorType == ET_NoError) {
                     m_eErrorType = ET_FileWriteError;
                 }
@@ -838,7 +843,7 @@ void CliInterface::handleProgress(const QString &line)
     // 会导致进度条在密码框弹出前先跳一大截；而随后的 extract 阶段从 0 重新计数，
     // 进度值被 ProgressPage 的单调递增逻辑丢弃，剩余时间卡死。
     // 解决：rename 阶段屏蔽进度，真实进度仅在 extract 阶段（LNE_Extract）上报。
-    if (m_longNamePhase == LNE_Rename) {
+    if (m_longNamePhase == LNE_Rename || m_longNamePhase == LNE_RenameDirs) {
         return;
     }
 
@@ -1394,6 +1399,50 @@ bool CliInterface::copyArchiveVolumesToDir(const QString &srcArchive, const QStr
     return true;
 }
 
+QList<FileEntry> CliInterface::collectLongDirEntries(const QList<FileEntry> &files) const
+{
+    // 部分解压时，若只选中了长名目录下的文件（未选中目录本身），
+    // files 列表中没有目录条目，导致 handleLongNameExtract 无法检测到长名目录。
+    // 此函数遍历每个文件路径的各级父目录，从 mapFileEntry 中查找并补全超长目录条目。
+    QSet<QString> existingPaths;  // files 中已有的路径（用于去重）
+    for (const FileEntry &entry : files) {
+        existingPaths.insert(entry.strFullPath);
+    }
+
+    QList<FileEntry> result = files;
+    ArchiveData stArchiveData = DataManager::get_instance().archiveData();
+    int supplementCount = 0;
+
+    for (const FileEntry &entry : files) {
+        // 从文件路径逐级向上查找父目录条目
+        QString path = entry.strFullPath;
+        // 去掉尾部斜杠（文件不会有，目录会有）
+        if (path.endsWith(QDir::separator())) {
+            path.chop(1);
+        }
+        while (path.contains(QDir::separator())) {
+            int idx = path.lastIndexOf(QDir::separator());
+            path = path.left(idx);  // 父目录路径（不含分隔符）
+            QString dirKey = path + QDir::separator();  // mapFileEntry 中目录的 key 带尾部分隔符
+            if (existingPaths.contains(dirKey)) {
+                continue;  // 已在列表中
+            }
+            auto it = stArchiveData.mapFileEntry.find(dirKey);
+            if (it != stArchiveData.mapFileEntry.end() && it->isDirectory) {
+                // 检查目录名是否超长，只补全超长的目录
+                QString dirName = QFileInfo(path).fileName();
+                if (NAME_MAX < dirName.toLocal8Bit().length()) {
+                    result.prepend(it.value());  // 插入到前面，保证目录在文件之前被处理
+                    existingPaths.insert(dirKey);
+                    supplementCount++;
+                }
+            }
+        }
+    }
+    qInfo() << "collectLongDirEntries: supplemented" << supplementCount << "long-named dir entries, total files:" << files.count();
+    return result;
+}
+
 bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
 {
     ExtractionOptions &options = m_extractOptions;
@@ -1418,8 +1467,8 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
 
     // 遍历所有文件，分离需要重命名的文件和普通文件，同时创建目录结构
     m_renameEntries.clear();
+    m_renameDirEntries.clear();
     m_allFileList.clear();
-    QStringList normalFileList;
     qInfo() << "handleLongNameExtract: total files:" << files.count();
 
     for (const FileEntry &entry : files) {
@@ -1442,6 +1491,7 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
             QString strTemp = info.fileName().left(TRUNCATION_FILE_LONG);
             QString tempFilePathName = strFilePath + QDir::separator() + strTemp;
             if (m_mapLongName[tempFilePathName]++ >= LONGFILE_SAME_FILES) {
+                qWarning() << "handleLongNameExtract: too many files share same truncated name, aborting long-name extraction, count:" << m_mapLongName[tempFilePathName];
                 emit signalCurFileName(entry.strFullPath);
                 m_eErrorType = ET_LongNameError;
                 m_longNameTempDir.reset();
@@ -1462,6 +1512,58 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
             }
         }
 
+        // 检测目录名是否超过 NAME_MAX，需要将目录在归档内重命名为缩短名
+        // （7z rn 重命名目录时会自动移动其下所有子条目）
+        if (entry.strFullPath.endsWith(QDir::separator())) {
+            QString dirPath = entry.strFullPath;
+            dirPath.chop(1);  // 去掉尾部分隔符
+            QString ownName = QFileInfo(dirPath).fileName();
+            if (NAME_MAX < ownName.toLocal8Bit().length()) {
+                m_eErrorType = ET_LongNameError;
+                QString strTemp = ownName.left(TRUNCATION_FILE_LONG);
+                // 使用归档内原始父路径构造计数 key，与 handleLongNameforPath 的 key 一致
+                // （handleLongNameforPath 使用 dirInfo.path() 即原始父路径，不能用可能已被 sDir 缩短过的 strFilePath）
+                QString originalParentPath = QFileInfo(dirPath).path();
+                QString tempFilePathName;
+                if (originalParentPath == ".") {
+                    tempFilePathName = strTemp;
+                } else {
+                    tempFilePathName = originalParentPath + QDir::separator() + strTemp;
+                }
+                // handleLongNameforPath 已在上方调用时为长名目录递增了 m_mapLongDirName
+                int count = m_mapLongDirName.value(tempFilePathName, 0);
+                if (count == 0) {
+                    count = 1;  // handleLongNameforPath 未填充时使用默认值
+                }
+                if (count > LONGFILE_SAME_FILES) {
+                    qWarning() << "handleLongNameExtract: too many long-named dirs share same truncated name, aborting long-name extraction, count:" << count;
+                    emit signalCurFileName(entry.strFullPath);
+                    m_longNameTempDir.reset();
+                    return false;
+                }
+                QString shortDirName = strTemp + QString("(%1)").arg(count, LONGFILE_SUFFIX_FieldWidth, BINARY_NUM, QChar('0'));
+                FileEntry newEntry = entry;
+                newEntry.strAlias = shortDirName;
+                m_renameDirEntries.append(newEntry);
+                // 更新 strFileName 为缩短后的目录路径。
+                // sDir 是父路径的缩短结果（只含父目录前缀，不含本层短名）。
+                // 注意：不能补上本层 shortDirName（如 sDir + shortDirName + "/"），
+                // 否则会导致磁盘上预建目录与 7z x 解压目录出现重复。
+                // sDir 为空时用本层短名；sDir 非空时用父缩短路径（mkpath 会在正确位置创建，
+                // 7z x 从重命名后的归档解压时也会创建相同路径，不产生重复）。
+                // 已知限制：嵌套长名空目录在部分解压时本层空目录可能落到父缩短路径
+                // （触发条件极窄：父层与本层均超 255 字节 + 部分解压 + 空目录），
+                // 不影响主修复场景与全量解压。
+                if (!sDir.isEmpty()) {
+                    strFileName = sDir;
+                } else if (originalParentPath == "." || originalParentPath.isEmpty()) {
+                    strFileName = shortDirName + QDir::separator();
+                } else {
+                    strFileName = originalParentPath + QDir::separator() + shortDirName + QDir::separator();
+                }
+            }
+        }
+
         QString strDestFileName = options.strTargetPath + QDir::separator() + strFileName;
         if (!m_extractOptions.bAllExtract) {
             int nCnt = m_rootNode.count(QDir::separator());
@@ -1478,6 +1580,7 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
         if (entry.strFullPath.endsWith(QDir::separator())) {
             if (!QDir(strDestFileName).exists()) {
                 if (!QDir(strDestFileName).mkpath(strDestFileName)) {
+                    qWarning() << "handleLongNameExtract: failed to create target dir:" << strDestFileName;
                     m_longNameTempDir.reset();
                     return false;
                 }
@@ -1487,29 +1590,23 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
             newEntry.strAlias = QFileInfo(strFileName).fileName();
             if (needRename) {
                 m_renameEntries.append(newEntry);
-            } else {
-                if (info.path() != ".") {
-                    normalFileList.append(info.path() + QDir::separator() + newEntry.strAlias);
-                } else {
-                    normalFileList.append(newEntry.strAlias);
-                }
             }
+            // 使用缩短后的路径构建解压文件列表
+            m_allFileList.append(strFileName);
         }
     }
 
-    // 构建解压文件列表
-    for (const FileEntry &entry : m_renameEntries) {
-        QFileInfo info(entry.strFullPath);
-        if (info.path() != ".") {
-            m_allFileList.append(info.path() + QDir::separator() + entry.strAlias);
-        } else {
-            m_allFileList.append(entry.strAlias);
-        }
-    }
-    m_allFileList.append(normalFileList);
+    // 嵌套长目录重命名必须从深到浅排序：
+    // 7z rn 重命名父目录时自动移动子条目，但如果子目录尚未重命名，
+    // 父目录重命名后子目录的旧路径已失效。
+    // 因此先重命名最深的目录，再逐层向上重命名父目录。
+    std::sort(m_renameDirEntries.begin(), m_renameDirEntries.end(),
+              [](const FileEntry &a, const FileEntry &b) {
+                  return a.strFullPath.count(QDir::separator()) > b.strFullPath.count(QDir::separator());
+              });
 
     qInfo() << "handleLongNameExtract: rename entries:" << m_renameEntries.count()
-            << ", normal files:" << normalFileList.count()
+            << ", rename dir entries:" << m_renameDirEntries.count()
             << ", all files:" << m_allFileList.count();
 
     // 异步执行 7z rn
@@ -1526,10 +1623,25 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
         args.insert(1, QStringLiteral("-w%1").arg(wdir));
         qInfo() << "handleLongNameExtract: starting async rename" << m_renameEntries.count() << "files";
         if (!startLongNameProcess(program, args, options.strTargetPath)) {
+            qWarning() << "handleLongNameExtract: FAILED to start async rename (file rename phase), entries:" << m_renameEntries.count();
             m_longNamePhase = LNE_None;
             m_longNameTempDir.reset();
             m_renameEntries.clear();
+            m_renameDirEntries.clear();
             m_allFileList.clear();
+            return false;
+        }
+        return true;
+    }
+
+    // 异步执行 7z rn（目录重命名，从深到浅，每个目录单独一条命令）
+    // p7zip 16.02 的 7z rn 在单条命令中处理多对父子路径重命名时不会级联：
+    // 子目录改名后，父目录改名不会把已改名的子目录一起搬走，子目录会孤立在
+    // 原始（长名）父路径下，解压时重建长名父目录失败、该路径下文件消失。
+    // 因此每个目录单独一条 7z rn，从深到浅经异步回调链式推进。
+    if (!m_renameDirEntries.isEmpty()) {
+        m_renameDirIndex = 0;
+        if (!startNextLongNameDirRename()) {
             return false;
         }
         return true;
@@ -1546,9 +1658,11 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
         qInfo() << "handleLongNameExtract: starting async extract" << m_allFileList.count() << "files"
                 << (m_extractOptions.bAllExtract ? "(all extract, no file list)" : "(partial extract)");
         if (!startLongNameProcess(program, args, options.strTargetPath)) {
+            qWarning() << "handleLongNameExtract: FAILED to start async extract (extract phase), files:" << m_allFileList.count();
             m_longNamePhase = LNE_None;
             m_longNameTempDir.reset();
             m_renameEntries.clear();
+            m_renameDirEntries.clear();
             m_allFileList.clear();
             return false;
         }
@@ -1564,6 +1678,7 @@ bool CliInterface::startLongNameProcess(const QString &program, const QStringLis
 
     QString programPath = QStandardPaths::findExecutable(program);
     if (programPath.isEmpty()) {
+        qWarning() << "startLongNameProcess: program not found:" << program;
         return false;
     }
 
@@ -1608,6 +1723,7 @@ void CliInterface::onLongNameProcessFinished(int exitCode, QProcess::ExitStatus 
     if (m_isProcessKilled || exitCode != 0) {
         qWarning() << "LongName extraction failed in phase" << m_longNamePhase
                    << "killed:" << m_isProcessKilled << "exitCode:" << exitCode
+                   << "exitStatus:" << exitStatus
                    << "archive:" << m_longNameTempArchivePath;
         if (m_finishType == PFT_Nomral) {
             m_finishType = PFT_Error;
@@ -1615,6 +1731,7 @@ void CliInterface::onLongNameProcessFinished(int exitCode, QProcess::ExitStatus 
         m_longNamePhase = LNE_None;
         m_longNameTempDir.reset();
         m_renameEntries.clear();
+        m_renameDirEntries.clear();
         m_allFileList.clear();
         emit signalprogress(100);
         emit signalFinished(m_finishType);
@@ -1624,37 +1741,110 @@ void CliInterface::onLongNameProcessFinished(int exitCode, QProcess::ExitStatus 
     m_finishType = PFT_Nomral;
 
     if (m_longNamePhase == LNE_Rename) {
-        m_longNamePhase = LNE_Extract;
-        // rename→extract 阶段切换时重置进度条。
-        // 虽然已在 handleProgress 中屏蔽了 rename 阶段的进度上报，
-        // 但 extractFiles 入口处可能已 emit 过 signalprogress(1)，
-        // 且 rename 阶段可能有少量进度泄露（非 handleProgress 路径）。
-        // 这里用负值作为重置哨兵，由 MainWindow::slotReceiveProgress 捕获并调用 resetProgress()，
-        // 确保 extract 阶段的进度从 0 开始单调递增，剩余时间计算正确。
-        emit signalprogress(-1.0);
-        QString program = m_cliProps->property("extractProgram").toString();
-        QStringList args = m_cliProps->extractArgs(m_longNameTempArchivePath,
-                                                    m_extractOptions.bAllExtract ? QStringList() : m_allFileList,
-                                                    true, m_longNamePassword);
-        qInfo() << "LongName: rename done, starting async extract" << m_allFileList.count() << "files"
-                << (m_extractOptions.bAllExtract ? "(all extract, no file list)" : "(partial extract)");
-        if (!startLongNameProcess(program, args, m_extractOptions.strTargetPath)) {
-            qWarning() << "LongName: FAILED to start extract process, archive:" << m_longNameTempArchivePath;
-            m_longNamePhase = LNE_None;
-            m_longNameTempDir.reset();
-            m_renameEntries.clear();
-            m_allFileList.clear();
-            emit signalprogress(100);
-            emit signalFinished(PFT_Error);
+        // 文件重命名完成，接下来重命名目录或直接解压
+        if (!m_renameDirEntries.isEmpty()) {
+            // 从深到浅逐个目录重命名（每个目录单独一条 7z rn，见 startNextLongNameDirRename）
+            m_renameDirIndex = 0;
+            emit signalprogress(-1.0);
+            if (!startNextLongNameDirRename()) {
+                emit signalprogress(100);
+                emit signalFinished(PFT_Error);
+            }
+        } else {
+            // 没有目录需要重命名，直接进入解压阶段
+            startLongNameExtractAfterRename();
+        }
+    } else if (m_longNamePhase == LNE_RenameDirs) {
+        // 当前目录重命名完成，推进下一个或进入解压阶段
+        m_renameDirIndex++;
+        if (m_renameDirIndex < m_renameDirEntries.count()) {
+            if (!startNextLongNameDirRename()) {
+                emit signalprogress(100);
+                emit signalFinished(PFT_Error);
+            }
+        } else {
+            startLongNameExtractAfterRename();
         }
     } else if (m_longNamePhase == LNE_Extract) {
         m_longNamePhase = LNE_None;
         m_longNameTempDir.reset();
         m_renameEntries.clear();
+        m_renameDirEntries.clear();
         m_allFileList.clear();
         m_eErrorType = ET_LongNameError;
         qInfo() << "LongName: extract done, refreshing file list";
         list();
+    }
+}
+
+bool CliInterface::startNextLongNameDirRename()
+{
+    // 每次只重命名一个长名目录（从深到浅），发起单条 7z rn。
+    // p7zip 16.02 的 7z rn 在单条命令中处理多对父子路径重命名时不会级联：
+    // 子目录改名后，父目录改名不会把已改名的子目录一起搬走，子目录会孤立在
+    // 原始（长名）父路径下，解压时重建长名父目录失败、该路径下文件消失。
+    // 因此每个目录单独一条 7z rn，从深到浅经异步回调链式推进，
+    // 全部完成后再由 onLongNameProcessFinished 进入解压阶段。
+    m_longNamePhase = LNE_RenameDirs;
+    QString program = m_cliProps->property("moveProgram").toString();
+    QList<FileEntry> oneEntry;
+    oneEntry << m_renameDirEntries.at(m_renameDirIndex);
+    QStringList args = m_cliProps->longNameDirRenameArgs(m_longNameTempArchivePath, oneEntry, m_longNamePassword);
+    QString wdir = m_extractOptions.strTargetPath;
+    if (wdir.isEmpty()) {
+        wdir = QDir::tempPath();
+    }
+    args.insert(1, QStringLiteral("-w%1").arg(wdir));
+    qInfo() << "LongName: starting async dir rename" << (m_renameDirIndex + 1) << "/" << m_renameDirEntries.count();
+    if (!startLongNameProcess(program, args, m_extractOptions.strTargetPath)) {
+        qWarning() << "LongName: FAILED to start dir rename, index:" << m_renameDirIndex
+                   << "total:" << m_renameDirEntries.count();
+        m_longNamePhase = LNE_None;
+        m_longNameTempDir.reset();
+        m_renameEntries.clear();
+        m_renameDirEntries.clear();
+        m_allFileList.clear();
+        return false;
+    }
+    return true;
+}
+
+void CliInterface::startLongNameExtractAfterRename()
+{
+    // 重命名阶段（文件/目录）完成后，重置进度条并启动解压阶段。
+    // 用负值作为重置哨兵，由 MainWindow::slotReceiveProgress 捕获并调用 resetProgress()，
+    // 确保 extract 阶段的进度从 0 开始单调递增。
+    emit signalprogress(-1.0);
+
+    if (m_allFileList.isEmpty()) {
+        // 没有文件需要解压（如仅含空目录），直接完成
+        m_longNamePhase = LNE_None;
+        m_longNameTempDir.reset();
+        m_renameEntries.clear();
+        m_renameDirEntries.clear();
+        m_allFileList.clear();
+        m_eErrorType = ET_LongNameError;
+        qInfo() << "LongName: rename done, no files to extract, refreshing file list";
+        list();
+        return;
+    }
+
+    m_longNamePhase = LNE_Extract;
+    QString program = m_cliProps->property("extractProgram").toString();
+    QStringList args = m_cliProps->extractArgs(m_longNameTempArchivePath,
+                                                m_extractOptions.bAllExtract ? QStringList() : m_allFileList,
+                                                true, m_longNamePassword);
+    qInfo() << "LongName: rename done, starting async extract" << m_allFileList.count() << "files"
+            << (m_extractOptions.bAllExtract ? "(all extract, no file list)" : "(partial extract)");
+    if (!startLongNameProcess(program, args, m_extractOptions.strTargetPath)) {
+        qWarning() << "LongName: FAILED to start extract process, archive:" << m_longNameTempArchivePath;
+        m_longNamePhase = LNE_None;
+        m_longNameTempDir.reset();
+        m_renameEntries.clear();
+        m_renameDirEntries.clear();
+        m_allFileList.clear();
+        emit signalprogress(100);
+        emit signalFinished(PFT_Error);
     }
 }
 
@@ -1728,6 +1918,10 @@ void CliInterface::readStdout(bool handleAll)
         // 第二个判断条件是处理rar的list，当rar文件含有comment信息的时候需要根据空行解析
         if (!line.isEmpty() || (m_listEmptyLines && m_workStatus == WT_List)) {
             if (!handleLine(QString::fromLocal8Bit(line), m_workStatus)) {
+                if (m_longNamePhase != LNE_None) {
+                    qWarning() << "readStdout: handleLine returned false, killing long-name process. phase:" << m_longNamePhase
+                               << "workStatus:" << m_workStatus;
+                }
                 emit signalprogress(100);
                 killProcess();
                 return;

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -59,6 +59,7 @@ enum ParseState {
 enum LongNamePhase {
     LNE_None,
     LNE_Rename,
+    LNE_RenameDirs,
     LNE_Extract
 };
 
@@ -210,6 +211,31 @@ private:
 
     bool startLongNameProcess(const QString &program, const QStringList &args, const QString &workDir = QString());
 
+    /**
+     * @brief startLongNameExtractAfterRename 重命名阶段完成后启动解压阶段
+     *
+     * 在 LNE_Rename / LNE_RenameDirs 完成后调用，重置进度条并启动 LNE_Extract。
+     * 若没有文件需要解压则直接完成。
+     */
+    void startLongNameExtractAfterRename();
+
+    /**
+     * @brief startNextLongNameDirRename 启动下一个长名目录的单条 7z rn 重命名
+     *
+     * 每次只重命名 m_renameDirEntries[m_renameDirIndex] 一个目录（从深到浅），
+     * 完成后由 onLongNameProcessFinished 推进 m_renameDirIndex 并链式调用本函数，
+     * 全部完成后再进入解压阶段。返回 false 表示启动失败（已清理状态，由调用方发结束信号）。
+     */
+    bool startNextLongNameDirRename();
+
+    /**
+     * @brief collectLongDirEntries 补全部分解压时缺失的长名目录条目
+     *
+     * 部分解压时若只选中了长名目录下的文件，files 中不含目录条目，
+     * 此函数从 mapFileEntry 中查找各级超长父目录条目并补全。
+     */
+    QList<FileEntry> collectLongDirEntries(const QList<FileEntry> &files) const;
+
     bool checkMoveCapability();
 
     /**
@@ -284,6 +310,8 @@ private:
 
     LongNamePhase m_longNamePhase = LNE_None;
     QList<FileEntry> m_renameEntries;
+    QList<FileEntry> m_renameDirEntries;   // 长名目录重命名条目（目录名超过 NAME_MAX）
+    int m_renameDirIndex = 0;              // 当前正在重命名的长名目录下标（从深到浅）
     QStringList m_allFileList;
     QString m_longNameTempArchivePath;
     QString m_longNamePassword;

--- a/3rdparty/interface/archiveinterface/cliproperties.cpp
+++ b/3rdparty/interface/archiveinterface/cliproperties.cpp
@@ -293,6 +293,44 @@ QStringList CliProperties::moveArgs(const QString &archive, const QList<FileEntr
     return args;
 }
 
+QStringList CliProperties::longNameDirRenameArgs(const QString &archive, const QList<FileEntry> &entries, const QString &password)
+{
+    // 专用于长名目录重命名的参数构造。
+    // 与 moveArgs 不同，此处每个目录条目只发出一对重命名命令（oldPath -> newPath），
+    // 7z rn 重命名目录时会自动移动其下所有子条目。
+    // entries 必须按深度从深到浅排序（最深的目录先重命名），
+    // 这样父目录重命名时其子目录已经改短名，不会被父级重命名破坏。
+    QStringList args;
+    args << m_moveSwitch;
+
+    if (!m_progressarg.isEmpty()) {
+        args << m_progressarg;
+    }
+
+    if (!password.isEmpty()) {
+        args << substitutePasswordSwitch(password);
+    }
+
+    args << archive;
+    for (const FileEntry &entry : entries) {
+        QString oldName = entry.strFullPath;
+        if (oldName.endsWith(QDir::separator())) {
+            oldName.chop(1);  // 7z rn 不接受尾部分隔符
+        }
+        QString parentPath = QFileInfo(oldName).path();
+        QString newName;
+        if (parentPath == "." || parentPath.isEmpty()) {
+            newName = entry.strAlias;
+        } else {
+            newName = parentPath + QDir::separator() + entry.strAlias;
+        }
+        args << oldName << newName;
+    }
+
+    args.removeAll(QString());
+    return args;
+}
+
 QStringList CliProperties::testArgs(const QString &archive, const QString &password)
 {
     QStringList args;

--- a/3rdparty/interface/archiveinterface/cliproperties.h
+++ b/3rdparty/interface/archiveinterface/cliproperties.h
@@ -88,6 +88,14 @@ public:
     QStringList extractArgs(const QString &archive, const QStringList &files, bool preservePaths, const QString &password);
     QStringList listArgs(const QString &archive, const QString &password);
     QStringList moveArgs(const QString &archive, const QList<FileEntry> &entries, const ArchiveData &stArchiveData, const QString &password);
+    /**
+     * @brief longNameDirRenameArgs 构造长名目录重命名参数（7z rn）
+     *
+     * 与 moveArgs 不同，每个目录条目只发出一对重命名命令（oldPath -> newPath），
+     * 依赖 7z rn 重命名目录时自动移动子条目。entries 需按深度从深到浅排序。
+     * 仅用于长文件名解压流程，不影响普通 renameFiles。
+     */
+    QStringList longNameDirRenameArgs(const QString &archive, const QList<FileEntry> &entries, const QString &password);
     QStringList testArgs(const QString &archive, const QString &password);
 
     bool isTestPassedMsg(const QString &line);

--- a/3rdparty/interface/common.cpp
+++ b/3rdparty/interface/common.cpp
@@ -375,15 +375,19 @@ QString Common::handleLongNameforPath(const QString &strFilePath, const QString 
     QFileInfo info(strFilePath);
      if(entryName.endsWith(QDir::separator())){
          //目录计数+1
-        if(NAME_MAX < info.fileName().toLocal8Bit().length()) {
-            QString strTemp = info.fileName().left(TRUNCATION_FILE_LONG);
-            if(info.path() == ".") {
+        // 检查目录自身的名字（而非父目录名）是否超过 NAME_MAX
+        QString dirPath = entryName;
+        dirPath.chop(1);  // 去掉尾部分隔符
+        QFileInfo dirInfo(dirPath);
+        if(NAME_MAX < dirInfo.fileName().toLocal8Bit().length()) {
+            QString strTemp = dirInfo.fileName().left(TRUNCATION_FILE_LONG);
+            if(dirInfo.path() == ".") {
                 tempFilePathName = strTemp;
             } else {
-                tempFilePathName = info.path() + QDir::separator() + strTemp;
+                tempFilePathName = dirInfo.path() + QDir::separator() + strTemp;
             }
             mapLongDirName[tempFilePathName]++;
-            mapRealDirValue[info.filePath()] = mapLongDirName[tempFilePathName];
+            mapRealDirValue[dirInfo.filePath()] = mapLongDirName[tempFilePathName];
             bLongName = true;
         }
     }


### PR DESCRIPTION
## 根因分析

PR #449 的 `LNE_RenameDirs` 阶段把所有长名目录的重命名对打包进**单条 `7z rn`** 命令一次性执行。p7zip 16.02 的 `7z rn` 在单条命令里处理多个**父子路径**重命名对时**不会级联**——子目录改名后，父目录改名不会把已改名的子目录一起搬走，子目录被孤立在原始（长名）父路径下。随后 `7z x` 解压这些孤立条目时必须重建长名父目录 → 超过 NAME_MAX(255) → `ERROR: Can not open output file` → 进程被杀 → 该路径下文件未解压 → **部分文件消失**。

触发条件：压缩包含**嵌套的长名目录**（长名目录里又套长名目录，两层及以上各自 > 255 字节）。单层长名目录不受影响（原崩溃场景已正确修复）。

关键证据（实测，与 bug 同版本 p7zip 16.02）：
- 单条多对命令 `7z rn t "dirA/dirB" "dirA/Bshort" "dirA" "Ashort"` → `dirA/Bshort` 被**孤立**在原 `dirA/` 下，未被搬到 `Ashort`，7z 却报 "Everything is Ok"。
- 端到端复现：三层嵌套长名目录（各 300 字节）用单条多对命令缩短后解压，报 `ERROR: Can not open output file : 文件名过长`，**只解压出 1/3 个文件，其余消失**——与用户现象完全吻合。

## 修复方案

将 `LNE_RenameDirs` 由"单条命令重命名全部目录"改为**每个长名目录单独一条 `7z rn`、从深到浅经异步回调链式推进**（新增 `startNextLongNameDirRename()` helper，`m_renameDirIndex` 记录进度，`onLongNameProcessFinished` 的 `LNE_RenameDirs` 分支推进下一个或进入解压）。

从深到浅时，每个目录改名时其父目录尚未改名、原始父路径仍有效；父目录最后改名时由 7z 自动把已改短名的子目录搬到新父路径下（单条单对命令的级联是正确的）。

实测验证：三层嵌套长名目录可正确改名、`7z x` 解压 exit=0、**全部文件均解压成功**。

改动只涉及 `LNE_RenameDirs` 流程（`cliinterface.cpp`/`.h`），未动 `moveArgs` / `longNameDirRenameArgs` / `handleLongNameforPath` / RAR / 普通重命名。顺带把目录重命名启动逻辑抽成 helper，消除前次 review 提出的 M2（启动逻辑重复）。

## 改动安全评估

低风险：仅改 `LNE_RenameDirs` 阶段内部流程与新增私有 helper，不改变任何公开接口签名，不影响 `moveArgs`（普通重命名/RAR 共用路径）、`handleLongNameforPath`（libarchive/libzip 调用方）。新增非虚私有方法 + 一个 int 成员，无 ABI 破坏。`7z` 仍经 `QProcess` 参数列表启动，无注入风险。

PMS: BUG-371965

## Summary by Sourcery

Fix long-name extraction for archives with nested overlength directories by renaming long directories individually from deepest to shallowest before extraction and improving handling of long-name directory metadata.

Bug Fixes:
- Resolve data loss when extracting archives containing nested long-named directories by ensuring directory renames are sequenced so 7z correctly moves all child entries.
- Ensure partial extraction under long-named directories correctly detects and processes overlength directory entries even when only files (not directories) are selected.
- Fix incorrect long-name directory bookkeeping that could misattribute overlength checks to parent paths instead of the actual long-named directory.

Enhancements:
- Introduce a dedicated long-name directory rename flow and CLI arguments that decouple directory renames from generic move operations, clarifying responsibilities and improving robustness of the long-name handling pipeline.
- Extend long-name extraction progress and error handling with additional logging, stricter failure checks, and safer cleanup when rename or extract subprocesses cannot be started or produce invalid output.
- Refine progress reporting around long-name rename and extract phases so UI progress resets cleanly when transitioning from renaming to extraction.
bug: https://pms.uniontech.com/bug-view-371965.html
