### PR TITLE
fix(security): skip chmod on symlink entries during tar extraction

### DIFF
--- a/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
+++ b/3rdparty/libarchive/libarchive/libarchiveplugin.cpp
@@ -255,6 +255,7 @@ PluginFinishType LibarchivePlugin::extractFiles(const QList<FileEntry> &files, c
         }
 
         const bool entryIsDir = S_ISDIR(archive_entry_mode(entry)); //该条entry是否是文件夹
+        const bool entryIsLink = (archive_entry_filetype(entry) == AE_IFLNK); //该条entry是否是符号链接
 
         const char *name = archive_entry_pathname(entry);
         QString entryName = m_common->trans2uft8(name, m_mapCode[QString(name)]); //该条entry在压缩包内文件名(全路径)
@@ -487,13 +488,17 @@ PluginFinishType LibarchivePlugin::extractFiles(const QList<FileEntry> &files, c
 
             copyDataFromSource(m_archiveReader.data(), writer.data(), QFileInfo(m_strArchiveName).size());
 
-            // qInfo() <<  destinationDirectory + QDir::separator() + entryName;
-            // 文件权限设置
-            QFileDevice::Permissions per = getPermissions(archive_entry_perm(entry));
-            if (entryIsDir) {
-                per |= QFileDevice::ReadUser | QFileDevice::WriteUser | QFileDevice::ExeUser;
+            // 文件权限设置（cwd 已切到解压目录，entryName 为相对路径）。
+            // 符号链接条目跳过：QFile::setPermissions 底层是 chmod，会跟随符号链接
+            // 作用到其指向的真实目标文件上，导致解压目录外文件权限被篡改
+            // (UT-2026-0114 / BUG-373791)。Linux 上符号链接自身 mode 无意义。
+            if (!entryIsLink) {
+                QFileDevice::Permissions per = getPermissions(archive_entry_perm(entry));
+                if (entryIsDir) {
+                    per |= QFileDevice::ReadUser | QFileDevice::WriteUser | QFileDevice::ExeUser;
+                }
+                QFile::setPermissions(entryName, per);
             }
-            QFile::setPermissions(/*destinationDirectory + QDir::separator() + */entryName, per);
         }
         break;
         case ARCHIVE_FAILED: {


### PR DESCRIPTION
## 根因分析

解压 tar 归档时，`3rdparty/libarchive/libarchive/libarchiveplugin.cpp` 的 `LibarchivePlugin::extractFiles` 在 `ARCHIVE_OK` 分支对**每个条目（含符号链接）**无条件调用 `QFile::setPermissions(entryName, per)`。该接口底层是 POSIX `chmod`，**默认跟随符号链接**，于是归档中符号链接条目携带的权限位被错误应用到了链接指向的真实目标文件上，篡改了解压目录之外的文件权限（CNVD/UT-2026-0114，中危 CVSS 6.5）。

关键证据：
1. 缺陷代码 `libarchiveplugin.cpp:496`（`extractionFlags()` 未设 `ARCHIVE_EXTRACT_PERM`，权限完全由该行设置）。
2. 同仓库 zip 路径 `libzipplugin.cpp:1134` 已用 `if(!isLink) { file.setPermissions(per); }` 跳过符号链接——tar/libarchive 路径遗漏了同样判别。
3. 用 libarchive 3.7.4 + 等价标志位的最小复现实测：绝对路径/`..` 目标符号链接均 `archive_write_header=ARCHIVE_OK`，随后 `chmod` 跟随链接将解压目录外目标文件权限 `0600→0777`；加修复后保持 `0600`。

## 修复方案

在 `ARCHIVE_OK` 分支增加符号链接判别 `entryIsLink = (archive_entry_filetype(entry) == AE_IFLNK)`，将权限设置代码包入 `if (!entryIsLink) { ... }`，与 `libzipplugin` 对齐。Linux 上符号链接自身 mode 无意义，跳过设置无功能损失。

## 改动安全评估

**低风险**：仅加类型判别 + 条件包裹已有权限设置调用，不改函数签名/返回值/控制流主干，无调用者依赖被改行为。目标行源自最早功能奠基提交，不与近期安全提交（`6170f429`/`111b45f3`）冲突。

## Summary by Sourcery

Bug Fixes:
- Avoid unintended chmod on files outside the extraction directory by no longer setting permissions for symlink entries during tar extraction.