### PR TITLE
fix: register zip split-volume mimetypes for consistent icon display

### DIFF
--- a/src/assets/mimetype/deepin-compressor.xml
+++ b/src/assets/mimetype/deepin-compressor.xml
@@ -12,5 +12,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 		<generic-icon name="deepin-compressor"/>
 		<glob pattern="*.7z.*" weight="80"/>
 	</mime-type>
+	<mime-type type="application/zip">
+		<generic-icon name="deepin-compressor"/>
+		<glob pattern="*.z[0-9][0-9]"/>
+		<glob pattern="*.zip.[0-9][0-9][0-9]"/>
+	</mime-type>
 </mime-info>
 


### PR DESCRIPTION
## 修复内容

在 `src/assets/mimetype/deepin-compressor.xml` 中新增 `application/zip` mime-type 注册，覆盖 zip 分卷扩展名，绑定 `generic-icon name="deepin-compressor"`，与现有 `application/x-7z-compressed` 处理方式对齐。

### 问题原因
`deepin-compressor.xml` 仅注册了 `application/x-7z-compressed`（glob `*.7z.*` + generic-icon），故 7z 分卷各分片图标一致；但 zip 分卷扩展名（`*.z01`、`*.zip.001` 等）完全未注册，文管/gio 对这些分片回退到 `application/octet-stream` → 未知图标，与主 `.zip` 不一致。

### 修复方案
```xml
<mime-type type="application/zip">
    <generic-icon name="deepin-compressor"/>
    <glob pattern="*.z[0-9][0-9]"/>
    <glob pattern="*.zip.[0-9][0-9][0-9]"/>
</mime-type>
```

- `*.z[0-9][0-9]`：覆盖 WinZip 风格分卷（如 `xxx.z01`），默认 weight 50，系统 `*.z64`（literal glob）同 weight 优先级更高，不受影响
- `*.zip.[0-9][0-9][0-9]`：覆盖通用分卷风格（如 `xxx.zip.001`）
- `generic-icon name="deepin-compressor"`：与 7z 一致，覆盖系统默认 `package-x-generic`

### 影响范围
仅修改 mime-type 注册 XML（+5 行），无 C++/CMake 代码变更，不影响应用内 mimetype 检测逻辑。

Log: PMS 268375

## Summary by Sourcery

Bug Fixes:
- Register ZIP split-volume extensions as application/zip files so their icons consistently use deepin-compressor instead of unknown-file icons.