### PR TITLE
fix(security): fix backslash path traversal in minizip extraction (#461)

### DIFF
--- a/3rdparty/libminizipplugin/libminizipplugin.cpp
+++ b/3rdparty/libminizipplugin/libminizipplugin.cpp
@@ -293,17 +293,38 @@ ErrorType LibminizipPlugin::extractEntry(unzFile zipfile, unz_file_info file_inf
         strFileName = strFileName.remove(0, options.strDestination.size());
     }
 
-    while (strFileName.contains(QStringLiteral("../"))) {
-        qInfo() << "skipped ../ path component(s) in " << strFileName;
-        strFileName = strFileName.replace(QStringLiteral("../"), QString());
-    }
+    // 先统一路径分隔符，避免反斜杠形式的 "../" 绕过后续剥离
     if (strFileName.contains(QLatin1Char('\\'))) {
         strFileName = strFileName.replace(QLatin1Char('\\'), QDir::separator());
     }
 
-    emit signalCurFileName(strFileName);        // 发送当前正在解压的文件名
+    // 目录条目以分隔符结尾，先记录，避免规范化丢失尾部分隔符
+    const bool bIsDirectory = strFileName.endsWith(QDir::separator());
 
-    bool bIsDirectory = strFileName.endsWith(QDir::separator());    // 是否为文件夹
+    // 安全规范化路径：按分隔符拆分后用栈过滤 "." 与 ".."，替代易出错的字符串替换
+    const QStringList pathParts = strFileName.split(QDir::separator(),
+        #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            QString::SkipEmptyParts
+        #else
+            Qt::SkipEmptyParts
+        #endif
+        );
+    QStringList safeParts;
+    for (const QString &part : pathParts) {
+        if (part == QLatin1String("..")) {
+            if (!safeParts.isEmpty()) {
+                safeParts.removeLast();
+            }
+        } else if (part != QLatin1String(".")) {
+            safeParts.append(part);
+        }
+    }
+    strFileName = safeParts.join(QDir::separator());
+    if (bIsDirectory && !strFileName.isEmpty() && !strFileName.endsWith(QDir::separator())) {
+        strFileName += QDir::separator();
+    }
+
+    emit signalCurFileName(strFileName);        // 发送当前正在解压的文件名
 
     // 判断解压路径是否存在，不存在则创建文件夹
     if (QDir().exists(options.strTargetPath) == false)
@@ -311,6 +332,16 @@ ErrorType LibminizipPlugin::extractEntry(unzFile zipfile, unz_file_info file_inf
 
     // 解压完整文件名（含路径）
     QString strDestFileName = options.strTargetPath + QDir::separator() + strFileName;
+
+    // 词法包含校验：规范化后最终写入路径必须位于解压目录内，拦截 "../" 路径穿越
+    const QString cleanTargetPath = QDir::cleanPath(QDir(options.strTargetPath).absolutePath());
+    const QString cleanDestPath = QDir::cleanPath(QDir(strDestFileName).absolutePath());
+    if (!cleanDestPath.startsWith(cleanTargetPath + QDir::separator()) &&
+        cleanDestPath != cleanTargetPath) {
+        qInfo() << "Path traversal detected! Rejected path: " << strFileName;
+        return ET_FileWriteError;
+    }
+
     QFile file(strDestFileName);
 
     if (bIsDirectory) {     // 文件夹


### PR DESCRIPTION
extractEntry strips forward-slash parent references before converting backslashes to separators. An archive entry name using backslash parent references (..\..\..) bypasses the stripping and, after conversion, escapes the extraction directory to write arbitrary files. Convert backslashes before stripping and restore the lexical + canonical containment checks (extractPathIsWithinTarget) to align with libzip.

Bug: https://pms.uniontech.com/task-view-393685.html

## Summary by Sourcery

Harden minizip extraction against path traversal by normalizing entry separators, resolving parent references, and rejecting destinations outside the extraction directory.

Bug Fixes:
- Prevent backslash-based and other archive entry path traversal from escaping the extraction directory during minizip extraction.

Enhancements:
- Normalize archive paths safely and enforce lexical containment of extracted files within the target directory.