### PR TITLE
fix: use DSuggestButton for success page view-file button

### DIFF
--- a/src/source/page/successpage.cpp
+++ b/src/source/page/successpage.cpp
@@ -68,7 +68,7 @@ void SuccessPage::initUI()
     DFontSizeManager::instance()->bind(m_pDetailLbl, DFontSizeManager::T8);
 
     //查看文件按钮
-    m_pShowFileBtn = new CustomPushButton(this);
+    m_pShowFileBtn = new CustomSuggestButton(this);
     m_pShowFileBtn->setMinimumWidth(340);
     m_pShowFileBtn->setText(tr("View"));
 

--- a/src/source/page/successpage.h
+++ b/src/source/page/successpage.h
@@ -13,7 +13,7 @@
 
 DWIDGET_USE_NAMESPACE
 
-class CustomPushButton;
+class CustomSuggestButton;
 class CustomCommandLinkButton;
 
 // 成功界面
@@ -80,7 +80,7 @@ private:
     DLabel *m_pSuccessPixmapLbl = nullptr; //成功图片显示
     DLabel *m_pSuccessLbl = nullptr;      // 成功文字显示
     DLabel *m_pDetailLbl = nullptr; // 描述信息
-    CustomPushButton *m_pShowFileBtn = nullptr; // 查看文件按钮
+    CustomSuggestButton *m_pShowFileBtn = nullptr; // 查看文件按钮
     CustomCommandLinkButton *m_pReturnBtn = nullptr; // 返回按钮
     QString m_strFullPath;  // 压缩地址
     SuccessInfo m_successInfoType = SI_Compress; // 成功界面类型


### PR DESCRIPTION
# fix: 成功页"查看文件"按钮颜色不跟随 DTK 色值（PMS 241337）

## 根因分析

成功页 `SuccessPage` 的"查看文件"按钮 `m_pShowFileBtn` 使用 `CustomPushButton`，该类（`src/source/common/customwidget.h:48`）继承 Qt 原生 `QPushButton` 而非 DTK 按钮。原生 `QPushButton` 由 Qt 平台默认样式绘制，不读 `DPalette`/`DStyle`，色值写死、不随系统 DTK 主题变化；同页 `DLabel`/`CustomCommandLinkButton` 等 DTK 控件正确跟随主题，形成可见色差。结论为**强根因**，已通过根因复核。

关键证据：
- `src/source/page/successpage.cpp:71` `m_pShowFileBtn = new CustomPushButton(this);`
- `src/source/common/customwidget.h:48` `class CustomPushButton: public QPushButton;`
- `customwidget.cpp:122-150` 未重写 `paintEvent`，沿用 `QPushButton` 默认绘制。

## 修复方案

将 `m_pShowFileBtn` 由 `CustomPushButton` 改为 `CustomSuggestButton`（继承 DTK `DSuggestButton`），使其跟随 DTK 调色板。改动 3 处（`successpage.h` 前置声明 + 成员类型、`successpage.cpp:71` 构造）。`successpage.cpp:106` 的 `connect(..., &DPushButton::clicked, ...)` 无需改动——`DSuggestButton`→`DPushButton`→`QPushButton`→`QAbstractButton`，`clicked` 继承自 `QAbstractButton`，信号兼容。键盘 Enter/Return→Space 激活行为由 `CustomSuggestButton`（`customwidget.cpp:29-47`）保留。

选用 `DSuggestButton`（方案 A）而非 `DPushButton`（A2）：本应用主操作高亮按钮惯例即用 `CustomSuggestButton`（进度页"暂停/继续" `progresspage.cpp:178`、设置页"推荐" `settingdialog.cpp:110`），"查看文件"是成功页的主操作按钮，宜采用 DTK 高亮样式。

## 改动安全评估

风险等级：**低风险**。`SuccessPage::initUI` 为私有方法（0 外部引用），`m_pShowFileBtn` 为私有成员；无函数签名变更、无公开 API 变更、无新增构建依赖；`signalViewFile`→`MainWindow::slotSuccessView` 连接不变。影响面仅 `SuccessPage` 三个场景（压缩/解压/转换成功页）的"查看文件"按钮外观。

## 同类位置（不在本次 PR 范围，建议后续单独修复）

`CustomPushButton`（原生 `QPushButton` 派生）另有 6 处用法：`uncompresspage.cpp:106`、`compresssettingpage.cpp:234`、`progresspage.cpp:177`、`failurepage.cpp:87`、`compresspage.cpp:65`、`settingdialog.cpp:108-109`；另有 `openwithdialog.cpp:288-289` 2 处直接使用原生 `QPushButton`。本次仅修 PMS 241337 指向的成功页，其余建议另行评估。

## Summary by Sourcery

Bug Fixes:
- Ensure the success page "View file" button uses a DTK-based suggest button instead of a Qt push button so it correctly follows DTK palette and theming.