### PR TITLE
fix: parse 7z Modified timestamp with fractional seconds

### DIFF
--- a/3rdparty/cli7zplugin/cli7zplugin.cpp
+++ b/3rdparty/cli7zplugin/cli7zplugin.cpp
@@ -262,7 +262,15 @@ bool Cli7zPlugin::readListLine(const QString &line)
             stArchiveData.qSize += m_fileEntry.qSize;
         } else if (line.startsWith(QLatin1String("Modified = "))) {
             // 文件最后修改时间
-            m_fileEntry.uLastModifiedTime = QDateTime::fromString(line.mid(11).trimmed(),
+            // 新版 7-Zip (24.09+/26.x) 的 -slt 输出带小数秒, 如 "2025-06-04 11:11:04.8826983",
+            // 老版 p7zip 只输出到秒 "2025-06-04 11:11:04"。uLastModifiedTime 是秒精度,
+            // 先截断小数点后的部分再解析, 兼容新旧两种输出, 避免解析失败得到 0xFFFFFFFF(2106-02-07)。
+            QString modified = line.mid(11).trimmed();
+            const int dotIndex = modified.indexOf(QLatin1Char('.'));
+            if (dotIndex != -1) {
+                modified = modified.left(dotIndex);
+            }
+            m_fileEntry.uLastModifiedTime = QDateTime::fromString(modified,
                                                                   QStringLiteral("yyyy-MM-dd hh:mm:ss")).toTime_t();
             if (ArchiveTypeIso == m_archiveType || ArchiveTypeUdf == m_archiveType) { // 读取的压缩包是iso、udf文件，读到Modified的时候已经结束了
 //                QString name = m_fileEntry.strFullPath;

--- a/tests/UnitTest/3rdparty/cli7zplugin/ut_cli7zplugin.cpp
+++ b/tests/UnitTest/3rdparty/cli7zplugin/ut_cli7zplugin.cpp
@@ -429,6 +429,16 @@ TEST_F(UT_Cli7zPlugin, test_readListLine_018)
     EXPECT_EQ(m_tester->m_fileEntry.uLastModifiedTime, QDateTime::fromString("2021-06-18 15:27:01", "yyyy-MM-dd hh:mm:ss").toTime_t());
 }
 
+// 新版 7-Zip (26.x) 的 -slt 输出带小数秒, 如 "Modified = 2021-06-18 15:27:01.8826983",
+// 应截断小数部分后解析, 保证与老版 p7zip 只输出到秒的格式结果一致。
+TEST_F(UT_Cli7zPlugin, test_readListLine_025)
+{
+    m_tester->m_parseState = ParseStateEntryInformation;
+    m_tester->m_archiveType = Cli7zPlugin::ArchiveType::ArchiveType7z;
+    EXPECT_EQ(m_tester->readListLine("Modified = 2021-06-18 15:27:01.8826983"), true);
+    EXPECT_EQ(m_tester->m_fileEntry.uLastModifiedTime, QDateTime::fromString("2021-06-18 15:27:01", "yyyy-MM-dd hh:mm:ss").toTime_t());
+}
+
 TEST_F(UT_Cli7zPlugin, test_readListLine_019)
 {
     m_tester->m_parseState = ParseStateEntryInformation;


### PR DESCRIPTION
New 7-Zip (26.x) appends fractional seconds to the Modified field in -slt output (e.g. '2025-06-04 11:11:04.8826983'), while old p7zip only outputs to the second. The strict 'yyyy-MM-dd hh:mm:ss' format failed to parse the new output, producing an invalid QDateTime whose toTime_t() returns -1 -> stored as 0xFFFFFFFF (2106-02-07) in the archive view.

Strip the fractional part before parsing so uLastModifiedTime keeps the same second-precision value for both old and new 7-Zip output.

bug: https://pms.uniontech.com/bug-view-375769.html

## Summary by Sourcery

Support fractional seconds in 7-Zip Modified timestamps to prevent invalid archive dates.

Bug Fixes:
- Parse 7-Zip Modified timestamps with fractional seconds while preserving second-level timestamps across old and new output formats.

Tests:
- Add coverage for parsing fractional-second Modified timestamps from newer 7-Zip output.