### PR TITLE
fix: remove non-empty garbage files when 7z password is wrong

### DIFF
--- a/3rdparty/interface/archiveinterface/cliinterface.cpp
+++ b/3rdparty/interface/archiveinterface/cliinterface.cpp
@@ -1286,7 +1286,8 @@ void CliInterface::removeExtractedFilesOnFailure(const QString &strTargetPath, c
         const QString &path = p.first;
         if (!p.second) {   // 文件
             QFileInfo fi(path);
-            if (fi.exists() && fi.isFile() && fi.size() == 0) {
+            // 密码错误时（Copy 存储 + 流式加密会把乱码写满整个文件）也删除非空文件，避免目标目录残留完整大小乱码
+            if (fi.exists() && fi.isFile() && ((m_eErrorType == ET_WrongPassword) || (fi.size() == 0))) {
                 QFile::remove(path);
             }
         }


### PR DESCRIPTION
Copy-stored (uncompressed) 7z archives encrypted with streaming AES write the decrypted garbage through the whole file before the trailing CRC check reveals a wrong password. The previous cleanup only removed size-0 residue files, leaving a full-size corrupt file in the target directory. Now also delete non-empty files when the failure is caused by a wrong password, avoiding garbage residue while keeping the behavior for other failure cases unchanged.

bug: https://pms.uniontech.com/bug-view-375281.html

## Summary by Sourcery

Bug Fixes:
- Remove non-empty extracted files when extraction fails due to an incorrect password, preventing full-size corrupted residue from remaining in the target directory.