### PR TITLE
fix: add zip split archive MIME icon definition

### DIFF
--- a/src/assets/mimetype/deepin-compressor.xml
+++ b/src/assets/mimetype/deepin-compressor.xml
@@ -12,5 +12,11 @@ SPDX-License-Identifier: GPL-3.0-or-later
 		<generic-icon name="deepin-compressor"/>
 		<glob pattern="*.7z.*" weight="80"/>
 	</mime-type>
+	<mime-type type="application/x-zip-split">
+		<comment>ZIP Split Archive Part</comment>
+		<generic-icon name="deepin-compressor"/>
+		<glob pattern="*.zip.[0-9]*" weight="80"/>
+		<glob pattern="*.z[0-9]*" weight="80"/>
+	</mime-type>
 </mime-info>
 


### PR DESCRIPTION
## Root Cause Analysis

The deepin-compressor MIME package (`src/assets/mimetype/deepin-compressor.xml`) only defines a custom MIME type with `generic-icon=deepin-compressor` for 7z split archives (`application/x-7z-compressed` + glob `*.7z.*`). Zip split archive sub-files have no MIME/glob/icon definition, so they fall back to generic or unknown icons in the file manager, causing icon inconsistency between the main archive and its parts. The two zip split naming formats are confirmed in `src/source/common/uitools.cpp:342` `transSplitFileName`: format A (`.zip.001`, `.zip.002`…) and format B (`.zip` + `.z01`, `.z02`…).

## Fix

Added a new `<mime-type type="application/x-zip-split">` entry to `deepin-compressor.xml`, with two glob patterns (`*.zip.[0-9]*` and `*.z[0-9]*`, both at weight 80) covering both zip split naming formats, and `generic-icon=deepin-compressor` to ensure sub-files display the same icon as the main archive. The new entry follows the existing 7z split definition pattern and does not modify any existing definitions.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- This is a pure data-file addition (XML MIME package) — no code logic, function signatures, or callers are modified; `References=0`.
- The target MIME definition is not a historical bug-fix product; this addition does not revert any prior change.

### Business Impact Scope

- **File manager icon display**: Zip split archive sub-files (`.zip.001`/`.zip.002`… and `.z01`/`.z02`…) will now display the deepin-compressor icon.
- Format B (`.zip` + `.z0N`) main `.zip` file still matches the system `application/zip` MIME type and shows the system zip icon. Overriding `application/zip`'s `generic-icon` would affect ALL zip files (including non-split regular zip), so this is intentionally NOT done. The main/sub icon difference for format B remains and is documented here as a known limitation.
- 7z split archives and regular zip files are unaffected (regression-safe).

### Verification Suggestion

Verify that both zip split naming formats show the deepin-compressor icon for sub-files, and that 7z split and regular zip icons are unchanged.

---

## 根因分析

归档管理器 MIME 包（`src/assets/mimetype/deepin-compressor.xml`）仅对 7z 分卷定义了自定义 MIME 类型及 `generic-icon=deepin-compressor`（`application/x-7z-compressed` + glob `*.7z.*`），zip 分卷子文件缺少 MIME/glob/icon 定义，在文件管理器中回退为通用/未知图标，导致主文件与子文件图标显示不一致。两种 zip 分卷命名格式在 `src/source/common/uitools.cpp:342` `transSplitFileName` 中确认：格式 A（`.zip.001`、`.zip.002`…）与格式 B（`.zip` + `.z01`、`.z02`…）。

## 修复方案

在 `deepin-compressor.xml` 中新增 `<mime-type type="application/x-zip-split">` 条目，配置两个 glob 模式（`*.zip.[0-9]*` 和 `*.z[0-9]*`，weight 80）覆盖 zip 分卷两种命名格式，并设置 `generic-icon=deepin-compressor` 使子文件与主文件图标一致。新增条目参照已有 7z 分卷定义模式，不修改任何已有定义。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 本次为纯数据文件（XML MIME 包）新增条目，不涉及代码逻辑、函数签名或调用者，`References=0`。
- 目标 MIME 定义非历史 bug 修复产物，本次新增不撤销任何历史改动。

### 业务影响范围

- **文件管理器图标显示**：zip 分卷压缩包子文件（`.zip.001`/`.zip.002`… 和 `.z01`/`.z02`…）将统一显示 deepin-compressor 图标。
- 格式 B（`.zip` + `.z0N`）主文件 `.zip` 仍命中系统 `application/zip` 类型，显示系统 zip 图标。覆盖 `application/zip` 的 `generic-icon` 会影响所有 zip 文件（含非分卷普通 zip），风险过高，本次有意不做覆盖。格式 B 主/子图标差异作为已知限制在此说明。
- 7z 分卷和普通 zip 文件不受影响（回归安全）。

### 验证建议

验证两种 zip 分卷命名格式的子文件均显示 deepin-compressor 图标，且 7z 分卷和普通 zip 图标无变化。

PMS: BUG-268375

## Summary by Sourcery

Bug Fixes:
- Add MIME recognition for ZIP split archive parts so they display the deepin-compressor icon.