### PR TITLE
chore: update version to 6.5.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+deepin-compressor (6.5.34) unstable; urgency=medium
+
+  * fix: update Arabic (ar) translations
+  * fix: update Arabic (ar) translations
+  * [skip CI] Translate desktop.ts in sv
+  * [skip CI] Translate desktop.ts in ar
+  * [skip CI] Translate deepin-compressor.ts in ar
+  * [skip CI] Translate deepin-compressor.ts in sv
+  * [skip CI] Translate deepin-compressor.ts in sv
+  * [skip CI] Translate deepin-compressor.ts in sv
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Mon, 07 Sep 2026 11:44:35 +0800
+
 deepin-compressor (6.5.33) unstable; urgency=medium
 
   * [skip CI] Translate desktop.ts in pt_BR


### PR DESCRIPTION
as title

Log: update version

## Summary by Sourcery

Chores:
- Update the Debian changelog for version 6.5.34.