### PR TITLE
fix(#266113): RAR5 wrong password shows incorrect prompt text

### DIFF
--- a/3rdparty/clirarplugin/clirarplugin.cpp
+++ b/3rdparty/clirarplugin/clirarplugin.cpp
@@ -292,6 +292,7 @@ bool CliRarPlugin::handleLine(const QString &line, WorkType workStatus)
             return false;
         } else { // RAR5密码错误：发送错误提示但不中断进程，允许用户重新输入密码
             emit error(tr("Wrong password"), tr("The password entered is incorrect. Please try again."));
+            m_bWrongPasswordRetry = true; // 标记下次重弹密码框时使用「密码错误」文案
             return true;
         }
     }

--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -1061,7 +1061,8 @@ PluginFinishType CliInterface::handlePassword()
         }
     }
 
-    PasswordNeededQuery query(name);
+    PasswordNeededQuery query(name, m_bWrongPasswordRetry);
+    m_bWrongPasswordRetry = false;
     emit signalQuery(&query);
     query.waitForResponse();
 

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -285,6 +285,7 @@ protected:
     bool m_isProcessKilled = false;  // 进程已经结束
     bool m_isEmptyArchive = false;  // 压缩包内无数据
     bool m_isCorruptArchive = false; // 是否非致命错误
+    bool m_bWrongPasswordRetry = false; // 密码错误后重弹密码框标记，供 handlePassword 区分重试文案
 
 private:
     QList<FileEntry> m_files; // 文件

--- a/3rdparty/interface/queries.cpp
+++ b/3rdparty/interface/queries.cpp
@@ -332,10 +332,11 @@ void OverwriteQuery::setWidgetType(QWidget *pWgt, DPalette::ColorType ct, double
 
 
 
-PasswordNeededQuery::PasswordNeededQuery(const QString &strFileName, QObject *parent)
+PasswordNeededQuery::PasswordNeededQuery(const QString &strFileName, bool bWrongPassword, QObject *parent)
     : Query(parent)
 {
     m_data[QStringLiteral("fileName")] = strFileName;
+    m_data[QStringLiteral("wrongPassword")] = bWrongPassword;
 }
 
 PasswordNeededQuery::~PasswordNeededQuery()
@@ -376,7 +377,11 @@ void PasswordNeededQuery::execute()
     pTipLbl->setForegroundRole(DPalette::WindowText);
 //    pTipLbl->setWordWrap(true);
     DFontSizeManager::instance()->bind(pTipLbl, DFontSizeManager::T6, QFont::Normal);
-    pTipLbl->setText(tr("Encrypted file, please enter the password"));
+    if (m_data.value(QStringLiteral("wrongPassword")).toBool()) {
+        pTipLbl->setText(tr("Wrong password, please re-enter the password"));
+    } else {
+        pTipLbl->setText(tr("Encrypted file, please enter the password"));
+    }
     pTipLbl->setAlignment(Qt::AlignCenter);
     m_strDesText = pTipLbl->text();
 

--- a/3rdparty/interface/queries.h
+++ b/3rdparty/interface/queries.h
@@ -194,7 +194,7 @@ public:
      * @param strFileName       文件名（含路径）
      * @param parent
      */
-    explicit PasswordNeededQuery(const QString &strFileName, QObject *parent = nullptr);
+    explicit PasswordNeededQuery(const QString &strFileName, bool bWrongPassword = false, QObject *parent = nullptr);
     ~PasswordNeededQuery() override;
 
     /**


### PR DESCRIPTION
## Bug #266113

归档管理器压缩包解密输入错误密码提示此文件已加密（仅 RAR5）

## 根因

RAR5 错误密码走 `clirarplugin.cpp` else 分支 `emit error(tr("Wrong password"),...) + return true`，不终止进程。unrar 再次输出密码提示，导致 `ET_WrongPassword` 被覆盖为 `ET_NeedPassword` → `ET_NoError`（`cliinterface.cpp:1050`），错误上下文丢失。首问与重试复用同一 `PasswordNeededQuery`、同一写死文案「此文件已加密」（`queries.cpp:379`），瞬时错误提示被对话框掩盖。

对比 RAR4/7z/ZIP 均通过 `return false` 终止并持久显示「密码错误」，唯独 RAR5 异常。

## 修复方案（方向① — 最小侵入）

新增 `m_bWrongPasswordRetry` 标记（`CliInterface` 成员），在 RAR5 else 分支设为 `true`，`handlePassword()` 重弹密码框时传入 `PasswordNeededQuery`，据此显示「密码错误，请重新输入解压密码」而非「此文件已加密」。标记在每次 `handlePassword()` 后重置为 `false`。

## 变更文件

- `3rdparty/interface/queries.h` — 构造函数增加 `bool bWrongPassword = false` 参数（默认值，向后兼容）
- `3rdparty/interface/queries.cpp` — 构造函数存储标记，`execute()` 据此区分提示文案
- `3rdparty/interface/archiveinterface/cliinterface.h` — 新增 `m_bWrongPasswordRetry` 成员
- `3rdparty/interface/archiveinterface/cliinterface.cpp` — `handlePassword()` 传入标记并重置
- `3rdparty/clirarplugin/clirarplugin.cpp` — RAR5 else 分支设 `m_bWrongPasswordRetry = true`

## 兼容性

- `PasswordNeededQuery` 新参数默认 `false`，现有调用与单元测试（`ut_queries.cpp`）无需改动。
- 不影响 `ET_MissingVolume` 豁免逻辑。
- 不影响 RAR4/ZIP/7z 密码错误处理路径。
- 基线：`6a7a7c9665b098275c0d75d1224621afb76d6908`（release/eagle）

## Summary by Sourcery

Correct the RAR5 wrong-password flow so retries display an explicit incorrect-password message.

Bug Fixes:
- Show a clear wrong-password retry prompt for RAR5 archives instead of treating the retry as an initial encrypted-file password request.

Enhancements:
- Preserve the existing password prompt behavior for first attempts and other archive formats while carrying retry state through the password query.