### PR TITLE
fix: decouple specialCpuTarGzCompressor dconfig read from m_isOrderMode gate

### DIFF
--- a/src/source/page/compresssettingpage.cpp
+++ b/src/source/page/compresssettingpage.cpp
@@ -468,6 +468,13 @@ void CompressSettingPage::setSplitEnabled(bool bEnabled)
 void CompressSettingPage::refreshCompressLevel(const QString &strType)
 {
 #ifdef DTKCORE_CLASS_DConfigFile
+    if (strType == "tar.gz" && m_dconfig) {
+        DConfig *dconfig = (DConfig *)m_dconfig;
+        if (dconfig && dconfig->isValid() && dconfig->keyList().contains("specialCpuTarGzCompressor")) {
+            int nCpu = dconfig->value("specialCpuTarGzCompressor").toInt();
+            m_pCpuCmb->setCurrentIndex(nCpu);
+        }
+    }
     if(m_isOrderMode) {
         // 其余格式支持设置压缩方式
         // 设置压缩方式可用
@@ -500,15 +507,6 @@ void CompressSettingPage::refreshCompressLevel(const QString &strType)
             if(dconfig && dconfig->isValid() && dconfig->keyList().contains("specialTarGzCompressor")){
                         int nMethod = dconfig->value("specialTarGzCompressor").toInt();
                         m_pCompressLevelCmb->setCurrentIndex(nMethod);
-                    }
-            if(dconfig && dconfig->isValid() && dconfig->keyList().contains("specialCpuTarGzCompressor")){
-                        int nCpu = dconfig->value("specialCpuTarGzCompressor").toInt();
-                        m_pCpuCmb->setCurrentIndex(nCpu);
-                    }
-        } else if(strType == "tar.gz") {
-             if(dconfig && dconfig->isValid() && dconfig->keyList().contains("specialTarGzCompressor")){
-                       int nMethod = dconfig->value("specialTarGzCompressor").toInt();
-                       m_pCompressLevelCmb->setCurrentIndex(nMethod);
                     }
         } else if(strType == "tar.lz") {
             if(dconfig && dconfig->isValid() && dconfig->keyList().contains("specialTarLzCompressor")){
@@ -804,12 +802,10 @@ void CompressSettingPage::slotAdvancedEnabled(bool bEnabled)
     if (m_pCompressTypeLbl->text() == "tar.gz") {
         m_pCpuCmb->setCurrentIndex(m_pCpuCmb->count() - 1);
 #ifdef DTKCORE_CLASS_DConfigFile
-        if(m_isOrderMode) {
-            DConfig *dconfig = (DConfig *)m_dconfig;
-            if(dconfig && dconfig->isValid() && dconfig->keyList().contains("specialCpuTarGzCompressor")){
-                int nCpu = dconfig->value("specialCpuTarGzCompressor").toInt();
-                m_pCpuCmb->setCurrentIndex(nCpu);
-            }
+        DConfig *dconfig = (DConfig *)m_dconfig;
+        if(dconfig && dconfig->isValid() && dconfig->keyList().contains("specialCpuTarGzCompressor")){
+            int nCpu = dconfig->value("specialCpuTarGzCompressor").toInt();
+            m_pCpuCmb->setCurrentIndex(nCpu);
         }
 #endif
     }


### PR DESCRIPTION
fix: decouple specialCpuTarGzCompressor dconfig read from m_isOrderMode gate

The CPU thread count config (specialCpuTarGzCompressor) for tar.gz was
gated behind m_isOrderMode, which defaults to false because
specialCustomizedType defaults to -1. This caused the dconfig value to
never be read, so the UI always fell back to max threads (8) regardless
of the configured value.

Fix by reading specialCpuTarGzCompressor independently of m_isOrderMode
in both refreshCompressLevel() and slotAdvancedEnabled(). Also remove
the duplicate dead-code tar.gz branch in refreshCompressLevel().

Log: fix tar.gz CPU thread count not applying from dconfig
Bug: https://pms.uniontech.com/bug-view-273093

## Summary by Sourcery

Apply tar.gz CPU thread settings independently of order mode so configured values are honored consistently.

Bug Fixes:
- Ensure the configured tar.gz CPU thread count is applied from dconfig regardless of order mode.

Enhancements:
- Remove redundant tar.gz compressor handling from compression-level refresh logic.