### PR TITLE
fix: parse 7z version line to support both old p7zip and new 7-Zip ou…

### DIFF
--- a/3rdparty/cli7zplugin/cli7zplugin.cpp
+++ b/3rdparty/cli7zplugin/cli7zplugin.cpp
@@ -193,7 +193,11 @@ bool Cli7zPlugin::readListLine(const QString &line)
         return false;
     }
 
-    const QRegularExpression rxVersionLine(QStringLiteral("^p7zip Version ([\\d\\.]+) .*$"));
+    // 兼容老 p7zip(输出 "p7zip Version 16.02 ...")与新版本 7-Zip(输出 "7-Zip 26.02 ...",
+    // 某些发行版首行可能形如 "7-Zip [64] 26.02" 或 "7-Zip (z) 26.02")。
+    // 仅以行首关键字作为"版本信息读取完毕"的哨兵，不依赖版本号做后续逻辑，
+    // 因此对输入尾部各种描述串 (locale=、CPUs、[64]、括号等) 均保持容错。
+    const QRegularExpression rxVersionLine(QStringLiteral("^(?:p7zip Version|7-Zip)"));
     QRegularExpressionMatch matchVersion;
 
     switch (m_parseState) {

--- a/tests/UnitTest/3rdparty/cli7zplugin/ut_cli7zplugin.cpp
+++ b/tests/UnitTest/3rdparty/cli7zplugin/ut_cli7zplugin.cpp
@@ -309,6 +309,14 @@ TEST_F(UT_Cli7zPlugin, test_readListLine_002)
     EXPECT_EQ(m_tester->m_parseState, ParseStateHeader);
 }
 
+TEST_F(UT_Cli7zPlugin, test_readListLine_version_7zip)
+{
+    // 新版本 7-Zip 的输出版本行不含 "p7zip Version"，需能正确推进解析状态
+    m_tester->m_parseState = ParseStateTitle;
+    EXPECT_EQ(m_tester->readListLine("7-Zip 26.02 (x64) : Copyright (c) 1999-2026 Igor Pavlov : 2026-08-05"), true);
+    EXPECT_EQ(m_tester->m_parseState, ParseStateHeader);
+}
+
 TEST_F(UT_Cli7zPlugin, test_readListLine_003)
 {
     m_tester->m_parseState = ParseStateHeader;


### PR DESCRIPTION
…tput

The readListLine state machine required the exact 'p7zip Version <num>' prefix to leave ParseStateTitle. The upstream 7-Zip binary outputs '7-Zip 26.02 ...' (no 'p7zip Version' substring), so list parsing stayed stuck at Title state and the compressor showed an empty archive despite valid data.

Match either prefix at line start as a sentinel, staying tolerant of trailing variants like '[64]', '(z)', 'locale=...' etc. Add a UT covering the new format.

bug: https://pms.uniontech.com/bug-view-375343.html

## Summary by Sourcery

Update 7-Zip version-line detection to support both legacy p7zip and modern 7-Zip output.

Bug Fixes:
- Fix archive listing for newer 7-Zip output so valid archive contents are parsed instead of appearing empty.

Enhancements:
- Support both legacy p7zip and modern 7-Zip version-line formats, including common trailing variants.

Tests:
- Add unit coverage for parsing the modern 7-Zip version format.