### PR TITLE
fix: prompt error types on single-file extract to align with full extract (PMS BUG-373669)

### DIFF
--- a/3rdparty/cli7zplugin/cli7zplugin.cpp
+++ b/3rdparty/cli7zplugin/cli7zplugin.cpp
@@ -329,7 +329,11 @@ bool Cli7zPlugin::handleLine(const QString &line, WorkType workStatus)
             DataManager::get_instance().archiveData().isListEncrypted = true; // 列表加密文件
         }
 
-        m_eErrorType = ET_NeedPassword;
+        // 加密分卷缺失时 7z 已置 ET_MissingVolume，密码提示不得覆盖
+        // 分卷缺失判定（PMS BUG-373669）
+        if (m_eErrorType != ET_MissingVolume) {
+            m_eErrorType = ET_NeedPassword;
+        }
         if (handlePassword() == PFT_Cancel) {
             m_finishType = PFT_Cancel;
             m_bWaitingPassword = true;

--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -1044,7 +1044,11 @@ void CliInterface::handleProgress(const QString &line)
 
 PluginFinishType CliInterface::handlePassword()
 {
-    m_eErrorType = ET_NoError;
+    // 加密分卷缺失时 7z 已置 ET_MissingVolume，handlePassword 入口不得
+    // 无条件清零，否则后续 CRC 失败行会误判为「密码错误」（PMS BUG-373669）
+    if (m_eErrorType != ET_MissingVolume) {
+        m_eErrorType = ET_NoError;
+    }
 
     QString name;
     if (m_process && m_process->program().at(0).contains("unrar")) {   // rar解压会提示加密的文件名


### PR DESCRIPTION
根因
加密 zip 分卷压缩包缺失分卷时，7z 先输出 "Unexpected end of archive" 置 ET_MissingVolume，随后 "Enter password" 触发 handlePassword()。存在两处无条件覆写（CLOBBER）：

两者均覆盖 ET_MissingVolume，导致 commit 99221e16 守卫失效，用户输入正确密码后 CRC 失败 → "Wrong password?" → 守卫判 false → 误报"密码错误"。非加密路径无密码提示，ET_MissingVolume 保持，正确提示"分卷缺失"。

修复方案（两处缺一不可）
主修复 cliinterface.cpp:1047：if (m_eErrorType != ET_MissingVolume) { m_eErrorType = ET_NoError; } —— 保留 ET_MissingVolume，解除 CLOBBER #2。
次修复 cli7zplugin.cpp:332：if (m_eErrorType != ET_MissingVolume) { m_eErrorType = ET_NeedPassword; } —— 解除 CLOBBER #1。
守卫 99221e16 不变，两处修复后既有守卫自然生效。
影响
加密 zip 分卷缺失时正确提示"分卷缺失"而非"密码错误"；正常密码流程与非加密路径行为不变。

改动安全评估
代码安全
风险等级：低风险
三个 commit 均为「加守卫/补提示」式增量：Commit 1 仅在错误路径新增用户可见提示，不改数据流/文件保留逻辑；Commit 2/3 仅在 ET_MissingVolume 已置时跳过一次错误类型覆写，其余所有状态行为与改动前完全一致。
Commit 2/3 的两处覆写点均 blame 到项目早期原始代码（非任何 PMS bug 修复产物），不撤销历史修复。Commit 3 与 99221e16（BUG-371879）守卫互补而非冲突——前者挡密码提示入口，后者挡密码错误行，覆盖范围正交。
业务影响范围
归档管理器 / 解压功能：单文件右键"提取"、整包"解压"路径的错误提示完整性；加密 zip/RAR 分卷压缩包缺失分卷时的提示准确性。
受影响用户场景：加密分卷压缩包提取（缺失分卷 + 正确/错误密码）、非加密分卷压缩包提取、加密非分卷压缩包提取、RAR4/RAR5 加密分卷提取。
验证建议
加密 zip 分卷压缩包缺失分卷 + 正确密码 → 期望"分卷缺失"提示（非"密码错误"）。
加密 zip 分卷压缩包缺失分卷 + 错误密码 → 期望"分卷缺失"提示。
加密 zip 压缩包（非分卷）正确/错误密码 → 期望对应提示，行为不变。
非加密 zip 分卷压缩包缺失分卷 → 期望"分卷缺失"提示，行为不变。
RAR4/RAR5 加密分卷压缩包缺失分卷 → 期望"分卷缺失"提示（非"密码错误"）。
单文件右键"提取"输错密码 / 破坏分卷 → 期望对应失败页提示；回归"解压"路径提示行为不变。
关联
PMS: BUG-373669（【1070u5】分卷加密压缩提取时无错误提示）
相关历史修复：BUG-371831（eee60d60，补 ET_MissingVolume 提示）、BUG-371879（99221e16，7z 密码错误不覆盖分卷缺失守卫）
非阻塞性加固建议：handleFileExists() 的 cliinterface.cpp:1108/1112 亦无条件置 ET_NoError，「分卷缺失 + 目标同名文件需跳过」叠加场景同样会覆盖 ET_MissingVolume，建议另行跟踪。