### PR TITLE
fix: update Arabic (ar) translations

### DIFF
--- a/translations/deepin-compressor_ar.ts
+++ b/translations/deepin-compressor_ar.ts
@@ -1,1567 +1,1569 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
-<context>
-    <name>AppendDialog</name>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="477"/>
-        <source>Add files to the current archive</source>
-        <translation>إضافة ملفات إلى الأرشيف الحالي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="482"/>
-        <source>Use password</source>
-        <translation>استخدام كلمة مرور</translation>
-    </message>
-</context>
-<context>
-    <name>CalculateSizeThread</name>
-    <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="63"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="148"/>
-        <source>The original file of %1 does not exist, please check and try again</source>
-        <translation>الملف الأصلي لـ %1 لا موجود، يرجى التحقق وإعادة المحاولة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="65"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="150"/>
-        <source>%1 does not exist on the disk, please check and try again</source>
-        <translation>&apos;%1 لا موجود على القرص، يرجى التحقق وإعادة المحاولة&apos;</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="75"/>
-        <location filename="../src/source/common/calculatesizethread.cpp" line="160"/>
-        <source>You do not have permission to compress %1</source>
-        <translation>ليس لديك صلاحية لضغط %1</translation>
-    </message>
-</context>
-<context>
-    <name>CommentProgressDialog</name>
-    <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="232"/>
-        <source>Updating the comment...</source>
-        <translation>تحديث التعليق...</translation>
-    </message>
-</context>
-<context>
-    <name>CompressPage</name>
-    <message>
-        <location filename="../src/source/page/compresspage.cpp" line="77"/>
-        <source>Next</source>
-        <translation>التالي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresspage.cpp" line="120"/>
-        <source>Please add files</source>
-        <translation>الرجاء إضافة ملف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresspage.cpp" line="120"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>موافق</translation>
-    </message>
-</context>
-<context>
-    <name>CompressSettingPage</name>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="147"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="252"/>
-        <source>New Archive</source>
-        <translation>أرشيف جديد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
-        <source>Advanced Options</source>
-        <translation>خيارات متقدمة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
-        <source>Compression method</source>
-        <translation>طريقة الضغط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="237"/>
-        <source>Encrypt the archive</source>
-        <translation>تشفير الأرشيف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
-        <source>CPU threads</source>
-        <translation>خيوط المعالج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="241"/>
-        <source>Encrypt the file list too</source>
-        <translation>تشفير قائمة الملفات أيضاً</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
-        <source>Split to volumes</source>
-        <translation>تقسيم إلى أجزاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="245"/>
-        <source>Comment</source>
-        <translation>تعليق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="247"/>
-        <source>Compress</source>
-        <comment>button</comment>
-        <translation>ضغط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
-        <source>Store</source>
-        <translation>تخزين</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
-        <source>Fastest</source>
-        <translation>الأسرع</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
-        <source>Fast</source>
-        <translation>سريع</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
-        <source>Normal</source>
-        <translation>عادي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
-        <source>Good</source>
-        <translation>جيد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
-        <source>Best</source>
-        <translation>أفضل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
-        <source>Single thread</source>
-        <translation>خيط واحد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
-        <source>2 threads</source>
-        <translation>2 خيوط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
-        <source>4 threads</source>
-        <translation>4 خيوط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
-        <source>8 threads</source>
-        <translation>8 خيوط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="283"/>
-        <source>Support zip, 7z type only</source>
-        <translation>يدعم نوعي zip و 7z فقط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="286"/>
-        <source>Support 7z type only</source>
-        <translation>يدعم نوع 7z فقط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="298"/>
-        <source>Enter up to %1 characters</source>
-        <translation>أدخل حتى %1 حرف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="318"/>
-        <source>Name</source>
-        <translation>الاسم</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="319"/>
-        <source>Save to</source>
-        <translation>حفظ في</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="621"/>
-        <source>Invalid file name</source>
-        <translation>اسم ملف غير صالح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="628"/>
-        <source>Please enter the path</source>
-        <translation>الرجاء إدخال المسار</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="634"/>
-        <source>The path does not exist, please retry</source>
-        <translation>المسار غير موجود، الرجاء إعادة المحاولة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="640"/>
-        <source>You do not have permission to save files here, please change and retry</source>
-        <translation>ليس لديك صلاحية لحفظ الملفات هنا، يرجى التغيير وإعادة المحاولة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="649"/>
-        <source>Too many volumes, please change and retry</source>
-        <translation>عددolumes كبير جدًا، يرجى التغيير وإعادة المحاولة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="659"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="691"/>
-        <source>%1 does not exist on the disk, please check and try again</source>
-        <translation>&apos;%1 لا موجود على القرص، يرجى التحقق وإعادة المحاولة&apos;</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="666"/>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="699"/>
-        <source>You do not have permission to compress %1</source>
-        <translation>ليس لديك صلاحية لضغط %1</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="688"/>
-        <source>The original file of %1 does not exist, please check and try again</source>
-        <translation>الملف الأصلي لـ %1 لا موجود، يرجى التحقق وإعادة المحاولة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="727"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>موافق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="989"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="989"/>
-        <source>Replace</source>
-        <comment>button</comment>
-        <translation>استبدال</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="891"/>
-        <source>Total size: %1</source>
-        <translation>&apos;المجموع: %1&apos;</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="912"/>
-        <source>The name is the same as that of the compressed archive, please use another one</source>
-        <translation>&gt;-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS language="ar" version="2.1">
+    <context>
+        <name>AppendDialog</name>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="477"/>
+            <source>Add files to the current archive</source>
+            <translation>إضافة ملفات إلى الأرشيف الحالي</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="482"/>
+            <source>Use password</source>
+            <translation>استخدام كلمة مرور</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalculateSizeThread</name>
+        <message>
+            <location filename="../src/source/common/calculatesizethread.cpp" line="63"/>
+            <location filename="../src/source/common/calculatesizethread.cpp" line="148"/>
+            <source>The original file of %1 does not exist, please check and try again</source>
+            <translation>الملف الأصلي لـ %1 لا موجود، يرجى التحقق وإعادة المحاولة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/calculatesizethread.cpp" line="65"/>
+            <location filename="../src/source/common/calculatesizethread.cpp" line="150"/>
+            <source>%1 does not exist on the disk, please check and try again</source>
+            <translation>'%1 لا موجود على القرص، يرجى التحقق وإعادة المحاولة'</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/calculatesizethread.cpp" line="75"/>
+            <location filename="../src/source/common/calculatesizethread.cpp" line="160"/>
+            <source>You do not have permission to compress %1</source>
+            <translation>ليس لديك صلاحية لضغط %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommentProgressDialog</name>
+        <message>
+            <location filename="../src/source/dialog/progressdialog.cpp" line="232"/>
+            <source>Updating the comment...</source>
+            <translation>تحديث التعليق...</translation>
+        </message>
+    </context>
+    <context>
+        <name>CompressPage</name>
+        <message>
+            <location filename="../src/source/page/compresspage.cpp" line="77"/>
+            <source>Next</source>
+            <translation>التالي</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresspage.cpp" line="120"/>
+            <source>Please add files</source>
+            <translation>الرجاء إضافة ملف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresspage.cpp" line="120"/>
+            <source>OK</source>
+            <translation>موافق</translation>
+            <comment>button</comment>
+        </message>
+    </context>
+    <context>
+        <name>CompressSettingPage</name>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="147"/>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="252"/>
+            <source>New Archive</source>
+            <translation>أرشيف جديد</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="230"/>
+            <source>Advanced Options</source>
+            <translation>خيارات متقدمة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="234"/>
+            <source>Compression method</source>
+            <translation>طريقة الضغط</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="237"/>
+            <source>Encrypt the archive</source>
+            <translation>تشفير الأرشيف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="239"/>
+            <source>CPU threads</source>
+            <translation>خيوط المعالج</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="241"/>
+            <source>Encrypt the file list too</source>
+            <translation>تشفير قائمة الملفات أيضاً</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="243"/>
+            <source>Split to volumes</source>
+            <translation>تقسيم إلى أجزاء</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="245"/>
+            <source>Comment</source>
+            <translation>تعليق</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="247"/>
+            <source>Compress</source>
+            <translation>ضغط</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
+            <source>Store</source>
+            <translation>تخزين</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
+            <source>Fastest</source>
+            <translation>الأسرع</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
+            <source>Fast</source>
+            <translation>سريع</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
+            <source>Normal</source>
+            <translation>عادي</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
+            <source>Good</source>
+            <translation>جيد</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="266"/>
+            <source>Best</source>
+            <translation>أفضل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
+            <source>Single thread</source>
+            <translation>خيط واحد</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
+            <source>2 threads</source>
+            <translation>2 خيوط</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
+            <source>4 threads</source>
+            <translation>4 خيوط</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="273"/>
+            <source>8 threads</source>
+            <translation>8 خيوط</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="283"/>
+            <source>Support zip, 7z type only</source>
+            <translation>يدعم نوعي zip و 7z فقط</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="286"/>
+            <source>Support 7z type only</source>
+            <translation>يدعم نوع 7z فقط</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="298"/>
+            <source>Enter up to %1 characters</source>
+            <translation>أدخل حتى %1 حرف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="318"/>
+            <source>Name</source>
+            <translation>الاسم</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="319"/>
+            <source>Save to</source>
+            <translation>حفظ في</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="621"/>
+            <source>Invalid file name</source>
+            <translation>اسم ملف غير صالح</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="628"/>
+            <source>Please enter the path</source>
+            <translation>الرجاء إدخال المسار</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="634"/>
+            <source>The path does not exist, please retry</source>
+            <translation>المسار غير موجود، الرجاء إعادة المحاولة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="640"/>
+            <source>You do not have permission to save files here, please change and retry</source>
+            <translation>ليس لديك صلاحية لحفظ الملفات هنا، يرجى التغيير وإعادة المحاولة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="649"/>
+            <source>Too many volumes, please change and retry</source>
+            <translation>عددolumes كبير جدًا، يرجى التغيير وإعادة المحاولة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="659"/>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="691"/>
+            <source>%1 does not exist on the disk, please check and try again</source>
+            <translation>'%1 لا موجود على القرص، يرجى التحقق وإعادة المحاولة'</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="666"/>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="699"/>
+            <source>You do not have permission to compress %1</source>
+            <translation>ليس لديك صلاحية لضغط %1</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="688"/>
+            <source>The original file of %1 does not exist, please check and try again</source>
+            <translation>الملف الأصلي لـ %1 لا موجود، يرجى التحقق وإعادة المحاولة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="727"/>
+            <source>OK</source>
+            <translation>موافق</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="989"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="989"/>
+            <source>Replace</source>
+            <translation>استبدال</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="891"/>
+            <source>Total size: %1</source>
+            <translation>'المجموع: %1'</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="912"/>
+            <source>The name is the same as that of the compressed archive, please use another one</source>
+            <translation>&gt;-
 اسم الملف مطابق لاسم الأرشيف المضغوط، يرجى استخدام اسم آخر
 واحد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="922"/>
-        <source>The password for ZIP volumes cannot be in Chinese</source>
-        <translation>كلمة المرور لـ ZIP volumes لا يمكن أن تكون باللغة الصينية</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="989"/>
-        <source>Another file with the same name already exists, replace it?</source>
-        <translation>يوجد ملف آخر بنفس الاسم بالفعل، هل تريد استبداله؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/compresssettingpage.cpp" line="1036"/>
-        <source>Only Chinese and English characters and some symbols are supported</source>
-        <translation>يتم دعم فقط الأحرف الصينية والإنجليزية وبعض الرموز</translation>
-    </message>
-</context>
-<context>
-    <name>CompressView</name>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="312"/>
-        <source>Open</source>
-        <translation>فتح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="325"/>
-        <source>Rename</source>
-        <translation>إعادة تسمية</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="330"/>
-        <source>Delete</source>
-        <translation>حذف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="333"/>
-        <source>Open with</source>
-        <translation>فتح باستخدام</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="337"/>
-        <location filename="../src/source/tree/compressview.cpp" line="536"/>
-        <source>Select default program</source>
-        <translation>اختيار البرنامج الافتراضي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="383"/>
-        <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
-        <translation>سوف يتم حذف الملفات بشكل دائم. هل أنت متأكد من أنك تريد الاستمرار?</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="383"/>
-        <location filename="../src/source/tree/compressview.cpp" line="505"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="383"/>
-        <source>Confirm</source>
-        <comment>button</comment>
-        <translation>تأكيد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="506"/>
-        <source>Add</source>
-        <comment>button</comment>
-        <translation>إضافة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="504"/>
-        <source>Do you want to add the archive to the list or open it in new window?</source>
-        <translation>هل ترغب في إضافة الملف إلى القائمة أم فتحه في نافذة جديدة؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/compressview.cpp" line="507"/>
-        <source>Open in new window</source>
-        <translation>افتح في نافذة جديدة</translation>
-    </message>
-</context>
-<context>
-    <name>ConvertDialog</name>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="338"/>
-        <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
-        <translation>لا يدعم هذا النوع من الملفات التعديل. الرجاء تحويل تنسيق الملف للحفاظ على التعديلات.</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="346"/>
-        <source>Convert the format to:</source>
-        <translation>تحويل التنسيق إلى:</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="370"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="371"/>
-        <source>Convert</source>
-        <comment>button</comment>
-        <translation>تحويل</translation>
-    </message>
-</context>
-<context>
-    <name>DataModel</name>
-    <message>
-        <location filename="../src/source/tree/datamodel.cpp" line="63"/>
-        <source>item(s)</source>
-        <translation>ملف(ات)</translation>
-    </message>
-</context>
-<context>
-    <name>FailurePage</name>
-    <message>
-        <location filename="../src/source/page/failurepage.cpp" line="79"/>
-        <source>Extraction failed</source>
-        <comment>解压失败</comment>
-        <translation>فشل الاستخراج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/failurepage.cpp" line="92"/>
-        <source>Damaged file, unable to extract</source>
-        <translation>ملف تالف، تعذر استخراجه</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/failurepage.cpp" line="97"/>
-        <source>Retry</source>
-        <comment>button</comment>
-        <translation>إعادة المحاولة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/failurepage.cpp" line="100"/>
-        <source>Back</source>
-        <translation>رجوع</translation>
-    </message>
-</context>
-<context>
-    <name>HomePage</name>
-    <message>
-        <location filename="../src/source/page/homepage.cpp" line="43"/>
-        <source>Drag file or folder here</source>
-        <translation>قم بسحب ملفاص أو مجلداً هنا</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/homepage.cpp" line="45"/>
-        <source>Select File</source>
-        <translation>تحديد ملف</translation>
-    </message>
-</context>
-<context>
-    <name>LoadCorruptQuery</name>
-    <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="637"/>
-        <source>The archive is damaged</source>
-        <translation>الملف مُدَمَّر</translation>
-    </message>
-    <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="640"/>
-        <source>Open as read-only</source>
-        <translation>افتح كقراء فقط</translation>
-    </message>
-    <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="641"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-</context>
-<context>
-    <name>LoadingPage</name>
-    <message>
-        <location filename="../src/source/page/loadingpage.cpp" line="55"/>
-        <source>Loading, please wait...</source>
-        <translation>جار التحميل، من فضلك انتظر...</translation>
-    </message>
-</context>
-<context>
-    <name>Main</name>
-    <message>
-        <location filename="../src/main.cpp" line="145"/>
-        <location filename="../src/main.cpp" line="146"/>
-        <source>Archive Manager</source>
-        <translation>مدير اﻷرشيفات</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="147"/>
-        <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
-        <translation>مدير الأرشيفات هو تطبيق سريع وخفيف الوزن لإنشاء واستخراج اﻷرشيفات</translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="106"/>
-        <source>Archive Manager</source>
-        <translation>مدير اﻷرشيفات</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="696"/>
-        <source>%1 was changed on the disk, please import it again.</source>
-        <translation>%1 تم تغييره على القرص ، يرجى استيراده مرة أخرى</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="249"/>
-        <source>Open file</source>
-        <translation>فتح ملف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="250"/>
-        <source>Settings</source>
-        <translation>اﻹعدادات</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="363"/>
-        <location filename="../src/source/mainwindow.cpp" line="375"/>
-        <source>Create New Archive</source>
-        <translation>إنشاء أرشيف جديد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="403"/>
-        <source>Adding files to %1</source>
-        <translation>جار إضافة الملفات إلى %1</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="411"/>
-        <source>Compressing</source>
-        <translation>يتم الضغط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="419"/>
-        <source>Extracting</source>
-        <translation>يتم الاستخراج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="427"/>
-        <source>Deleting</source>
-        <translation>جار الحذف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="443"/>
-        <source>Converting</source>
-        <translation>جار التحويل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="582"/>
-        <location filename="../src/source/mainwindow.cpp" line="775"/>
-        <source>You do not have permission to load %1</source>
-        <translation>ليس لديك إذن لتحميل %1</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="649"/>
-        <location filename="../src/source/mainwindow.cpp" line="3375"/>
-        <source>Loading, please wait...</source>
-        <translation>جار التحميل، من فضلك انتظر...</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="660"/>
-        <location filename="../src/source/mainwindow.cpp" line="2473"/>
-        <location filename="../src/source/mainwindow.cpp" line="2507"/>
-        <location filename="../src/source/mainwindow.cpp" line="2536"/>
-        <source>Plugin error</source>
-        <translation>خطأ في المُسند</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="739"/>
-        <source>Are you sure you want to stop the ongoing task?</source>
-        <translation>هل أنت متأكد من أنك تريد التوقف عن المهمة الجارية؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="739"/>
-        <location filename="../src/source/mainwindow.cpp" line="1669"/>
-        <location filename="../src/source/mainwindow.cpp" line="2905"/>
-        <location filename="../src/source/mainwindow.cpp" line="3405"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="739"/>
-        <location filename="../src/source/mainwindow.cpp" line="1669"/>
-        <source>Confirm</source>
-        <comment>button</comment>
-        <translation>تأكيد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="769"/>
-        <source>No such file or directory</source>
-        <translation>لا يوجد ملف أو دليل بهذا الاسم</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1118"/>
-        <source>Unable to add system files or network files, please select files on local devices</source>
-        <translation>تعذر إضافة ملفات النظام أو ملفات الشبكة، الرجاء تحديد ملفات على الأجهزة المحلية</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1558"/>
-        <source>Adding successful</source>
-        <translation>تمت الإضافة بنجاح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1565"/>
-        <location filename="../src/source/mainwindow.cpp" line="1693"/>
-        <location filename="../src/source/mainwindow.cpp" line="1709"/>
-        <source>Updating, please wait...</source>
-        <translation>جار التحديث، من فضلك انتظر...</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1608"/>
-        <source>Extraction successful</source>
-        <comment>提取成功</comment>
-        <translation>تم الاستخراج بنجاح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1819"/>
-        <source>Extraction canceled</source>
-        <comment>取消提取</comment>
-        <translation>تم إلغاء الاستخراج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1961"/>
-        <source>Extraction failed: the file name is too long</source>
-        <translation>فشل في الاستخراج: اسم الملف طويل جدًا</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1973"/>
-        <location filename="../src/source/mainwindow.cpp" line="2052"/>
-        <location filename="../src/source/mainwindow.cpp" line="2511"/>
-        <location filename="../src/source/mainwindow.cpp" line="2540"/>
-        <source>The archive is damaged</source>
-        <translation>الملف مُدَمَّر</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2114"/>
-        <source>Open failed: the file name is too long</source>
-        <translation>فشل الفتح: اسم الملف طويل جداً</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2372"/>
-        <location filename="../src/source/mainwindow.cpp" line="2377"/>
-        <source>Failed to create temporary directory, please check and try again.</source>
-        <translation>فشل في إنشاء الدليل المؤقت، الرجاء التحقق وإعادة المحاولة.</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2388"/>
-        <location filename="../src/source/mainwindow.cpp" line="2398"/>
-        <source>Failed to prepare renamed item &quot;%1&quot; for compression, please check permissions and available space.</source>
-        <translation>فشل في تحضير العنصر المعاد تسميته &quot;%1&quot; للضغط، الرجاء التحقق من الصلاحيات والمساحة المتاحة.</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2450"/>
-        <source>Extraction successful</source>
-        <comment>解压成功</comment>
-        <translation>تم الاستخراج بنجاح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2452"/>
-        <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
-        <translation>اسم الملف طويل جداً، لذلك تم التقاط أول 60 حرفًا كاسم للملف.</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2481"/>
-        <location filename="../src/source/mainwindow.cpp" line="2564"/>
-        <source>Insufficient disk space</source>
-        <translation>مساحة القرص غير كافية</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2485"/>
-        <source>The compressed volumes already exist</source>
-        <translation>الوحدات المضغوطة موجودة بالفعل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2489"/>
-        <source>No compression support in current directory. Download the files to a local device.</source>
-        <translation>لا يوجد دعم للضغط في الدليل الحالي. قم بتنزيل الملفات إلى جهاز محلي.</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2523"/>
-        <source>Can&apos;t open compressed packages in current directory. Download the compressed package to a local device.</source>
-        <translation>تعذر فتح الحزم المضغوطة في الدليل الحالي. قم بتنزيل الحزمة المضغوطة إلى جهاز محلي.</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2533"/>
-        <source>Extraction failed</source>
-        <comment>解压失败</comment>
-        <translation>فشل الاستخراج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2493"/>
-        <location filename="../src/source/mainwindow.cpp" line="2552"/>
-        <location filename="../src/source/mainwindow.cpp" line="2580"/>
-        <source>The file name is too long. Keep the name within 60 characters please.</source>
-        <translation>اسم الملف طويل جدًا. من فضلك احتفظ بالاسم ضمن 60 حرفًا</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2577"/>
-        <source>Conversion failed</source>
-        <translation>فشل في التحويل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2897"/>
-        <source>The name is the same as that of the compressed archive, please use another one</source>
-        <translation>اسم الملف هو نفسه للارشيف المضغوط، من فضلك استخدم اسمًا آخر</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2905"/>
-        <source>Another file with the same name already exists, replace it?</source>
-        <translation>يوجد ملف آخر بنفس الاسم بالفعل، هل تريد استبداله؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3048"/>
-        <source>You cannot add the archive to itself</source>
-        <translation>لا يمكنك إضافة الأرشيف إلى نفسه</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3063"/>
-        <source>You cannot add files to archives in this file type</source>
-        <translation>لا يمكنك إضافة ملفات إلى أرشيفات بهذا نوع الملف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3699"/>
-        <source>Enter up to %1 characters</source>
-        <translation>أدخل حتى %1 حرف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1983"/>
-        <source>File name too long</source>
-        <translation>اسم الملف طويل جداً</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2477"/>
-        <source>Failed to create file</source>
-        <translation>فشل في إنشاء الملف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2446"/>
-        <source>Compression successful</source>
-        <translation>تم الضغط بنجاح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2470"/>
-        <source>Compression failed</source>
-        <translation>تعذر الضغط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2969"/>
-        <source>Find directory</source>
-        <translation>بحث عن دليل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2504"/>
-        <source>Open failed</source>
-        <translation>فشل في الفتح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2735"/>
-        <location filename="../src/source/mainwindow.cpp" line="2755"/>
-        <source>The archive was changed on the disk, please import it again.</source>
-        <translation>تم تغيير الأرشيف على القرص ، يرجى استيراده مرة أخرى.</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1900"/>
-        <location filename="../src/source/mainwindow.cpp" line="1978"/>
-        <location filename="../src/source/mainwindow.cpp" line="2057"/>
-        <location filename="../src/source/mainwindow.cpp" line="2112"/>
-        <location filename="../src/source/mainwindow.cpp" line="2515"/>
-        <source>Wrong password</source>
-        <translation>كلمة سر خاطىة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="202"/>
-        <location filename="../src/source/mainwindow.cpp" line="582"/>
-        <location filename="../src/source/mainwindow.cpp" line="660"/>
-        <location filename="../src/source/mainwindow.cpp" line="699"/>
-        <location filename="../src/source/mainwindow.cpp" line="769"/>
-        <location filename="../src/source/mainwindow.cpp" line="775"/>
-        <location filename="../src/source/mainwindow.cpp" line="784"/>
-        <location filename="../src/source/mainwindow.cpp" line="830"/>
-        <location filename="../src/source/mainwindow.cpp" line="1118"/>
-        <location filename="../src/source/mainwindow.cpp" line="1592"/>
-        <location filename="../src/source/mainwindow.cpp" line="2735"/>
-        <location filename="../src/source/mainwindow.cpp" line="2755"/>
-        <location filename="../src/source/mainwindow.cpp" line="3063"/>
-        <location filename="../src/source/mainwindow.cpp" line="3234"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>موافق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="784"/>
-        <location filename="../src/source/mainwindow.cpp" line="823"/>
-        <source>The file format is not supported by Archive Manager</source>
-        <translation>تنسيق الملف غير مدعوم من قبل مدير الأرشيف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2456"/>
-        <source>Conversion successful</source>
-        <translation>التحويل ناجح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2767"/>
-        <source>Close</source>
-        <translation>إغلاق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2771"/>
-        <source>Help</source>
-        <translation>مساعدة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2779"/>
-        <source>Delete</source>
-        <translation>حذف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2787"/>
-        <source>Display shortcuts</source>
-        <translation>عرض الأختصارات</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2799"/>
-        <source>Shortcuts</source>
-        <translation>الأختصارات</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3571"/>
-        <source>File info</source>
-        <translation>معلومات الملف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="451"/>
-        <source>Updating comments</source>
-        <translation>تحديث التعليقات</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="435"/>
-        <source>Renaming</source>
-        <translation>إعادة التسمية</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1592"/>
-        <location filename="../src/source/mainwindow.cpp" line="2560"/>
-        <source>No data in it</source>
-        <translation>لا يوجد بيانات داخلها</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1798"/>
-        <source>Adding canceled</source>
-        <translation>تم إلغاء الإضافة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1904"/>
-        <source>Adding failed</source>
-        <translation>فشل في الإضافة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1988"/>
-        <location filename="../src/source/mainwindow.cpp" line="2556"/>
-        <source>Failed to create &quot;%1&quot;</source>
-        <translation>فشل في إنشاء &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2519"/>
-        <location filename="../src/source/mainwindow.cpp" line="2544"/>
-        <source>Some volumes are missing</source>
-        <translation>بعض الوحدات مفقودة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2548"/>
-        <source>Wrong password, please retry</source>
-        <translation>كلمة المرور خاطئة، من فضلك حاول مرة أخرى</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2568"/>
-        <source>No extraction support in current directory. Download the compressed package to a local device.</source>
-        <translation>لا يوجد دعم للاستخراج في الدليل الحالي. قم بتنزيل الحزمة المضغوطة إلى جهاز محلي.</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2775"/>
-        <source>Select file</source>
-        <translation>اختر ملفًا</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="2905"/>
-        <source>Replace</source>
-        <comment>button</comment>
-        <translation>استبدال</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3405"/>
-        <source>Update</source>
-        <comment>button</comment>
-        <translation>تحديث</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3595"/>
-        <source>Basic info</source>
-        <translation>معلومات أساسية</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3611"/>
-        <source>Size</source>
-        <translation>الحجم</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3612"/>
-        <source>Type</source>
-        <translation>النوع</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3613"/>
-        <source>Location</source>
-        <translation>الموقع</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3614"/>
-        <source>Time created</source>
-        <translation>وقت الإنشاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3615"/>
-        <source>Time accessed</source>
-        <translation>وقت الوصول</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3616"/>
-        <source>Time modified</source>
-        <translation>وقت التعديل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3626"/>
-        <source>Archive</source>
-        <translation>أرشيف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3661"/>
-        <source>Comment</source>
-        <translation>تعليق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="819"/>
-        <source>Please check the file association type in the settings of Archive Manager</source>
-        <translation>يرجى التحقق من نوع ارتباط الملف في إعدادات مدير الملفات</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="202"/>
-        <source>You do not have permission to save files here, please change and retry</source>
-        <translation>ليس لديك إذن لحفظ الملفات هنا، الرجاء تغيير المسار وإعادة المحاولة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="1669"/>
-        <source>Do you want to delete the archive?</source>
-        <translation>هل ترغب في حذف الملف؟</translation>
-    </message>
-</context>
-<context>
-    <name>MimeTypeDisplayManager</name>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
-        <source>Directory</source>
-        <translation>دليل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
-        <source>Application</source>
-        <translation>تطبيق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
-        <source>Video</source>
-        <translation>فيديو</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
-        <source>Audio</source>
-        <translation>صوت</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
-        <source>Image</source>
-        <translation>صورة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
-        <source>Archive</source>
-        <translation>أرشيف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
-        <source>Document</source>
-        <translation>مستند</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="39"/>
-        <source>Executable</source>
-        <translation>ملف تنفيذي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="40"/>
-        <source>Backup file</source>
-        <translation>ملف نسخة احتياطية</translation>
-    </message>
-    <message>
-        <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="41"/>
-        <source>Unknown</source>
-        <translation>غير معروف</translation>
-    </message>
-</context>
-<context>
-    <name>OpenWithDialog</name>
-    <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="302"/>
-        <source>Open with</source>
-        <translation>التشغيل بواسطة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="322"/>
-        <source>Add other programs</source>
-        <translation>إضافة برامج أخرى</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="323"/>
-        <source>Set as default</source>
-        <translation>تحديد كالافتراضي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="325"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="326"/>
-        <source>Confirm</source>
-        <comment>button</comment>
-        <translation>تأكيد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="331"/>
-        <source>Recommended Applications</source>
-        <translation>التطبيقات المقترحة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="333"/>
-        <source>Other Applications</source>
-        <translation>تطبيقات أخرى</translation>
-    </message>
-</context>
-<context>
-    <name>PasswordNeededQuery</name>
-    <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="506"/>
-        <source>Encrypted file, please enter the password</source>
-        <translation>ملف مشفر، الرجاء إدخال كلمة المرور</translation>
-    </message>
-</context>
-<context>
-    <name>PreviousLabel</name>
-    <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="39"/>
-        <source>Current path:</source>
-        <translation>مسار الحالي:</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/treeheaderview.cpp" line="48"/>
-        <source>Back to: %1</source>
-        <translation>العودة إلى: %1</translation>
-    </message>
-</context>
-<context>
-    <name>ProgressDialog</name>
-    <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="42"/>
-        <source>%1 task(s) in progress</source>
-        <translation>%1 من المهام قيد المعالجة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="49"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="93"/>
-        <source>Task</source>
-        <translation>مهمة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="55"/>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="106"/>
-        <source>Extracting</source>
-        <translation>يتم الاستخراج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="184"/>
-        <source>Are you sure you want to stop the extraction?</source>
-        <translation>هل أنت متأكد من أنك تريد إيقاف الاستخراج؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="186"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/progressdialog.cpp" line="186"/>
-        <source>Confirm</source>
-        <comment>button</comment>
-        <translation>تأكيد</translation>
-    </message>
-</context>
-<context>
-    <name>ProgressPage</name>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="46"/>
-        <location filename="../src/source/page/progresspage.cpp" line="381"/>
-        <location filename="../src/source/page/progresspage.cpp" line="384"/>
-        <location filename="../src/source/page/progresspage.cpp" line="387"/>
-        <source>Speed</source>
-        <comment>compress</comment>
-        <translation>السرعة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="46"/>
-        <location filename="../src/source/page/progresspage.cpp" line="48"/>
-        <location filename="../src/source/page/progresspage.cpp" line="50"/>
-        <location filename="../src/source/page/progresspage.cpp" line="52"/>
-        <location filename="../src/source/page/progresspage.cpp" line="56"/>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="178"/>
-        <source>Calculating...</source>
-        <translation>جاري الحساب...</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="48"/>
-        <location filename="../src/source/page/progresspage.cpp" line="392"/>
-        <location filename="../src/source/page/progresspage.cpp" line="394"/>
-        <source>Speed</source>
-        <comment>delete</comment>
-        <translation>السرعة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="50"/>
-        <location filename="../src/source/page/progresspage.cpp" line="399"/>
-        <location filename="../src/source/page/progresspage.cpp" line="401"/>
-        <source>Speed</source>
-        <comment>rename</comment>
-        <translation>السرعة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="52"/>
-        <location filename="../src/source/page/progresspage.cpp" line="415"/>
-        <location filename="../src/source/page/progresspage.cpp" line="417"/>
-        <location filename="../src/source/page/progresspage.cpp" line="419"/>
-        <source>Speed</source>
-        <comment>convert</comment>
-        <translation>السرعة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="56"/>
-        <location filename="../src/source/page/progresspage.cpp" line="406"/>
-        <location filename="../src/source/page/progresspage.cpp" line="408"/>
-        <location filename="../src/source/page/progresspage.cpp" line="410"/>
-        <source>Speed</source>
-        <comment>uncompress</comment>
-        <translation>الوقت المتبقي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="59"/>
-        <location filename="../src/source/page/progresspage.cpp" line="376"/>
-        <source>Time left</source>
-        <translation>الحذف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="148"/>
-        <source>Compressing</source>
-        <translation>جاري الضغط</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="150"/>
-        <source>Deleting</source>
-        <translation>الإسماع</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="152"/>
-        <source>Renaming</source>
-        <translation>التحويل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="154"/>
-        <source>Converting</source>
-        <translation>تحديث التعليق...</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="156"/>
-        <location filename="../src/source/page/progresspage.cpp" line="176"/>
-        <source>Updating the comment...</source>
-        <translation>إبقاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="158"/>
-        <source>Extracting</source>
-        <translation>جاري الاستخراج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="170"/>
-        <location filename="../src/source/page/progresspage.cpp" line="224"/>
-        <location filename="../src/source/page/progresspage.cpp" line="439"/>
-        <source>Pause</source>
-        <comment>button</comment>
-        <translation>استمر</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="223"/>
-        <location filename="../src/source/page/progresspage.cpp" line="475"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="210"/>
-        <location filename="../src/source/page/progresspage.cpp" line="434"/>
-        <source>Continue</source>
-        <comment>button</comment>
-        <translation>هل أنت متأكد من التوقف عن فك الضغط؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="475"/>
-        <source>Confirm</source>
-        <comment>button</comment>
-        <translation>تأكيد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="461"/>
-        <source>Are you sure you want to stop the decompression?</source>
-        <translation>هل أنت متأكد من التوقف عن الحذف؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="464"/>
-        <source>Are you sure you want to stop the deletion?</source>
-        <translation>هل أنت متأكد من التوقف عن التحويل؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="458"/>
-        <location filename="../src/source/page/progresspage.cpp" line="467"/>
-        <source>Are you sure you want to stop the compression?</source>
-        <translation>هل أنت متأكد من أنك تريد إيقاف الضغط؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/progresspage.cpp" line="470"/>
-        <source>Are you sure you want to stop the conversion?</source>
-        <translation>عرض الملفات المُستخرجة عند الانتهاء</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="224"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="236"/>
-        <source>Skip</source>
-        <comment>button</comment>
-        <translation>تجاوز</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="219"/>
-        <source>Merge</source>
-        <comment>button</comment>
-        <translation>دمج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="222"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="213"/>
-        <source>Another file with the same name already exists, replace it?</source>
-        <translation>يوجد ملف آخر بنفس الاسم بالفعل، هل تريد استبداله؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="225"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="237"/>
-        <source>Replace</source>
-        <comment>button</comment>
-        <translation>استبدال</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="522"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="388"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="517"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="523"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="389"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="518"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>موافق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="216"/>
-        <source>Another folder with the same name already exists, replace it?</source>
-        <translation>مجلد آخر بنفس الاسم موجود بالفعل، هل تريد استبداله؟</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="228"/>
-        <location filename="../3rdparty/interface/queries.cpp" line="218"/>
-        <source>Apply to all</source>
-        <translation>تطبيق على جميع</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/datamodel.h" line="56"/>
-        <source>Name</source>
-        <translation>الاسم</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/datamodel.h" line="56"/>
-        <source>Time modified</source>
-        <translation>وقت التعديل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/datamodel.h" line="56"/>
-        <source>Type</source>
-        <translation>النوع</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/datamodel.h" line="56"/>
-        <source>Size</source>
-        <translation>الحجم</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3402"/>
-        <source>%1 changed. Do you want to save changes to the archive?</source>
-        <translation>&apos;%1 تغيّر. هل تريد حفظ التغييرات في الملف الأرشيفي؟&apos;</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
-        <source>General</source>
-        <translation>عام</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
-        <source>Extraction</source>
-        <translation>الاستخراج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
-        <source>Auto create a folder for multiple extracted files</source>
-        <translation>إضافة مجلد تلقائياً للمهام المتعدة للملفات المستخرجة </translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
-        <source>Show extracted files when completed</source>
-        <translation>إدارة الملفات</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
-        <source>File Management</source>
-        <translation>إدارة الملفات</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
-        <source>Delete files after compression</source>
-        <translation> удалить файлы после сжатия</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="18"/>
-        <source>Files Associated</source>
-        <translation>ملفات مرتبطة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settings_translation.cpp" line="19"/>
-        <source>File Type</source>
-        <translation>نوع الملف</translation>
-    </message>
-    <message>
-        <location filename="../3rdparty/interface/queries.cpp" line="376"/>
-        <source>Another file with the same name already exists, extract to %1?</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>RenameDialog</name>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
-        <source>Rename</source>
-        <translation>إعادة التسمية</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="682"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="683"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>موافق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/popupdialog.cpp" line="693"/>
-        <source>The name already exists</source>
-        <translation>الاسم موجود بالفعل</translation>
-    </message>
-</context>
-<context>
-    <name>SettingDialog</name>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="131"/>
-        <source>Select All</source>
-        <comment>button</comment>
-        <translation>تحديد الكل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="132"/>
-        <source>Clear All</source>
-        <translation>مسح الكل</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="133"/>
-        <source>Recommended</source>
-        <translation>موصى به</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="168"/>
-        <source>Extract archives to</source>
-        <translation>استخراج إلى</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="174"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="203"/>
-        <source>Current directory</source>
-        <translation>الدليل الحالي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="174"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="208"/>
-        <source>Desktop</source>
-        <translation>سطح المكتب</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="174"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="213"/>
-        <source>Other directory</source>
-        <translation>دليل آخر</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="281"/>
-        <source>Delete archives after extraction</source>
-        <translation> удалить الملفات الأرشيفية بعد استخراجها</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="287"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="308"/>
-        <source>Never</source>
-        <translation>从不</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="287"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="311"/>
-        <source>Ask for confirmation</source>
-        <translation>طلب التأكيد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="287"/>
-        <location filename="../src/source/dialog/settingdialog.cpp" line="314"/>
-        <source>Always</source>
-        <translation>بشكل دائم</translation>
-    </message>
-</context>
-<context>
-    <name>SuccessPage</name>
-    <message>
-        <location filename="../src/source/page/successpage.cpp" line="70"/>
-        <source>Compression successful</source>
-        <translation>تم الضغط بنجاح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/successpage.cpp" line="80"/>
-        <source>View</source>
-        <translation>عرض</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/successpage.cpp" line="83"/>
-        <source>Back</source>
-        <translation>رجوع</translation>
-    </message>
-</context>
-<context>
-    <name>TitleWidget</name>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3881"/>
-        <location filename="../src/source/mainwindow.cpp" line="3936"/>
-        <source>Open file</source>
-        <translation>فتح ملف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3884"/>
-        <source>Back</source>
-        <translation>رجوع</translation>
-    </message>
-    <message>
-        <location filename="../src/source/mainwindow.cpp" line="3940"/>
-        <source>File info</source>
-        <translation>معلومات الملف</translation>
-    </message>
-</context>
-<context>
-    <name>UnCompressPage</name>
-    <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="68"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="82"/>
-        <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
-        <source>Extract to:</source>
-        <translation>استخراج إلى :</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
-        <source>Extract</source>
-        <comment>button</comment>
-        <translation>استخراج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
-        <source>The default extraction path does not exist, please retry</source>
-        <translation>مسار الاستخراج الافتراضي غير موجود، الرجاء إعادة المحاولة</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="205"/>
-        <source>You do not have permission to save files here, please change and retry</source>
-        <translation>ليس لديك إذن لحفظ الملفات هنا، يرجى تعديل المسار وحاول مرة أخرى</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="209"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>موافق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/page/uncompresspage.cpp" line="225"/>
-        <source>Find directory</source>
-        <translation>بحث عن دليل</translation>
-    </message>
-</context>
-<context>
-    <name>UnCompressView</name>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="426"/>
-        <source>You cannot add the archive to itself</source>
-        <translation>لا يمكنك إضافة الملف الأرشيفي إلى نفسه</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="426"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>موافق</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="666"/>
-        <source>Extract</source>
-        <comment>提取</comment>
-        <translation>استخراج</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="668"/>
-        <source>Extract to current directory</source>
-        <translation>استخراج إلى الدليل الحالي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="670"/>
-        <source>Open</source>
-        <translation>فتح</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="672"/>
-        <source>Rename</source>
-        <translation>إعادة التسمية</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="680"/>
-        <source>Delete</source>
-        <translation>حذف</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="689"/>
-        <source>Open with</source>
-        <translation>فتح باستخدام</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="693"/>
-        <location filename="../src/source/tree/uncompressview.cpp" line="858"/>
-        <source>Select default program</source>
-        <translation>اختر البرنامج الافتراضي</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="753"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>إلغاء</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="753"/>
-        <source>Confirm</source>
-        <comment>button</comment>
-        <translation>تأكيد</translation>
-    </message>
-    <message>
-        <location filename="../src/source/tree/uncompressview.cpp" line="753"/>
-        <source>Do you want to delete the selected file(s)?</source>
-        <translation>هل تريد حذف العناصرين(ات) المحدد(ة)؟</translation>
-    </message>
-</context>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="922"/>
+            <source>The password for ZIP volumes cannot be in Chinese</source>
+            <translation>كلمة المرور لـ ZIP volumes لا يمكن أن تكون باللغة الصينية</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="989"/>
+            <source>Another file with the same name already exists, replace it?</source>
+            <translation>يوجد ملف آخر بنفس الاسم بالفعل، هل تريد استبداله؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/compresssettingpage.cpp" line="1036"/>
+            <source>Only Chinese and English characters and some symbols are supported</source>
+            <translation>يتم دعم فقط الأحرف الصينية والإنجليزية وبعض الرموز</translation>
+        </message>
+    </context>
+    <context>
+        <name>CompressView</name>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="312"/>
+            <source>Open</source>
+            <translation>فتح</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="325"/>
+            <source>Rename</source>
+            <translation>إعادة تسمية</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="330"/>
+            <source>Delete</source>
+            <translation>حذف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="333"/>
+            <source>Open with</source>
+            <translation>فتح باستخدام</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="337"/>
+            <location filename="../src/source/tree/compressview.cpp" line="536"/>
+            <source>Select default program</source>
+            <translation>اختيار البرنامج الافتراضي</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="383"/>
+            <source>It will permanently delete the file(s). Are you sure you want to continue?</source>
+            <translation>سوف يتم حذف الملفات بشكل دائم. هل أنت متأكد من أنك تريد الاستمرار?</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="383"/>
+            <location filename="../src/source/tree/compressview.cpp" line="505"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="383"/>
+            <source>Confirm</source>
+            <translation>تأكيد</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="506"/>
+            <source>Add</source>
+            <translation>إضافة</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="504"/>
+            <source>Do you want to add the archive to the list or open it in new window?</source>
+            <translation>هل ترغب في إضافة الملف إلى القائمة أم فتحه في نافذة جديدة؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/compressview.cpp" line="507"/>
+            <source>Open in new window</source>
+            <translation>افتح في نافذة جديدة</translation>
+        </message>
+    </context>
+    <context>
+        <name>ConvertDialog</name>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="338"/>
+            <source>Changes to archives in this file type are not supported. Please convert the archive format to save the changes.</source>
+            <translation>لا يدعم هذا النوع من الملفات التعديل. الرجاء تحويل تنسيق الملف للحفاظ على التعديلات.</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="346"/>
+            <source>Convert the format to:</source>
+            <translation>تحويل التنسيق إلى:</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="370"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="371"/>
+            <source>Convert</source>
+            <translation>تحويل</translation>
+            <comment>button</comment>
+        </message>
+    </context>
+    <context>
+        <name>DataModel</name>
+        <message>
+            <location filename="../src/source/tree/datamodel.cpp" line="63"/>
+            <source>item(s)</source>
+            <translation>ملف(ات)</translation>
+        </message>
+    </context>
+    <context>
+        <name>FailurePage</name>
+        <message>
+            <location filename="../src/source/page/failurepage.cpp" line="79"/>
+            <source>Extraction failed</source>
+            <translation>فشل الاستخراج</translation>
+            <comment>解压失败</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/failurepage.cpp" line="92"/>
+            <source>Damaged file, unable to extract</source>
+            <translation>ملف تالف، تعذر استخراجه</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/failurepage.cpp" line="97"/>
+            <source>Retry</source>
+            <translation>إعادة المحاولة</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/failurepage.cpp" line="100"/>
+            <source>Back</source>
+            <translation>رجوع</translation>
+        </message>
+    </context>
+    <context>
+        <name>HomePage</name>
+        <message>
+            <location filename="../src/source/page/homepage.cpp" line="43"/>
+            <source>Drag file or folder here</source>
+            <translation>قم بسحب ملفاص أو مجلداً هنا</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/homepage.cpp" line="45"/>
+            <source>Select File</source>
+            <translation>تحديد ملف</translation>
+        </message>
+    </context>
+    <context>
+        <name>LoadCorruptQuery</name>
+        <message>
+            <location filename="../3rdparty/interface/queries.cpp" line="637"/>
+            <source>The archive is damaged</source>
+            <translation>الملف مُدَمَّر</translation>
+        </message>
+        <message>
+            <location filename="../3rdparty/interface/queries.cpp" line="640"/>
+            <source>Open as read-only</source>
+            <translation>افتح كقراء فقط</translation>
+        </message>
+        <message>
+            <location filename="../3rdparty/interface/queries.cpp" line="641"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+    </context>
+    <context>
+        <name>LoadingPage</name>
+        <message>
+            <location filename="../src/source/page/loadingpage.cpp" line="55"/>
+            <source>Loading, please wait...</source>
+            <translation>جار التحميل، من فضلك انتظر...</translation>
+        </message>
+    </context>
+    <context>
+        <name>Main</name>
+        <message>
+            <location filename="../src/main.cpp" line="145"/>
+            <location filename="../src/main.cpp" line="146"/>
+            <source>Archive Manager</source>
+            <translation>مدير اﻷرشيفات</translation>
+        </message>
+        <message>
+            <location filename="../src/main.cpp" line="147"/>
+            <source>Archive Manager is a fast and lightweight application for creating and extracting archives.</source>
+            <translation>مدير الأرشيفات هو تطبيق سريع وخفيف الوزن لإنشاء واستخراج اﻷرشيفات</translation>
+        </message>
+    </context>
+    <context>
+        <name>MainWindow</name>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="106"/>
+            <source>Archive Manager</source>
+            <translation>مدير اﻷرشيفات</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="696"/>
+            <source>%1 was changed on the disk, please import it again.</source>
+            <translation>%1 تم تغييره على القرص ، يرجى استيراده مرة أخرى</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="249"/>
+            <source>Open file</source>
+            <translation>فتح ملف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="250"/>
+            <source>Settings</source>
+            <translation>اﻹعدادات</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="363"/>
+            <location filename="../src/source/mainwindow.cpp" line="375"/>
+            <source>Create New Archive</source>
+            <translation>إنشاء أرشيف جديد</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="403"/>
+            <source>Adding files to %1</source>
+            <translation>جار إضافة الملفات إلى %1</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="411"/>
+            <source>Compressing</source>
+            <translation>يتم الضغط</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="419"/>
+            <source>Extracting</source>
+            <translation>يتم الاستخراج</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="427"/>
+            <source>Deleting</source>
+            <translation>جار الحذف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="443"/>
+            <source>Converting</source>
+            <translation>جار التحويل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="582"/>
+            <location filename="../src/source/mainwindow.cpp" line="775"/>
+            <source>You do not have permission to load %1</source>
+            <translation>ليس لديك إذن لتحميل %1</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="649"/>
+            <location filename="../src/source/mainwindow.cpp" line="3375"/>
+            <source>Loading, please wait...</source>
+            <translation>جار التحميل، من فضلك انتظر...</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="660"/>
+            <location filename="../src/source/mainwindow.cpp" line="2473"/>
+            <location filename="../src/source/mainwindow.cpp" line="2507"/>
+            <location filename="../src/source/mainwindow.cpp" line="2536"/>
+            <source>Plugin error</source>
+            <translation>خطأ في المُسند</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="739"/>
+            <source>Are you sure you want to stop the ongoing task?</source>
+            <translation>هل أنت متأكد من أنك تريد التوقف عن المهمة الجارية؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="739"/>
+            <location filename="../src/source/mainwindow.cpp" line="1669"/>
+            <location filename="../src/source/mainwindow.cpp" line="2905"/>
+            <location filename="../src/source/mainwindow.cpp" line="3405"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="739"/>
+            <location filename="../src/source/mainwindow.cpp" line="1669"/>
+            <source>Confirm</source>
+            <translation>تأكيد</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="769"/>
+            <source>No such file or directory</source>
+            <translation>لا يوجد ملف أو دليل بهذا الاسم</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1118"/>
+            <source>Unable to add system files or network files, please select files on local devices</source>
+            <translation>تعذر إضافة ملفات النظام أو ملفات الشبكة، الرجاء تحديد ملفات على الأجهزة المحلية</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1558"/>
+            <source>Adding successful</source>
+            <translation>تمت الإضافة بنجاح</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1565"/>
+            <location filename="../src/source/mainwindow.cpp" line="1693"/>
+            <location filename="../src/source/mainwindow.cpp" line="1709"/>
+            <source>Updating, please wait...</source>
+            <translation>جار التحديث، من فضلك انتظر...</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1608"/>
+            <source>Extraction successful</source>
+            <translation>تم الاستخراج بنجاح</translation>
+            <comment>提取成功</comment>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1819"/>
+            <source>Extraction canceled</source>
+            <translation>تم إلغاء الاستخراج</translation>
+            <comment>取消提取</comment>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1961"/>
+            <source>Extraction failed: the file name is too long</source>
+            <translation>فشل في الاستخراج: اسم الملف طويل جدًا</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1973"/>
+            <location filename="../src/source/mainwindow.cpp" line="2052"/>
+            <location filename="../src/source/mainwindow.cpp" line="2511"/>
+            <location filename="../src/source/mainwindow.cpp" line="2540"/>
+            <source>The archive is damaged</source>
+            <translation>الملف مُدَمَّر</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2114"/>
+            <source>Open failed: the file name is too long</source>
+            <translation>فشل الفتح: اسم الملف طويل جداً</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2372"/>
+            <location filename="../src/source/mainwindow.cpp" line="2377"/>
+            <source>Failed to create temporary directory, please check and try again.</source>
+            <translation>فشل في إنشاء الدليل المؤقت، الرجاء التحقق وإعادة المحاولة.</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2388"/>
+            <location filename="../src/source/mainwindow.cpp" line="2398"/>
+            <source>Failed to prepare renamed item "%1" for compression, please check permissions and available space.</source>
+            <translation>فشل في تحضير العنصر المعاد تسميته "%1" للضغط، الرجاء التحقق من الصلاحيات والمساحة المتاحة.</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2450"/>
+            <source>Extraction successful</source>
+            <translation>تم الاستخراج بنجاح</translation>
+            <comment>解压成功</comment>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2452"/>
+            <source>The file name is too long, so the first 60 characters have been intercepted as the file name.</source>
+            <translation>اسم الملف طويل جداً، لذلك تم التقاط أول 60 حرفًا كاسم للملف.</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2481"/>
+            <location filename="../src/source/mainwindow.cpp" line="2564"/>
+            <source>Insufficient disk space</source>
+            <translation>مساحة القرص غير كافية</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2485"/>
+            <source>The compressed volumes already exist</source>
+            <translation>الوحدات المضغوطة موجودة بالفعل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2489"/>
+            <source>No compression support in current directory. Download the files to a local device.</source>
+            <translation>لا يوجد دعم للضغط في الدليل الحالي. قم بتنزيل الملفات إلى جهاز محلي.</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2523"/>
+            <source>Can't open compressed packages in current directory. Download the compressed package to a local device.</source>
+            <translation>تعذر فتح الحزم المضغوطة في الدليل الحالي. قم بتنزيل الحزمة المضغوطة إلى جهاز محلي.</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2533"/>
+            <source>Extraction failed</source>
+            <translation>فشل الاستخراج</translation>
+            <comment>解压失败</comment>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2493"/>
+            <location filename="../src/source/mainwindow.cpp" line="2552"/>
+            <location filename="../src/source/mainwindow.cpp" line="2580"/>
+            <source>The file name is too long. Keep the name within 60 characters please.</source>
+            <translation>اسم الملف طويل جدًا. من فضلك احتفظ بالاسم ضمن 60 حرفًا</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2577"/>
+            <source>Conversion failed</source>
+            <translation>فشل في التحويل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2897"/>
+            <source>The name is the same as that of the compressed archive, please use another one</source>
+            <translation>اسم الملف هو نفسه للارشيف المضغوط، من فضلك استخدم اسمًا آخر</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2905"/>
+            <source>Another file with the same name already exists, replace it?</source>
+            <translation>يوجد ملف آخر بنفس الاسم بالفعل، هل تريد استبداله؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3048"/>
+            <source>You cannot add the archive to itself</source>
+            <translation>لا يمكنك إضافة الأرشيف إلى نفسه</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3063"/>
+            <source>You cannot add files to archives in this file type</source>
+            <translation>لا يمكنك إضافة ملفات إلى أرشيفات بهذا نوع الملف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3699"/>
+            <source>Enter up to %1 characters</source>
+            <translation>أدخل حتى %1 حرف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1983"/>
+            <source>File name too long</source>
+            <translation>اسم الملف طويل جداً</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2477"/>
+            <source>Failed to create file</source>
+            <translation>فشل في إنشاء الملف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2446"/>
+            <source>Compression successful</source>
+            <translation>تم الضغط بنجاح</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2470"/>
+            <source>Compression failed</source>
+            <translation>تعذر الضغط</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2969"/>
+            <source>Find directory</source>
+            <translation>بحث عن دليل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2504"/>
+            <source>Open failed</source>
+            <translation>فشل في الفتح</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2735"/>
+            <location filename="../src/source/mainwindow.cpp" line="2755"/>
+            <source>The archive was changed on the disk, please import it again.</source>
+            <translation>تم تغيير الأرشيف على القرص ، يرجى استيراده مرة أخرى.</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1900"/>
+            <location filename="../src/source/mainwindow.cpp" line="1978"/>
+            <location filename="../src/source/mainwindow.cpp" line="2057"/>
+            <location filename="../src/source/mainwindow.cpp" line="2112"/>
+            <location filename="../src/source/mainwindow.cpp" line="2515"/>
+            <source>Wrong password</source>
+            <translation>كلمة سر خاطىة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="202"/>
+            <location filename="../src/source/mainwindow.cpp" line="582"/>
+            <location filename="../src/source/mainwindow.cpp" line="660"/>
+            <location filename="../src/source/mainwindow.cpp" line="699"/>
+            <location filename="../src/source/mainwindow.cpp" line="769"/>
+            <location filename="../src/source/mainwindow.cpp" line="775"/>
+            <location filename="../src/source/mainwindow.cpp" line="784"/>
+            <location filename="../src/source/mainwindow.cpp" line="830"/>
+            <location filename="../src/source/mainwindow.cpp" line="1118"/>
+            <location filename="../src/source/mainwindow.cpp" line="1592"/>
+            <location filename="../src/source/mainwindow.cpp" line="2735"/>
+            <location filename="../src/source/mainwindow.cpp" line="2755"/>
+            <location filename="../src/source/mainwindow.cpp" line="3063"/>
+            <location filename="../src/source/mainwindow.cpp" line="3234"/>
+            <source>OK</source>
+            <translation>موافق</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="784"/>
+            <location filename="../src/source/mainwindow.cpp" line="823"/>
+            <source>The file format is not supported by Archive Manager</source>
+            <translation>تنسيق الملف غير مدعوم من قبل مدير الأرشيف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2456"/>
+            <source>Conversion successful</source>
+            <translation>التحويل ناجح</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2767"/>
+            <source>Close</source>
+            <translation>إغلاق</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2771"/>
+            <source>Help</source>
+            <translation>مساعدة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2779"/>
+            <source>Delete</source>
+            <translation>حذف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2787"/>
+            <source>Display shortcuts</source>
+            <translation>عرض الأختصارات</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2799"/>
+            <source>Shortcuts</source>
+            <translation>الأختصارات</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3571"/>
+            <source>File info</source>
+            <translation>معلومات الملف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="451"/>
+            <source>Updating comments</source>
+            <translation>تحديث التعليقات</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="435"/>
+            <source>Renaming</source>
+            <translation>إعادة التسمية</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1592"/>
+            <location filename="../src/source/mainwindow.cpp" line="2560"/>
+            <source>No data in it</source>
+            <translation>لا يوجد بيانات داخلها</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1798"/>
+            <source>Adding canceled</source>
+            <translation>تم إلغاء الإضافة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1904"/>
+            <source>Adding failed</source>
+            <translation>فشل في الإضافة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1988"/>
+            <location filename="../src/source/mainwindow.cpp" line="2556"/>
+            <source>Failed to create "%1"</source>
+            <translation>فشل في إنشاء "%1"</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2519"/>
+            <location filename="../src/source/mainwindow.cpp" line="2544"/>
+            <source>Some volumes are missing</source>
+            <translation>بعض الوحدات مفقودة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2548"/>
+            <source>Wrong password, please retry</source>
+            <translation>كلمة المرور خاطئة، من فضلك حاول مرة أخرى</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2568"/>
+            <source>No extraction support in current directory. Download the compressed package to a local device.</source>
+            <translation>لا يوجد دعم للاستخراج في الدليل الحالي. قم بتنزيل الحزمة المضغوطة إلى جهاز محلي.</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2775"/>
+            <source>Select file</source>
+            <translation>اختر ملفًا</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="2905"/>
+            <source>Replace</source>
+            <translation>استبدال</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3405"/>
+            <source>Update</source>
+            <translation>تحديث</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3595"/>
+            <source>Basic info</source>
+            <translation>معلومات أساسية</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3611"/>
+            <source>Size</source>
+            <translation>الحجم</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3612"/>
+            <source>Type</source>
+            <translation>النوع</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3613"/>
+            <source>Location</source>
+            <translation>الموقع</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3614"/>
+            <source>Time created</source>
+            <translation>وقت الإنشاء</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3615"/>
+            <source>Time accessed</source>
+            <translation>وقت الوصول</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3616"/>
+            <source>Time modified</source>
+            <translation>وقت التعديل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3626"/>
+            <source>Archive</source>
+            <translation>أرشيف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3661"/>
+            <source>Comment</source>
+            <translation>تعليق</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="819"/>
+            <source>Please check the file association type in the settings of Archive Manager</source>
+            <translation>يرجى التحقق من نوع ارتباط الملف في إعدادات مدير الملفات</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="202"/>
+            <source>You do not have permission to save files here, please change and retry</source>
+            <translation>ليس لديك إذن لحفظ الملفات هنا، الرجاء تغيير المسار وإعادة المحاولة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="1669"/>
+            <source>Do you want to delete the archive?</source>
+            <translation>هل ترغب في حذف الملف؟</translation>
+        </message>
+    </context>
+    <context>
+        <name>MimeTypeDisplayManager</name>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="32"/>
+            <source>Directory</source>
+            <translation>دليل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="33"/>
+            <source>Application</source>
+            <translation>تطبيق</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="34"/>
+            <source>Video</source>
+            <translation>فيديو</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="35"/>
+            <source>Audio</source>
+            <translation>صوت</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="36"/>
+            <source>Image</source>
+            <translation>صورة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="37"/>
+            <source>Archive</source>
+            <translation>أرشيف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="38"/>
+            <source>Document</source>
+            <translation>مستند</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="39"/>
+            <source>Executable</source>
+            <translation>ملف تنفيذي</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="40"/>
+            <source>Backup file</source>
+            <translation>ملف نسخة احتياطية</translation>
+        </message>
+        <message>
+            <location filename="../src/source/common/mimetypedisplaymanager.cpp" line="41"/>
+            <source>Unknown</source>
+            <translation>غير معروف</translation>
+        </message>
+    </context>
+    <context>
+        <name>OpenWithDialog</name>
+        <message>
+            <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="302"/>
+            <source>Open with</source>
+            <translation>التشغيل بواسطة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="322"/>
+            <source>Add other programs</source>
+            <translation>إضافة برامج أخرى</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="323"/>
+            <source>Set as default</source>
+            <translation>تحديد كالافتراضي</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="325"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="326"/>
+            <source>Confirm</source>
+            <translation>تأكيد</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="331"/>
+            <source>Recommended Applications</source>
+            <translation>التطبيقات المقترحة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/openwithdialog/openwithdialog.cpp" line="333"/>
+            <source>Other Applications</source>
+            <translation>تطبيقات أخرى</translation>
+        </message>
+    </context>
+    <context>
+        <name>PasswordNeededQuery</name>
+        <message>
+            <location filename="../3rdparty/interface/queries.cpp" line="506"/>
+            <source>Encrypted file, please enter the password</source>
+            <translation>ملف مشفر، الرجاء إدخال كلمة المرور</translation>
+        </message>
+    </context>
+    <context>
+        <name>PreviousLabel</name>
+        <message>
+            <location filename="../src/source/tree/treeheaderview.cpp" line="39"/>
+            <source>Current path:</source>
+            <translation>مسار الحالي:</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/treeheaderview.cpp" line="48"/>
+            <source>Back to: %1</source>
+            <translation>العودة إلى: %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>ProgressDialog</name>
+        <message>
+            <location filename="../src/source/dialog/progressdialog.cpp" line="42"/>
+            <source>%1 task(s) in progress</source>
+            <translation>%1 من المهام قيد المعالجة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/progressdialog.cpp" line="49"/>
+            <location filename="../src/source/dialog/progressdialog.cpp" line="93"/>
+            <source>Task</source>
+            <translation>مهمة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/progressdialog.cpp" line="55"/>
+            <location filename="../src/source/dialog/progressdialog.cpp" line="106"/>
+            <source>Extracting</source>
+            <translation>يتم الاستخراج</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/progressdialog.cpp" line="184"/>
+            <source>Are you sure you want to stop the extraction?</source>
+            <translation>هل أنت متأكد من أنك تريد إيقاف الاستخراج؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/progressdialog.cpp" line="186"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/progressdialog.cpp" line="186"/>
+            <source>Confirm</source>
+            <translation>تأكيد</translation>
+            <comment>button</comment>
+        </message>
+    </context>
+    <context>
+        <name>ProgressPage</name>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="46"/>
+            <location filename="../src/source/page/progresspage.cpp" line="381"/>
+            <location filename="../src/source/page/progresspage.cpp" line="384"/>
+            <location filename="../src/source/page/progresspage.cpp" line="387"/>
+            <source>Speed</source>
+            <translation>السرعة</translation>
+            <comment>compress</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="46"/>
+            <location filename="../src/source/page/progresspage.cpp" line="48"/>
+            <location filename="../src/source/page/progresspage.cpp" line="50"/>
+            <location filename="../src/source/page/progresspage.cpp" line="52"/>
+            <location filename="../src/source/page/progresspage.cpp" line="56"/>
+            <location filename="../src/source/page/progresspage.cpp" line="59"/>
+            <location filename="../src/source/page/progresspage.cpp" line="178"/>
+            <source>Calculating...</source>
+            <translation>جاري الحساب...</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="48"/>
+            <location filename="../src/source/page/progresspage.cpp" line="392"/>
+            <location filename="../src/source/page/progresspage.cpp" line="394"/>
+            <source>Speed</source>
+            <translation>السرعة</translation>
+            <comment>delete</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="50"/>
+            <location filename="../src/source/page/progresspage.cpp" line="399"/>
+            <location filename="../src/source/page/progresspage.cpp" line="401"/>
+            <source>Speed</source>
+            <translation>السرعة</translation>
+            <comment>rename</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="52"/>
+            <location filename="../src/source/page/progresspage.cpp" line="415"/>
+            <location filename="../src/source/page/progresspage.cpp" line="417"/>
+            <location filename="../src/source/page/progresspage.cpp" line="419"/>
+            <source>Speed</source>
+            <translation>السرعة</translation>
+            <comment>convert</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="56"/>
+            <location filename="../src/source/page/progresspage.cpp" line="406"/>
+            <location filename="../src/source/page/progresspage.cpp" line="408"/>
+            <location filename="../src/source/page/progresspage.cpp" line="410"/>
+            <source>Speed</source>
+            <translation>الوقت المتبقي</translation>
+            <comment>uncompress</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="59"/>
+            <location filename="../src/source/page/progresspage.cpp" line="376"/>
+            <source>Time left</source>
+            <translation>الحذف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="148"/>
+            <source>Compressing</source>
+            <translation>جاري الضغط</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="150"/>
+            <source>Deleting</source>
+            <translation>الإسماع</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="152"/>
+            <source>Renaming</source>
+            <translation>التحويل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="154"/>
+            <source>Converting</source>
+            <translation>تحديث التعليق...</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="156"/>
+            <location filename="../src/source/page/progresspage.cpp" line="176"/>
+            <source>Updating the comment...</source>
+            <translation>إبقاء</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="158"/>
+            <source>Extracting</source>
+            <translation>جاري الاستخراج</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="170"/>
+            <location filename="../src/source/page/progresspage.cpp" line="224"/>
+            <location filename="../src/source/page/progresspage.cpp" line="439"/>
+            <source>Pause</source>
+            <translation>استمر</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="223"/>
+            <location filename="../src/source/page/progresspage.cpp" line="475"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="210"/>
+            <location filename="../src/source/page/progresspage.cpp" line="434"/>
+            <source>Continue</source>
+            <translation>هل أنت متأكد من التوقف عن فك الضغط؟</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="475"/>
+            <source>Confirm</source>
+            <translation>تأكيد</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="461"/>
+            <source>Are you sure you want to stop the decompression?</source>
+            <translation>هل أنت متأكد من التوقف عن الحذف؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="464"/>
+            <source>Are you sure you want to stop the deletion?</source>
+            <translation>هل أنت متأكد من التوقف عن التحويل؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="458"/>
+            <location filename="../src/source/page/progresspage.cpp" line="467"/>
+            <source>Are you sure you want to stop the compression?</source>
+            <translation>هل أنت متأكد من أنك تريد إيقاف الضغط؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/progresspage.cpp" line="470"/>
+            <source>Are you sure you want to stop the conversion?</source>
+            <translation>عرض الملفات المُستخرجة عند الانتهاء</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="218"/>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="224"/>
+            <location filename="../3rdparty/interface/queries.cpp" line="236"/>
+            <source>Skip</source>
+            <translation>تجاوز</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="219"/>
+            <source>Merge</source>
+            <translation>دمج</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="222"/>
+            <location filename="../3rdparty/interface/queries.cpp" line="213"/>
+            <source>Another file with the same name already exists, replace it?</source>
+            <translation>يوجد ملف آخر بنفس الاسم بالفعل، هل تريد استبداله؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="225"/>
+            <location filename="../3rdparty/interface/queries.cpp" line="237"/>
+            <source>Replace</source>
+            <translation>استبدال</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="522"/>
+            <location filename="../3rdparty/interface/queries.cpp" line="388"/>
+            <location filename="../3rdparty/interface/queries.cpp" line="517"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="523"/>
+            <location filename="../3rdparty/interface/queries.cpp" line="389"/>
+            <location filename="../3rdparty/interface/queries.cpp" line="518"/>
+            <source>OK</source>
+            <translation>موافق</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="216"/>
+            <source>Another folder with the same name already exists, replace it?</source>
+            <translation>مجلد آخر بنفس الاسم موجود بالفعل، هل تريد استبداله؟</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="228"/>
+            <location filename="../3rdparty/interface/queries.cpp" line="218"/>
+            <source>Apply to all</source>
+            <translation>تطبيق على جميع</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/datamodel.h" line="56"/>
+            <source>Name</source>
+            <translation>الاسم</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/datamodel.h" line="56"/>
+            <source>Time modified</source>
+            <translation>وقت التعديل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/datamodel.h" line="56"/>
+            <source>Type</source>
+            <translation>النوع</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/datamodel.h" line="56"/>
+            <source>Size</source>
+            <translation>الحجم</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3402"/>
+            <source>%1 changed. Do you want to save changes to the archive?</source>
+            <translation>'%1 تغيّر. هل تريد حفظ التغييرات في الملف الأرشيفي؟'</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settings_translation.cpp" line="12"/>
+            <source>General</source>
+            <translation>عام</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settings_translation.cpp" line="13"/>
+            <source>Extraction</source>
+            <translation>الاستخراج</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settings_translation.cpp" line="14"/>
+            <source>Auto create a folder for multiple extracted files</source>
+            <translation>إضافة مجلد تلقائياً للمهام المتعدة للملفات المستخرجة </translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settings_translation.cpp" line="15"/>
+            <source>Show extracted files when completed</source>
+            <translation>إدارة الملفات</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settings_translation.cpp" line="16"/>
+            <source>File Management</source>
+            <translation>إدارة الملفات</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settings_translation.cpp" line="17"/>
+            <source>Delete files after compression</source>
+            <translation> удалить файлы после сжатия</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settings_translation.cpp" line="18"/>
+            <source>Files Associated</source>
+            <translation>ملفات مرتبطة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settings_translation.cpp" line="19"/>
+            <source>File Type</source>
+            <translation>نوع الملف</translation>
+        </message>
+        <message>
+            <location filename="../3rdparty/interface/queries.cpp" line="376"/>
+            <source>Another file with the same name already exists, extract to %1?</source>
+            <translation>يوجد ملف آخر بنفس الاسم بالفعل، هل تريد الاستخراج إلى %1؟</translation>
+        </message>
+    </context>
+    <context>
+        <name>RenameDialog</name>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="631"/>
+            <source>Rename</source>
+            <translation>إعادة التسمية</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="682"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="683"/>
+            <source>OK</source>
+            <translation>موافق</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/popupdialog.cpp" line="693"/>
+            <source>The name already exists</source>
+            <translation>الاسم موجود بالفعل</translation>
+        </message>
+    </context>
+    <context>
+        <name>SettingDialog</name>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="131"/>
+            <source>Select All</source>
+            <translation>تحديد الكل</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="132"/>
+            <source>Clear All</source>
+            <translation>مسح الكل</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="133"/>
+            <source>Recommended</source>
+            <translation>موصى به</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="168"/>
+            <source>Extract archives to</source>
+            <translation>استخراج إلى</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="174"/>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="203"/>
+            <source>Current directory</source>
+            <translation>الدليل الحالي</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="174"/>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="208"/>
+            <source>Desktop</source>
+            <translation>سطح المكتب</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="174"/>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="213"/>
+            <source>Other directory</source>
+            <translation>دليل آخر</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="281"/>
+            <source>Delete archives after extraction</source>
+            <translation> удалить الملفات الأرشيفية بعد استخراجها</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="287"/>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="308"/>
+            <source>Never</source>
+            <translation>从不</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="287"/>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="311"/>
+            <source>Ask for confirmation</source>
+            <translation>طلب التأكيد</translation>
+        </message>
+        <message>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="287"/>
+            <location filename="../src/source/dialog/settingdialog.cpp" line="314"/>
+            <source>Always</source>
+            <translation>بشكل دائم</translation>
+        </message>
+    </context>
+    <context>
+        <name>SuccessPage</name>
+        <message>
+            <location filename="../src/source/page/successpage.cpp" line="70"/>
+            <source>Compression successful</source>
+            <translation>تم الضغط بنجاح</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/successpage.cpp" line="80"/>
+            <source>View</source>
+            <translation>عرض</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/successpage.cpp" line="83"/>
+            <source>Back</source>
+            <translation>رجوع</translation>
+        </message>
+    </context>
+    <context>
+        <name>TitleWidget</name>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3881"/>
+            <location filename="../src/source/mainwindow.cpp" line="3936"/>
+            <source>Open file</source>
+            <translation>فتح ملف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3884"/>
+            <source>Back</source>
+            <translation>رجوع</translation>
+        </message>
+        <message>
+            <location filename="../src/source/mainwindow.cpp" line="3940"/>
+            <source>File info</source>
+            <translation>معلومات الملف</translation>
+        </message>
+    </context>
+    <context>
+        <name>UnCompressPage</name>
+        <message>
+            <location filename="../src/source/page/uncompresspage.cpp" line="68"/>
+            <location filename="../src/source/page/uncompresspage.cpp" line="82"/>
+            <location filename="../src/source/page/uncompresspage.cpp" line="116"/>
+            <source>Extract to:</source>
+            <translation>استخراج إلى :</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/uncompresspage.cpp" line="117"/>
+            <source>Extract</source>
+            <translation>استخراج</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/uncompresspage.cpp" line="202"/>
+            <source>The default extraction path does not exist, please retry</source>
+            <translation>مسار الاستخراج الافتراضي غير موجود، الرجاء إعادة المحاولة</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/uncompresspage.cpp" line="205"/>
+            <source>You do not have permission to save files here, please change and retry</source>
+            <translation>ليس لديك إذن لحفظ الملفات هنا، يرجى تعديل المسار وحاول مرة أخرى</translation>
+        </message>
+        <message>
+            <location filename="../src/source/page/uncompresspage.cpp" line="209"/>
+            <source>OK</source>
+            <translation>موافق</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/page/uncompresspage.cpp" line="225"/>
+            <source>Find directory</source>
+            <translation>بحث عن دليل</translation>
+        </message>
+    </context>
+    <context>
+        <name>UnCompressView</name>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="426"/>
+            <source>You cannot add the archive to itself</source>
+            <translation>لا يمكنك إضافة الملف الأرشيفي إلى نفسه</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="426"/>
+            <source>OK</source>
+            <translation>موافق</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="666"/>
+            <source>Extract</source>
+            <translation>استخراج</translation>
+            <comment>提取</comment>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="668"/>
+            <source>Extract to current directory</source>
+            <translation>استخراج إلى الدليل الحالي</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="670"/>
+            <source>Open</source>
+            <translation>فتح</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="672"/>
+            <source>Rename</source>
+            <translation>إعادة التسمية</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="680"/>
+            <source>Delete</source>
+            <translation>حذف</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="689"/>
+            <source>Open with</source>
+            <translation>فتح باستخدام</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="693"/>
+            <location filename="../src/source/tree/uncompressview.cpp" line="858"/>
+            <source>Select default program</source>
+            <translation>اختر البرنامج الافتراضي</translation>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="753"/>
+            <source>Cancel</source>
+            <translation>إلغاء</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="753"/>
+            <source>Confirm</source>
+            <translation>تأكيد</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/source/tree/uncompressview.cpp" line="753"/>
+            <source>Do you want to delete the selected file(s)?</source>
+            <translation>هل تريد حذف العناصرين(ات) المحدد(ة)؟</translation>
+        </message>
+    </context>
 </TS>


### PR DESCRIPTION
Update Arabic (ar) translations for unfinished strings.

Log: update Arabic (ar) translations

## Summary by Sourcery

Complete the Arabic localization catalog and standardize its translation-file formatting.

Bug Fixes:
- Complete the remaining Arabic translation for the archive extraction conflict prompt.

Enhancements:
- Normalize the Arabic translation catalog formatting and XML metadata while preserving existing translated strings and correcting translation/comment element structure.