### PR TITLE
fix: validate index before accessing entry in DataModel::data

### DIFF
--- a/src/source/tree/datamodel.cpp
+++ b/src/source/tree/datamodel.cpp
@@ -47,8 +47,17 @@ QVariant DataModel::headerData(int section, Qt::Orientation orientation, int rol
 
 QVariant DataModel::data(const QModelIndex &index, int role) const
 {
+    if (!index.isValid()) {
+        return QVariant();
+    }
+
     int iRow = index.row();
     int iColumn = index.column();
+
+    if (iRow < 0 || iRow >= m_listEntry.size()
+            || iColumn < 0 || iColumn >= m_listColumn.size()) {
+        return QVariant();
+    }
 
     FileEntry entry = m_listEntry[iRow];
 


### PR DESCRIPTION
## 根因分析

`DataModel::data()`（`src/source/tree/datamodel.cpp`）在访问 `m_listEntry[iRow]` 前未校验 `index.isValid()` 与行列边界。压测脚本反复刷新文件列表（`refreshFileEntry` 的 `beginResetModel/endResetModel`）并键盘导航时，视图对过期/越界索引请求数据，`QList::operator[]` 越界读取 → `FileEntry` 拷贝构造对脏 `QString` 解引用 → 段错误 coredump。

关键证据：开发者 gdb 栈 `#0 QString::QString` ← `#1 FileEntry::FileEntry(commonstruct.h:74)` ← `#2 DataModel::data(datamodel.cpp:53)` ← `QAbstractItemView::keyPressEvent` ← `DataTreeView::keyPressEvent(datatreeview.cpp:504)`，与缺陷行号、类型完全吻合。

## 修复方案

在 `DataModel::data()` 开头补齐 Qt 模型/视图契约要求的索引合法性 + 行列边界校验，越界返回 `QVariant()`，随后原有逻辑不变。改动仅 9 行，仅限 `data()` 函数开头。

## 改动安全评估

低风险。目标代码自 2020-10-13 首次提交起未被任何 bug 修复改动，本次为纯防御性 early-return，不改函数签名、不改合法路径返回值、无外部直接调用者（`data()` 由 Qt 框架虚分派调用），符合 `QAbstractItemModel::data()` 重写契约。

## Summary by Sourcery

Bug Fixes:
- Prevent crashes in DataModel::data by returning an empty QVariant for invalid or out-of-range model indexes instead of accessing entries out of bounds.