### PR TITLE
fix: allow help shortcut in custom mode with edit permission

### DIFF
--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -281,8 +281,20 @@ void MainWindow::initConnections()
     connect(ArchiveManager::get_instance(), &ArchiveManager::signalTempMessage, this, &MainWindow::slotReceiveTempMessage);
 
     connect(m_pOpenFileWatcher, &OpenFileWatcher::fileChanged, this, &MainWindow::slotOpenFileChanged);
-    //定制需求不显示ctrl+shift+？快捷键菜单
-    if(!property(ORDER_JSON).isValid()) {
+    //定制需求默认不显示ctrl+shift+？快捷键菜单，但具有编辑权限(edit)时仍需显示
+    bool bShowShortcut = true;
+    if(property(ORDER_JSON).isValid()) {
+        bShowShortcut = false;
+        QJsonObject obj = QJsonDocument::fromJson(property(ORDER_JSON).toString().toLower().toLocal8Bit()).object();
+        QVariantMap mapdata = obj.toVariantMap();
+        if(mapdata.contains("permission")) {
+            QVariantMap permission = mapdata.value("permission").toMap();
+            if(permission.contains(ORDER_EDIT) && permission.value(ORDER_EDIT).toBool()) {
+                bShowShortcut = true;
+            }
+        }
+    }
+    if(bShowShortcut) {
         connect(m_openkey, &QShortcut::activated, this, &MainWindow::slotShowShortcutTip);
     }
 }


### PR DESCRIPTION
# fix: allow help shortcut in custom mode with edit permission

PMS: [BUG-243679]

## 根因分析（强根因，已通过根因复核）

`src/source/mainwindow.cpp:285`（`MainWindow::initConnections()` 内）对帮助快捷键 `Ctrl+Shift+?` 的 connect 采用粗粒度门控 `if(!property(ORDER_JSON).isValid())`：定制模式下一刀切跳过连接，未像本仓其它功能门控那样解析 `permission.edit`。故定制配置含 `edit=true`（有编辑权限）时，帮助提示框仍无法打开。

关键证据：
1. 缺陷点 `mainwindow.cpp:284-287`：取反门控跳过 `connect(m_openkey, ..., slotShowShortcutTip)`，全程无 `ORDER_EDIT` 判定；`slotShowShortcutTip`（3556 行）经 `deepin-shortcut-viewer` 弹帮助框，连接被跳过即不弹出。
2. 时序实锤：`initConnections()` 由 500ms 一次性定时器 `timerEvent`（552-561 行）延迟触发，而 `main.cpp:216` 在构造后即设 `ORDER_JSON` 属性 → 第 285 行时属性恒有效，是确定性逻辑错误，非竞态。
3. 范式对比：`mainwindow.cpp:324/925/3183/3510` 与 `datatreeview.cpp:340/354/372` 解析编辑权限均走 `mapOrderJson()` + `ORDER_EDIT`；全仓取反门控 `if(!property(ORDER_JSON).isValid())` **仅命中第 285 行一处**。

缺陷由 `8ec460cc "fix: Merge into WPS custom code"` 引入，无后续修复。

## 修复方案

将第 285 行的粗粒度门控改为：定制模式下解析 `this->property(ORDER_JSON).toString()` 的 `permission.edit`，`edit=true` 时仍执行 `connect(m_openkey, &QShortcut::activated, this, &MainWindow::slotShowShortcutTip)`。

- 解析逻辑对齐 `datatreeview.cpp:216-224`（`QJsonDocument::fromJson(...toLower().toLocal8Bit())` → `.object().toVariantMap()` → `value("permission").toMap()` → `value(ORDER_EDIT).toBool()`）。
- **不复用** `m_pUnCompressPage->mapOrderJson()`：该处权限表仅在加载压缩包后填充，第 285 行紧跟 `initUI()` 执行、尚未加载压缩包，必为空。

## 改动安全评估

低风险。仅改 `initConnections()` 内部逻辑，不改函数签名；非定制模式与无编辑权限的定制模式行为完全不变；无外部调用者受影响；不撤销任何历史修复（缺陷块由 WPS 定制回合一次性引入，非历史 bug 修复产物）。

## 范围边界

仅修复帮助提示框 `Ctrl+Shift+?` 快捷键门控（`mainwindow.cpp`）。`settingdialog.cpp:299` 的同类「不看 ORDER_EDIT」现象属另一功能（设置项下拉框），已判为不在本 bug 范围，不纳入本 commit。

## 验证建议

项目存在已有测试 `tests/UnitTest/`，建议自行运行验证。本修复未新增/运行测试（遵循项目惯例）。

## Summary by Sourcery

Bug Fixes:
- Fix help shortcut (Ctrl+Shift+?) being suppressed in custom configurations that still have edit permission by refining the permission check around its activation.