### PR TITLE
fix: adapt working archive location by free space for long-name 7z ex…

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -45,6 +45,7 @@
 
 #include "common.h"
 #include <linux/limits.h>
+#include <unistd.h>
 
 CliInterface::CliInterface(QObject *parent, const QVariantList &args)
     : ReadWriteArchiveInterface(parent, args)
@@ -1389,9 +1390,16 @@ bool CliInterface::copyArchiveVolumesToDir(const QString &srcArchive, const QStr
     QString destPath = destDir + QDir::separator() + srcName;
     QString tempPath = destDir + QDir::separator() + srcName + QStringLiteral(".tmpcopy.") + QUuid::createUuid().toString(QUuid::WithoutBraces);
 
-    if (!QFile::copy(srcArchive, tempPath)) {
-        qWarning() << "copyArchiveVolumesToDir: FAILED to copy" << srcArchive << "->" << tempPath;
-        return false;
+    // 同文件系统时优先硬链接(零拷贝), 失败(跨盘/不支持硬链)回退整包复制。
+    // 安全性: 7z rn 重写归档采用"先 DeleteFileAlways 删目录项、再 MyMoveFile 搬新归档",
+    // 从不向既有 inode 内写字节, 因此硬链被 rn 替换后源归档 inode 引用 2→1 原样保留。
+    if (::link(srcArchive.toLocal8Bit().constData(), tempPath.toLocal8Bit().constData()) == 0) {
+        qInfo() << "copyArchiveVolumesToDir: hardlinked" << srcArchive << "->" << tempPath;
+    } else {
+        if (!QFile::copy(srcArchive, tempPath)) {
+            qWarning() << "copyArchiveVolumesToDir: FAILED to copy" << srcArchive << "->" << tempPath;
+            return false;
+        }
     }
     QFile::remove(destPath);
     if (!QFile::rename(tempPath, destPath)) {
@@ -1401,6 +1409,62 @@ bool CliInterface::copyArchiveVolumesToDir(const QString &srcArchive, const QStr
     }
     outFirstVolumePath = destPath;
     return true;
+}
+
+qint64 CliInterface::longNameArchiveSize() const
+{
+    QFileInfo srcInfo(m_strArchiveName);
+    const QString srcDir = srcInfo.absolutePath();
+    const QString srcName = srcInfo.fileName();
+
+    // 7z/zip 分卷: 合并后单文件大小 = 各卷大小之和
+    // 正则与 copyArchiveVolumesToDir 保持一致
+    static const QRegularExpression reSplitVol(QStringLiteral("^(.+\\.(?:7z|zip))\\.[0-9]{3}$"));
+    QRegularExpressionMatch m = reSplitVol.match(srcName);
+    if (m.hasMatch()) {
+        const QString base = m.captured(1);   // 例如 "archive.7z" / "archive.zip"
+        qint64 total = 0;
+        for (int i = 1;; ++i) {
+            const QString volPath = srcDir + QDir::separator() + QString("%1.%2").arg(base).arg(i, 3, 10, QChar('0'));
+            if (!QFile::exists(volPath)) {
+                break;
+            }
+            total += QFileInfo(volPath).size();
+        }
+        return total;
+    }
+
+    return srcInfo.size();
+}
+
+bool CliInterface::prepareLongNameTempDir()
+{
+    // 工作归档落点固定为压缩包所在目录(源目录), 不使用 /tmp:
+    // tmpfs 为独立内存盘且通常很小, 大包复制到其中易 ENOSPC;
+    // 源目录与压缩包同盘, 可硬链接零拷贝。
+    const QString srcDir = QFileInfo(m_strArchiveName).absolutePath();
+    const qint64 archiveSize = longNameArchiveSize();
+    const qint64 margin = 16LL * 1024 * 1024;   // 预留 16MB 安全余量(文件系统元数据/头部开销)
+
+    // 空间预检: rn 重写会在源目录新生成一个整包大小的工作归档, 需源目录有足够剩余空间。
+    // 不足直接提示用户, 避免中途 ENOSPC 留下半解压状态。
+    if (isInsufficientDiskSpace(srcDir, archiveSize + margin)) {
+        qWarning() << "prepareLongNameTempDir: 源目录磁盘空间不足, 需" << archiveSize << "srcDir=" << srcDir;
+        m_eErrorType = ET_InsufficientDiskSpace;
+        return false;
+    }
+
+    QTemporaryDir *tmp = new QTemporaryDir(srcDir + QDir::separator() + QStringLiteral(".deepin-compressor-XXXXXX"));
+    if (tmp->isValid()) {
+        m_longNameTempDir.reset(tmp);
+        qInfo() << "prepareLongNameTempDir: 源目录作为临时拷贝目录" << srcDir
+                << " 归档大小=" << archiveSize;
+        return true;
+    }
+    delete tmp;
+    qWarning() << "prepareLongNameTempDir: 无法在源目录创建临时目录" << srcDir;
+    m_eErrorType = ET_FileWriteError;
+    return false;
 }
 
 QList<FileEntry> CliInterface::collectLongDirEntries(const QList<FileEntry> &files) const
@@ -1459,7 +1523,13 @@ bool CliInterface::handleLongNameExtract(const QList<FileEntry> &files)
     }
     m_longNamePassword = password;
 
-    m_longNameTempDir.reset(new QTemporaryDir());
+    // 工作归档固定落在源目录(压缩包所在目录), 不用 /tmp; 空间不足时提前提示用户
+    if (!prepareLongNameTempDir()) {
+        // prepareLongNameTempDir 已设置具体错误类型:
+        //   空间不足 -> ET_InsufficientDiskSpace; 无法创建临时目录 -> ET_FileWriteError
+        m_longNameTempDir.reset();
+        return false;
+    }
     QString absoluteDestinationPath;
     if (!copyArchiveVolumesToDir(m_strArchiveName, m_longNameTempDir->path(), absoluteDestinationPath)) {
         qWarning() << "handleLongNameExtract: Failed to copy archive volumes to temp dir" << m_longNameTempDir->path();

--- a/3rdparty/interface/archiveinterface/cliinterface.h
+++ b/3rdparty/interface/archiveinterface/cliinterface.h
@@ -242,8 +242,26 @@ private:
      * @brief copyArchiveVolumesToDir 将压缩包(含分卷)完整复制到目标目录
      *
      * 7z/zip 分卷合并为单个文件 (7z rn 不支持分卷), rar/非分卷直接复制。
+     * 非分卷分支在源目录同文件系统(固定落点)时优先硬链接(零拷贝), 失败回退整包复制。
      */
     bool copyArchiveVolumesToDir(const QString &srcArchive, const QString &destDir, QString &outFirstVolumePath);
+
+    /**
+     * @brief 计算工作归档大小 x
+     *
+     * 非分卷取归档文件大小; 7z/zip 分卷取所有卷大小之和(合并后单文件大小)。
+     */
+    qint64 longNameArchiveSize() const;
+
+    /**
+     * @brief 在压缩包所在目录(源目录)创建工作归档临时目录
+     *
+     * 不使用 /tmp (tmpfs 易满且为独立内存盘, 大包易 ENOSPC)。
+     * 固定以源目录为临时拷贝目录: 与压缩包同盘可硬链接零拷贝。
+     * 空间不足(源目录可用空间 < 工作归档大小 x)时返回 false,
+     * 由调用方置 ET_InsufficientDiskSpace 提示用户, 避免中途 ENOSPC。
+     */
+    bool prepareLongNameTempDir();
 
 private slots:
     /**


### PR DESCRIPTION
…tract

长名 7z 解压的工作归档落点由固定 /tmp 改为按剩余空间自适应:
/tmp -> 压缩包所在目录 -> 解压目标目录, 均不足时提前报磁盘空间不足,
避免中途 ENOSPC 留下半解压状态。空间需求按挂载点计算, 同盘时叠加
rn 临时归档(瞬态 2x)与解压产物(稳态 x+Y)。

copyArchiveVolumesToDir 单文件分支在同文件系统时优先硬链接(零拷贝),
失败回退整包复制; 普通解压路径用真实解压大小替代固定 10M 空间阈值
预检(仅目标目录为空时)。

bug: https://pms.uniontech.com/bug-view-375401.html

## Summary by Sourcery

Prevent incomplete long-name extractions by placing working archives on suitable local storage and validating disk capacity in advance.

Bug Fixes:
- Prevent long-name archive extraction from failing mid-operation with ENOSPC by checking available source-directory space before creating the working archive.

Enhancements:
- Place long-name extraction working archives alongside the source archive and use hard links when possible, falling back to copying when necessary.
- Calculate required space from the actual archive size, including all split volumes, with additional safety margin.