### PR TITLE
fix: report wrong password for encrypted split archive with missing v…

### DIFF
--- a/3rdparty/cli7zplugin/cli7zplugin.cpp
+++ b/3rdparty/cli7zplugin/cli7zplugin.cpp
@@ -356,12 +356,11 @@ bool Cli7zPlugin::handleLine(const QString &line, WorkType workStatus)
     }
 
     if (isWrongPasswordMsg(line)) {  // 提示密码错误
-        // 加密分卷包缺失分卷时，7z 先输出 "Unexpected end of archive"（已置
-        // ET_MissingVolume），随后输出 "CRC Failed in encrypted file. Wrong
-        // password?"。根因是分卷缺失而非密码错误，密码错误不得覆盖已判定的
-        // 分卷缺失（PMS BUG-371879）。
-        if (workStatus == WT_Extract && ET_MissingVolume == m_eErrorType) {
-            return true;  // 已判定分卷缺失，忽略密码错误行，继续解析
+        // 分卷缺失时（密码正确）7z 输出 "CRC Failed in encrypted file. Wrong password?"，
+        // 根因是分卷缺失，不覆盖 ET_MissingVolume；其余 "Wrong password" 行为真正密码错误。
+        if (workStatus == WT_Extract && ET_MissingVolume == m_eErrorType
+                && line.contains(QLatin1String("CRC Failed in encrypted file."))) {
+            return true;
         }
         m_eErrorType = ET_WrongPassword;
         if (workStatus != WT_Delete) { // 区分删除操作密码错误的处理

--- a/tests/UnitTest/3rdparty/cli7zplugin/ut_cli7zplugin.cpp
+++ b/tests/UnitTest/3rdparty/cli7zplugin/ut_cli7zplugin.cpp
@@ -527,6 +527,35 @@ TEST_F(UT_Cli7zPlugin, test_handleLine_006)
     EXPECT_EQ(m_tester->m_finishType, PFT_Error);
 }
 
+// 分卷缺失且密码正确：CRC Failed 行不覆盖 ET_MissingVolume（回归保护）。
+TEST_F(UT_Cli7zPlugin, test_handleLine_MissingVolume_WithCRCFailedWrongPasswordMsg)
+{
+    m_tester->m_eErrorType = ET_MissingVolume;
+    m_tester->m_finishType = PFT_Error;
+    EXPECT_EQ(m_tester->handleLine("ERROR: CRC Failed in encrypted file. Wrong password? : file1.txt", WT_Extract), true);
+    EXPECT_EQ(m_tester->m_eErrorType, ET_MissingVolume);
+}
+
+// 分卷缺失但密码错误：真正 "Wrong password" 行覆盖为密码错误。
+TEST_F(UT_Cli7zPlugin, test_handleLine_MissingVolume_WithWrongPasswordMsg)
+{
+    m_tester->m_eErrorType = ET_MissingVolume;
+    m_tester->m_finishType = PFT_Error;
+    EXPECT_EQ(m_tester->handleLine("ERROR: Wrong password : file1.txt", WT_Extract), false);
+    EXPECT_EQ(m_tester->m_eErrorType, ET_WrongPassword);
+    EXPECT_EQ(m_tester->m_finishType, PFT_Error);
+}
+
+// 分卷缺失但错误密码（7z 格式的 Data Error 变体）：同样覆盖为密码错误。
+TEST_F(UT_Cli7zPlugin, test_handleLine_MissingVolume_WithDataErrorWrongPasswordMsg)
+{
+    m_tester->m_eErrorType = ET_MissingVolume;
+    m_tester->m_finishType = PFT_Error;
+    EXPECT_EQ(m_tester->handleLine("ERROR: Data Error in encrypted file. Wrong password? : file2.txt", WT_Extract), false);
+    EXPECT_EQ(m_tester->m_eErrorType, ET_WrongPassword);
+    EXPECT_EQ(m_tester->m_finishType, PFT_Error);
+}
+
 TEST_F(UT_Cli7zPlugin, test_handleLine_007)
 {
     EXPECT_EQ(m_tester->handleLine("No files to process", WT_Extract), true);


### PR DESCRIPTION
…olume

When extracting an encrypted split archive with a missing volume, 7z emits "CRC Failed in encrypted file. Wrong password?" even when the password is correct (data truncated by the missing volume), and a plain "Wrong password" line when it is wrong. The previous guard ignored all wrong-password lines once ET_MissingVolume was set, so a truly wrong password was misreported as missing volume. Now only that CRC variant is ignored, letting genuine wrong-password lines override ET_MissingVolume. Normal password flows and non-encrypted paths are unchanged.

Bug: https://pms.uniontech.com/bug-view-376387.html

## Summary by Sourcery

Fix encrypted split-archive extraction to report the actual password error without masking missing-volume failures.

Bug Fixes:
- Correctly distinguish genuine wrong-password errors from missing-volume errors when extracting encrypted split archives.
- Preserve missing-volume reporting for CRC failures caused by truncated encrypted data.

Tests:
- Add regression coverage for CRC-based, plain, and data-error wrong-password messages when a split volume is missing.