### PR TITLE
fix: clear input box focus on blank area click

### DIFF
--- a/src/source/page/compresssettingpage.cpp
+++ b/src/source/page/compresssettingpage.cpp
@@ -1006,3 +1006,25 @@ TypeLabel *CompressSettingPage::getClickLbl() const
 {
     return m_pClickLbl;
 }
+
+void CompressSettingPage::mousePressEvent(QMouseEvent *event)
+{
+    // 点击空白区域时，清除输入框焦点
+    if (m_pFileNameEdt && m_pFileNameEdt->lineEdit()->hasFocus()) {
+        m_pFileNameEdt->lineEdit()->clearFocus();
+    }
+    if (m_pSavePathEdt && m_pSavePathEdt->lineEdit()->hasFocus()) {
+        m_pSavePathEdt->lineEdit()->clearFocus();
+    }
+    if (m_pPasswordEdt && m_pPasswordEdt->lineEdit()->hasFocus()) {
+        m_pPasswordEdt->lineEdit()->clearFocus();
+    }
+    if (m_pSplitValueEdt && m_pSplitValueEdt->hasFocus()) {
+        m_pSplitValueEdt->clearFocus();
+    }
+    if (m_pCommentEdt && m_pCommentEdt->hasFocus()) {
+        m_pCommentEdt->clearFocus();
+    }
+
+    DWidget::mousePressEvent(event);
+}

--- a/src/source/page/compresssettingpage.h
+++ b/src/source/page/compresssettingpage.h
@@ -89,6 +89,13 @@ public:
      */
     bool isOrderMode();
 
+protected:
+    /**
+     * @brief mousePressEvent 鼠标点击事件，点击空白区域取消输入框焦点
+     * @param event
+     */
+    void mousePressEvent(QMouseEvent *event) override;
+
 private:
     /**
      * @brief initUI    初始化界面


### PR DESCRIPTION
## Root Cause Analysis

`CompressSettingPage` (baseline `release/eagle`) did not override `mousePressEvent`, so clicking a blank area never cleared focus from input controls. The focused `DDoubleSpinBox` (`m_pSplitValueEdt`) then intercepted mouse wheel events (`QAbstractSpinBox::stepBy()` in Qt 5.15 fires only while focused) and changed the split-size value instead of letting the wheel scroll the outer `QScrollArea`. Mainline commit `80b6b0b1` already fixed this but was never backported to `release/eagle`.

Key evidence: `compresssettingpage.cpp` had no `mousePressEvent` override; blank-area widgets use `Qt::NoFocus`; the spinbox retains focus after value entry, so the wheel is consumed by the spinbox rather than bubbling to the scroll area.

## Fix Plan

Backport mainline `80b6b0b1`: add a `mousePressEvent` override to `CompressSettingPage` that calls `clearFocus()` on each focused input control (filename, save path, password, split value, comment) when a blank area is clicked, then forwards to `DWidget::mousePressEvent`. All control pointers are null-checked. Debug `qDebug()` statements from the mainline commit were removed, and the `.h` `isOrderMode()` placement conflict was resolved by keeping it in its original `public` section and adding a new `protected:` block.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Pure additive override — no existing function signatures, public members, or logic modified; null-pointer guards on every control; base-class `DWidget::mousePressEvent(event)` preserved at the end.
- Pickaxe history confirms `CompressSettingPage` never had this override before, so there is no prior fix to regress. Recent file changes (dconfig adaptation, drag-drop disable on comment box) do not touch focus handling.

### Business Impact Scope

Affected module: **Compress settings page** (`CompressSettingPage`). User scenarios: after typing in the split-size box (or filename / save path / password / comment), clicking a blank area now removes input focus, so the mouse wheel scrolls the page instead of altering the split-size value.

### Verification Suggestion

Enter a value in the split-size box, click blank area, then scroll — confirm the value no longer changes. Repeat for filename, save path, password, and comment boxes. Confirm page buttons and scrolling still work normally after focus loss.

---

## 根因分析

`CompressSettingPage`（基线 `release/eagle`）未重写 `mousePressEvent`，点击空白区域时不会清除输入控件焦点。持焦的 `DDoubleSpinBox`（`m_pSplitValueEdt`）随后拦截鼠标滚轮事件（Qt 5.15 中 `QAbstractSpinBox::stepBy()` 仅在持焦时触发），改变分卷大小数值，而非让滚轮事件冒泡至外层 `QScrollArea` 滚动页面。主线 commit `80b6b0b1` 已修复此问题但未回移到 `release/eagle`。

关键证据：`compresssettingpage.cpp` 无 `mousePressEvent` 重写；空白区域控件焦点策略为 `Qt::NoFocus`；spinbox 在输入后保留焦点，滚轮被 spinbox 消费而非冒泡到滚动区域。

## 修复方案

backport 主线 `80b6b0b1`：为 `CompressSettingPage` 新增 `mousePressEvent` 重写，点击空白区域时对各持焦输入控件（文件名、保存路径、密码、分卷大小、注释）调用 `clearFocus()`，再转发至 `DWidget::mousePressEvent`。所有控件指针均做空指针判断。已清理主线 commit 中的 `qDebug()` 调试日志，并解决 `.h` 中 `isOrderMode()` 位置冲突（保留在原 `public` 段，新增 `protected:` 块）。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 纯新增重写——未修改任何已有函数签名、公开成员或既有逻辑；每个控件均有空指针保护；末尾保留 `DWidget::mousePressEvent(event)` 基类行为。
- Pickaxe 历史确认 `CompressSettingPage` 此前无此重写，不存在撤销历史修复引入回归的风险。近期文件改动（dconfig 适配、注释框禁用拖拽）均不涉及焦点处理。

### 业务影响范围

受影响模块：**压缩设置页**（`CompressSettingPage`）。用户场景：在分卷大小输入框（或文件名/保存路径/密码/注释）输入后，点击空白区域即移除输入焦点，鼠标滚轮改为滚动页面而非误改分卷大小数值。

### 验证建议

在分卷大小输入框填值后点击空白处，再滚动滚轮——确认数值不再变化。对文件名、保存路径、密码、注释等输入框重复验证。确认失焦后页面按钮与滚动等交互仍正常。

## Summary by Sourcery

Bug Fixes:
- Clear focus from input controls when users click a blank area of the compression settings page, allowing mouse-wheel scrolling instead of unintended split-size changes.