### PR TITLE
fix: reject drag-drop add for non-local compressed files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -288,12 +288,9 @@ int main(int argc, char *argv[])
             if (strType == "dragdropadd") {
                 // 最后一个参数为“dragdropadd”时，说明是拖拽追加
                 eType = MainWindow::AT_DragDropAdd;
-                QFileInfo info(newfilelist.first());
-                if (info.isSymLink()) {
-                    QUrl fileName = QUrl::fromLocalFile(info.symLinkTarget());
-                    if (!UiTools::isLocalDeviceFile(fileName.toLocalFile())) {
-                        return -1;
-                    }
+                // 校验入参压缩包是否位于本地设备（符号链接解析其指向，兼容 276309；非本地如 ftp/gvfs 挂载则拒绝）
+                if (!w.checkArchiveLocalDevice(newfilelist.first())) {
+                    return -1;
                 }
             } else if (strType == "compress" || strType == "compress_to_7z" || strType == "compress_to_zip" ||
                        strType == "extract" || strType == "extract_here" || strType == "extract_to_specifypath") {

--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -169,6 +169,23 @@ bool MainWindow::checkHerePath(const QString &strPath)
     return true;
 }
 
+bool MainWindow::checkArchiveLocalDevice(const QString &strArchivePath)
+{
+    // 解析真实路径：符号链接取其指向（兼容 276309 场景），其余取路径本身（含 gvfs/ftp 挂载路径）
+    QFileInfo info(strArchivePath);
+    QString strRealPath = info.isSymLink() ? info.symLinkTarget() : info.filePath();
+
+    // 非本地设备（ftp/smb/手机等）不支持拖拽追加，提示并退出
+    if (!UiTools::isLocalDeviceFile(strRealPath)) {
+        TipDialog dialog(this);
+        moveDialogToCenter(&dialog);
+        dialog.showDialog(tr("Dragging files to the shortcut of a compressed file on a non-local device is not supported"), tr("OK", "button"), DDialog::ButtonNormal);
+        return false;
+    }
+
+    return true;
+}
+
 void MainWindow::initUI()
 {
     // 初始化界面

--- a/src/source/mainwindow.h
+++ b/src/source/mainwindow.h
@@ -65,6 +65,13 @@ public :
     bool checkHerePath(const QString &strPath);
 
     /**
+     * @brief checkArchiveLocalDevice 检查拖拽追加的压缩包是否位于本地设备
+     * @param strArchivePath  dragdropadd 入参的压缩包路径（可为符号链接/gvfs 挂载路径等）
+     * @return true=本地设备（可继续追加）；false=非本地设备（已提示并应退出）
+     */
+    bool checkArchiveLocalDevice(const QString &strArchivePath);
+
+    /**
      * @brief checkSettings 检测目标文件合法性
      * @param file  文件名
      * @return

--- a/translations/deepin-compressor_zh_CN.ts
+++ b/translations/deepin-compressor_zh_CN.ts
@@ -917,6 +917,11 @@
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>当前压缩文件已经发生变化，请重新导入文件。</translation>
     </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="182"/>
+        <source>Dragging files to the shortcut of a compressed file on a non-local device is not supported</source>
+        <translation>不支持拖拽到压缩文件快捷方式里</translation>
+    </message>
 </context>
 <context>
     <name>MimeTypeDisplayManager</name>

--- a/translations/deepin-compressor_zh_HK.ts
+++ b/translations/deepin-compressor_zh_HK.ts
@@ -917,6 +917,11 @@
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>當前壓縮文件已經發生變化，請重新導入文件。</translation>
     </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="182"/>
+        <source>Dragging files to the shortcut of a compressed file on a non-local device is not supported</source>
+        <translation>不支持拖拽到壓縮檔快捷方式裡</translation>
+    </message>
 </context>
 <context>
     <name>MimeTypeDisplayManager</name>

--- a/translations/deepin-compressor_zh_TW.ts
+++ b/translations/deepin-compressor_zh_TW.ts
@@ -917,6 +917,11 @@
         <source>The archive was changed on the disk, please import it again.</source>
         <translation>目前壓縮文件已經發生變化，請重新匯入文件。</translation>
     </message>
+    <message>
+        <location filename="../src/source/mainwindow.cpp" line="182"/>
+        <source>Dragging files to the shortcut of a compressed file on a non-local device is not supported</source>
+        <translation>不支援拖曳到壓縮檔捷徑裡</translation>
+    </message>
 </context>
 <context>
     <name>MimeTypeDisplayManager</name>


### PR DESCRIPTION
## 根因分析

dragdropadd 启动参数分支的本地设备守卫被错误地闸在 `if (info.isSymLink())` 之内（`src/main.cpp:292`，来自 bug 276309 的部分修复 `f9c58e81`）。文管「创建链接到本地目录」生成的是 .desktop 快捷方式，或入参直接是 gvfs/ftp 挂载路径（`/run/user/<uid>/gvfs/ftp:host=…/xxx.zip`），`isSymLink()` 为 false，守卫整体跳过，流程进入 `handleArguments_Append()`（无本地设备校验）→ `ArchiveManager::addFiles()` 在 gvfs-ftp 上 seek 失败 → 失败页弹「解压失败」。

关键证据：
- 全仓 `isLocalDeviceFile` 其余调用点（`homepage.cpp:100 dragEnterEvent`、`datatreeview.cpp:334 dragEnterEvent`、`mainwindow.cpp:965 slotChoosefiles`）均对路径本身逐个无条件校验，唯独 dragdropadd 分支带 `isSymLink()` 闸门——反证该闸门即缺陷。
- `uitools.cpp:424 isLocalDeviceFile()` 对 gvfs-ftp（device 非 `/dev/`、fstype `fuse.gvfs`）返回 false，判定正确可复用。

详见附件 `analysis-report.md`。

## 修复方案

将 dragdropadd 分支的校验从「仅符号链接」放宽为「对入参压缩包真实路径无条件校验」：
- 新增 `MainWindow::checkArchiveLocalDevice()`（`src/source/mainwindow.h`/`mainwindow.cpp`，紧邻既有同款守卫 `checkHerePath`）：解析真实路径（符号链接→`symLinkTarget()`，其余→`filePath()`），调 `UiTools::isLocalDeviceFile()`，非本地则用 `TipDialog` 提示并返回 false。
- `src/main.cpp:288-294` dragdropadd 分支：删除原 `isSymLink()` 闸门块，改为 `if (!w.checkArchiveLocalDevice(newfilelist.first())) { return -1; }`，与同文件 `w.checkHerePath(...)`/`w.checkSettings(...)` 调用方式一致。
- 保留符号链接场景处理（放宽而非删除），避免回归 bug 276309；退出语义（`return -1`）与原 `f9c58e81` 一致。
- 补充 zh_CN/zh_HK/zh_TW 翻译（对照 `0d683734` 的 seek 文案条目格式）。

## 改动安全评估

低风险。无签名变更；`isLocalDeviceFile` 实现与签名不变；dragdropadd 分支属 `main()` 启动参数解析，无外部调用者；改动为新增 early-return 守卫 + 新增局部方法，符合「只加边界检查/early return、无外部调用者」。行为变更受控：仅「非符号链接且非本地设备」路径由「进入追加→失败」改为「入口提示并退出」（期望行为）；符号链接非本地（276309 场景）与所有本地路径行为不变。详见附件 `change-safety.md`。

## 测试建议

项目存在已有单元测试 `tests/UnitTest/`（含 `ut_uitools.cpp` 等引用 `isLocalDeviceFile`），本次未改动其实现与签名，建议自行运行验证。复现验证：挂载 ftp 共享 → ftp 目录压缩文件右键「创建链接到本地目录」→ 拖本地文件到快捷方式，应弹「不支持拖拽到压缩文件快捷方式里」并退出，不再弹「解压失败」。

## Summary by Sourcery

Validate drag-and-drop append targets for archives and reject non-local compressed-file shortcuts to avoid failing operations on remote mounts.

Bug Fixes:
- Prevent drag-and-drop append operations from proceeding when the target compressed file (or its shortcut) resides on non-local devices such as gvfs/FTP mounts, avoiding seek failures and misleading extraction error pages.

Enhancements:
- Introduce a MainWindow helper to resolve an archive’s real path (including symlinks) and reuse existing local-device checks before drag-and-drop append operations.